### PR TITLE
Add test with usage of mock server

### DIFF
--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -20,6 +20,7 @@ set(OLP_SDK_FUNCTIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-core/OlpClientDefaultAsyncHttpTest.cpp
     ./olp-cpp-sdk-dataservice-read/ApiTest.cpp
     ./olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+    ./olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
     ./olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
     ./olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
     ./olp-cpp-sdk-dataservice-write/DataserviceWriteIndexLayerClientTest.cpp
@@ -37,12 +38,15 @@ set(OLP_SDK_FUNCTIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-authentication/FederatedAuthenticationTest.cpp
     ./olp-cpp-sdk-authentication/HereAccountOauth2ProductionTest.cpp
     ./olp-cpp-sdk-authentication/DecisionApiTest.cpp
+    ./utils/MockServerHelper.cpp
 )
 
 set(OLP_SDK_FUNCTIONAL_TESTS_HEADERS
     ./olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.h
     ./olp-cpp-sdk-authentication/AuthenticationTestUtils.h
     ./olp-cpp-sdk-authentication/TestConstants.h
+    ./utils/DefaultResponses.h
+    ./utils/MockServerHelper.h
     ./utils/Utils.h
 )
 
@@ -55,6 +59,7 @@ if (ANDROID OR IOS)
     target_include_directories(${OLP_SDK_FUNCTIONAL_TESTS_LIB}
         PRIVATE
             ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-dataservice-read/src
+            ${PROJECT_SOURCE_DIR}/tests/utils/mock-server-client/
             utils
     )
     target_link_libraries(${OLP_SDK_FUNCTIONAL_TESTS_LIB}
@@ -89,6 +94,7 @@ else()
     target_include_directories(olp-cpp-sdk-functional-tests
     PRIVATE
         ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-dataservice-read/src
+        ${PROJECT_SOURCE_DIR}/tests/utils/mock-server-client/
         utils
     )
     target_link_libraries(olp-cpp-sdk-functional-tests

--- a/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gtest/gtest.h>
+#include <olp/authentication/AuthenticationCredentials.h>
+#include <olp/authentication/Settings.h>
+#include <olp/authentication/TokenProvider.h>
+#include <olp/core/client/OlpClientSettings.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/http/NetworkSettings.h>
+#include <olp/core/logging/Log.h>
+#include <olp/core/porting/make_unique.h>
+#include <olp/dataservice/read/VersionedLayerClient.h>
+#include <string>
+#include <testutils/CustomParameters.hpp>
+#include "DefaultResponses.h"
+#include "MockServerHelper.h"
+#include "Utils.h"
+
+namespace {
+
+const auto kMockServerHost = "localhost";
+const auto kMockServerPort = 1080;
+
+const auto kAppId = "id";
+const auto kAppSecret = "secret";
+const auto kTestHrn = "hrn:here:data::olp-here-test:hereos-internal-test";
+
+class VersionedLayerClientTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto network = olp::client::OlpClientSettingsFactory::
+        CreateDefaultNetworkRequestHandler();
+
+    olp::authentication::Settings auth_settings({kAppId, kAppSecret});
+    auth_settings.network_request_handler = network;
+
+    // setup proxy
+    auth_settings.network_proxy_settings =
+        olp::http::NetworkProxySettings()
+            .WithHostname(kMockServerHost)
+            .WithPort(kMockServerPort)
+            .WithType(olp::http::NetworkProxySettings::Type::HTTP);
+    olp::authentication::TokenProviderDefault provider(auth_settings);
+    olp::client::AuthenticationSettings auth_client_settings;
+    auth_client_settings.provider = provider;
+
+    settings_ = std::make_shared<olp::client::OlpClientSettings>();
+    settings_->network_request_handler = network;
+    settings_->authentication_settings = auth_client_settings;
+
+    // setup proxy
+    settings_->proxy_settings =
+        olp::http::NetworkProxySettings()
+            .WithHostname(kMockServerHost)
+            .WithPort(kMockServerPort)
+            .WithType(olp::http::NetworkProxySettings::Type::HTTP);
+    SetUpMockServer(network);
+  }
+
+  void TearDown() override {
+    auto network = std::move(settings_->network_request_handler);
+    settings_.reset();
+    mock_server_client_.reset();
+  }
+
+  void SetUpMockServer(std::shared_ptr<olp::http::Network> network) {
+    // create client to set mock server expectations
+    olp::client::OlpClientSettings olp_client_settings;
+    olp_client_settings.network_request_handler = network;
+    mock_server_client_ = std::make_shared<mockserver::MockServerHelper>(
+        olp_client_settings, kTestHrn);
+  }
+
+  std::shared_ptr<olp::client::OlpClientSettings> settings_;
+  std::shared_ptr<mockserver::MockServerHelper> mock_server_client_;
+};
+
+TEST_F(VersionedLayerClientTest, GetPartitions) {
+  olp::client::HRN hrn(kTestHrn);
+  {
+    mock_server_client_->MockAuth();
+    mock_server_client_->MockTimestamp();
+    mock_server_client_->MockGetResponse(
+        mockserver::DefaultResponses::GenerateApisResponse(kTestHrn));
+    mock_server_client_->MockGetResponse(
+        mockserver::DefaultResponses::GenerateVersionResponse(44));
+    mock_server_client_->MockGetResponse(
+        mockserver::DefaultResponses::GeneratePartitionsResponse(4));
+  }
+
+  auto catalog_client =
+      std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+          hrn, "testlayer", boost::none, *settings_);
+
+  auto request = olp::dataservice::read::PartitionsRequest();
+  auto future = catalog_client->GetPartitions(request);
+  auto partitions_response = future.GetFuture().get();
+
+  EXPECT_SUCCESS(partitions_response);
+  ASSERT_EQ(4u, partitions_response.GetResult().GetPartitions().size());
+  EXPECT_TRUE(mock_server_client_->Verify());
+}
+
+}  // namespace

