### PR TITLE
Pass arguments to VolatileLayerClient by value

### DIFF
--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VolatileLayerClient.h
@@ -102,7 +102,7 @@ class DATASERVICE_WRITE_API VolatileLayerClient {
    * @return A CancellableFuture containing the PublishPartitionDataResponse.
    */
   olp::client::CancellableFuture<PublishPartitionDataResponse>
-  PublishPartitionData(const model::PublishPartitionDataRequest& request);
+  PublishPartitionData(model::PublishPartitionDataRequest request);
 
   /**
    * @brief Call to publish data into an OLP Volatile Layer.
@@ -117,7 +117,7 @@ class DATASERVICE_WRITE_API VolatileLayerClient {
    * request.
    */
   olp::client::CancellationToken PublishPartitionData(
-      const model::PublishPartitionDataRequest& request,
+      model::PublishPartitionDataRequest request,
       PublishPartitionDataCallback callback);
 
   /**
@@ -140,7 +140,7 @@ class DATASERVICE_WRITE_API VolatileLayerClient {
    * @return olp::client::CancellableFuture<StartBatchResponse>
    */
   olp::client::CancellableFuture<StartBatchResponse> StartBatch(
-      const model::StartBatchRequest& request);
+      model::StartBatchRequest request);
 
   /**
    * @brief Start a batch operation.
@@ -148,8 +148,8 @@ class DATASERVICE_WRITE_API VolatileLayerClient {
    * @param callback of type std::function<void(StartBatchResponse response)>
    * @return olp::client::CancellationToken
    */
-  olp::client::CancellationToken StartBatch(
-      const model::StartBatchRequest& request, StartBatchCallback callback);
+  olp::client::CancellationToken StartBatch(model::StartBatchRequest request,
+                                            StartBatchCallback callback);
 
   /**
    * @brief Get the details of the given batch publication

--- a/olp-cpp-sdk-dataservice-write/src/VolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VolatileLayerClient.cpp
@@ -33,12 +33,12 @@ void VolatileLayerClient::cancellAll() { impl_->cancellAll(); }
 
 olp::client::CancellableFuture<PublishPartitionDataResponse>
 VolatileLayerClient::PublishPartitionData(
-    const model::PublishPartitionDataRequest& request) {
+    model::PublishPartitionDataRequest request) {
   return impl_->PublishPartitionData(request);
 }
 
 olp::client::CancellationToken VolatileLayerClient::PublishPartitionData(
-    const model::PublishPartitionDataRequest& request,
+    model::PublishPartitionDataRequest request,
     PublishPartitionDataCallback callback) {
   return impl_->PublishPartitionData(request, std::move(callback));
 }
@@ -54,12 +54,12 @@ olp::client::CancellationToken VolatileLayerClient::GetBaseVersion(
 }
 
 olp::client::CancellableFuture<StartBatchResponse>
-VolatileLayerClient::StartBatch(const model::StartBatchRequest& request) {
+VolatileLayerClient::StartBatch(model::StartBatchRequest request) {
   return impl_->StartBatch(request);
 }
 
 olp::client::CancellationToken VolatileLayerClient::StartBatch(
-    const model::StartBatchRequest& request, StartBatchCallback callback) {
+    model::StartBatchRequest request, StartBatchCallback callback) {
   return impl_->StartBatch(request, std::move(callback));
 }
 


### PR DESCRIPTION
Pass request to VolatileLayerClient by value. This aligns interface with
read dataservice API.

Relates-to: OLPEDGE-798
Signed-off-by: Diachenko Mykahilo <ext-mykhailo.z.diachenko@here.com>