--- a/tests/functional/utils/DefaultResponses.h
+++ b/tests/functional/utils/DefaultResponses.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "generated/model/Api.h"
+#include "olp/dataservice/read/model/Partitions.h"
+#include "olp/dataservice/read/model/VersionResponse.h"
+
+namespace mockserver {
+
+class DefaultResponses {
+ public:
+  static olp::dataservice::read::model::VersionResponse GenerateVersionResponse(
+      int64_t version) {
+    olp::dataservice::read::model::VersionResponse version_responce;
+    version_responce.SetVersion(version);
+    return version_responce;
+  }
+
+  static olp::dataservice::read::model::Apis GenerateApisResponse(
+      std::string catalog) {
+    return GenerateApisResponse(catalog, {{"blob", "v1"},
+                                          {"index", "v1"},
+                                          {"ingest", "v1"},
+                                          {"metadata", "v1"},
+                                          {"notification", "v2"},
+                                          {"publish", "v2"},
+                                          {"query", "v1"},
+                                          {"statistics", "v1"},
+                                          {"stream", "v2"},
+                                          {"volatile-blob", "v1"}});
+  }
+
+  static olp::dataservice::read::model::Apis GenerateApisResponse(
+      std::string catalog,
+      std::vector<std::pair<std::string, std::string>> api_types) {
+    olp::dataservice::read::model::Apis apis(api_types.size());
+    std::string version = "v1";
+    for (size_t i = 0; i < apis.size(); i++) {
+      apis[i].SetApi(api_types.at(i).first);
+      apis[i].SetBaseUrl("https://tmp." + api_types.at(i).first +
+                         ".data.api.platform.here.com/" +
+                         api_types.at(i).first + "/" + api_types.at(i).second +
+                         "/catalogs/" + catalog);
+      apis[i].SetVersion(api_types.at(i).second);
+    }
+    return apis;
+  }
+
+  static olp::dataservice::read::model::Partitions GeneratePartitionsResponse(
+      size_t size = 10) {
+    std::vector<olp::dataservice::read::model::Partition> partitions_vect(size);
+    for (size_t i = 0; i < partitions_vect.size(); i++) {
+      partitions_vect[i].SetPartition(std::to_string(i));
+      partitions_vect[i].SetDataHandle(std::to_string(i) + "-" +
+                                       std::to_string(i * 100));
+    }
+
+    olp::dataservice::read::model::Partitions partitions;
+    partitions.SetPartitions(partitions_vect);
+    return partitions;
+  }
+};
+
+}  // namespace mockserver

--- a/tests/functional/utils/MockServerHelper.cpp
+++ b/tests/functional/utils/MockServerHelper.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+#include "MockServerHelper.h"
+
+#include <utility>
+#include <vector>
+
+#include "generated/serializer/ApiSerializer.h"
+#include "generated/serializer/PartitionsSerializer.h"
+#include "generated/serializer/VersionResponseSerializer.h"
+#include "generated/serializer/JsonSerializer.h"
+
+namespace mockserver {
+template <>
+std::string
+MockServerHelper::GetPathMatcher<olp::dataservice::read::model::Partitions>() {
+  return "/metadata/v1/catalogs/" + catalog_ + "/layers/testlayer/partitions";
+}
+
+template <>
+std::string MockServerHelper::GetPathMatcher<
+    olp::dataservice::read::model::VersionResponse>() {
+  return "/metadata/v1/catalogs/" + catalog_ + "/versions/latest";
+}
+
+template <>
+std::string
+MockServerHelper::GetPathMatcher<olp::dataservice::read::model::Api>() {
+  return "/lookup/v1/resources/" + catalog_ + "/apis";
+}
+
+template <class T>
+void MockServerHelper::MockGetResponse(T data) {
+  auto str = olp::serializer::serialize(data);
+  auto path = GetPathMatcher<T>();
+  paths__.push_back(path);
+  mock_server_client_.MockResponse("GET", path, str);
+}
+
+template <class T>
+void MockServerHelper::MockGetResponse(std::vector<T> data) {
+  std::string str = "[";
+  for (const auto& el : data) {
+    str.append(olp::serializer::serialize(el));
+    str.append(",");
+  }
+  str[str.length() - 1] = ']';
+  auto path = GetPathMatcher<T>();
+  paths__.push_back(path);
+  mock_server_client_.MockResponse("GET", path, str);
+}
+
+MockServerHelper::MockServerHelper(olp::client::OlpClientSettings settings,
+                                   std::string catalog)
+    : catalog_(std::move(catalog)), mock_server_client_(std::move(settings)) {
+  mock_server_client_.Reset();
+}
+
+void MockServerHelper::MockTimestamp(time_t time) {
+  mock_server_client_.MockResponse(
+      "GET", "/timestamp",
+      R"({"timestamp" : )" + std::to_string(time) + R"(})", true);
+}
+
+void MockServerHelper::MockAuth() {
+  mock_server_client_.MockResponse(
+      "POST", "/oauth2/token",
+      R"({"access_token": "token","token_type": "bearer"})", true);
+}
+
+void MockServerHelper::MockGetResponse(
+    olp::dataservice::read::model::VersionResponse data) {
+  MockGetResponse<olp::dataservice::read::model::VersionResponse>(
+      std::move(data));
+}
+
+void MockServerHelper::MockGetResponse(
+    olp::dataservice::read::model::Apis data) {
+  MockGetResponse<olp::dataservice::read::model::Api>(std::move(data));
+}
+
+void MockServerHelper::MockGetResponse(
+    olp::dataservice::read::model::Partitions data) {
+  MockGetResponse<olp::dataservice::read::model::Partitions>(std::move(data));
+}
+
+bool MockServerHelper::Verify() {
+  return mock_server_client_.VerifySequence(paths__);
+}
+
+}  // namespace mockserver

--- a/tests/functional/utils/MockServerHelper.h
+++ b/tests/functional/utils/MockServerHelper.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+#include "Client.h"
+
+#include <string>
+#include <vector>
+
+#include "generated/model/Api.h"
+#include "olp/dataservice/read/model/Partitions.h"
+#include "olp/dataservice/read/model/VersionResponse.h"
+
+namespace mockserver {
+/**
+ * @brief Easy mock functionality.
+ *
+ * @note Keep orders of mocked requests if want use
+ * Verify function to check calls on server. MockTimestamp and MockAuth set
+ * property to be called infinite times.
+ */
+class MockServerHelper {
+ public:
+  MockServerHelper(olp::client::OlpClientSettings settings,
+                   std::string catalog);
+  /**
+   * @brief Mock get timestamp request.
+   *
+   * @note after mocking timestamp request could be called infinite times.
+   *
+   * @param time to be returned by server.
+   */
+  void MockTimestamp(time_t time = 0);
+
+  /**
+   * @brief Mock get authentication tocken request.
+   *
+   * @note after mocking request could be called infinite times.
+   */
+  void MockAuth();
+
+  /**
+   * @brief Mock get version request.
+   *
+   * @note keep order of mocks for future use of Verify function.
+   *
+   * @param time to be returned by server.
+   */
+  void MockGetResponse(olp::dataservice::read::model::VersionResponse data);
+
+  /**
+   * @brief Mock get apis request.
+   *
+   * @note keep order of mocks for future use of Verify function.
+   *
+   * @param data apis to be returned by server.
+   */
+  void MockGetResponse(olp::dataservice::read::model::Apis data);
+
+  /**
+   * @brief Mock get partitions request.
+   *
+   * @note keep order of mocks for future use of Verify function.
+   *
+   * @param data partitions to be returned by server.
+   */
+  void MockGetResponse(olp::dataservice::read::model::Partitions data);
+
+  /**
+   * @brief Verify if all calls were called on server and its order.
+   *
+   */
+  bool Verify();
+
+ private:
+  // template specialization for type to get path matcher
+  template <class T>
+  std::string GetPathMatcher();
+  template <class T>
+  void MockGetResponse(T data);
+  template <class T>
+  void MockGetResponse(std::vector<T> data);
+
+ private:
+  std::string catalog_;
+  Client mock_server_client_;
+  std::vector<std::string> paths__;
+};
+
+}  // namespace mockserver


### PR DESCRIPTION
Create mock client to set expectation on server.
Add helper class to create server responces structures.
Add sequence verification of requests on server.

Relates-To: OLPEDGE-732

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>