### PR TITLE
Adapt ULRs after repository name change.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Contributing to HERE OLP SDK for C++
 
-First off, thanks for taking the time to contribute! The team behind the [HERE OLP SDK for C++](https://github.com/heremaps/here-olp-sdk-cpp) gratefully accepts contributions via [pull requests](https://help.github.com/articles/about-pull-requests/) filed against the [GitHub project](https://github.com/heremaps/here-olp-sdk-cpp/pulls). As part of filing a pull request, we ask you to sign off the [Developer Certificate of Origin](https://developercertificate.org/) (DCO).
+First off, thanks for taking the time to contribute! The team behind the [HERE OLP SDK for C++](https://github.com/heremaps/here-data-sdk-cpp) gratefully accepts contributions via [pull requests](https://help.github.com/articles/about-pull-requests/) filed against the [GitHub project](https://github.com/heremaps/here-data-sdk-cpp/pulls). As part of filing a pull request, we ask you to sign off the [Developer Certificate of Origin](https://developercertificate.org/) (DCO).
 
 ## Development
 

--- a/docs/dataservice-read-catalog-example.md
+++ b/docs/dataservice-read-catalog-example.md
@@ -119,7 +119,7 @@ Before you integrate the HERE OLP SDK for C++ libraries in the iOS example proje
 
 1. To set up the iOS development environment, install the `XCode` and command-line tools.
 2. Install external dependencies.
-   For information on dependencies and installation instructions, see the [related section](https://github.com/heremaps/here-olp-sdk-cpp#dependencies) in the README.md file.
+   For information on dependencies and installation instructions, see the [related section](https://github.com/heremaps/here-data-sdk-cpp#dependencies) in the README.md file.
 3. In `examples/ios/ViewController.mm`, replace the placeholders with your application access key ID, access key secret, and catalog HRN and specify that the example should run `RunExampleRead`.
    For instructions on how to get the access key ID and access key secret, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
 

--- a/docs/dataservice-write-example.md
+++ b/docs/dataservice-write-example.md
@@ -108,7 +108,7 @@ Before you integrate the HERE OLP SDK for C++ libraries in the iOS example proje
 
 1. To set up the iOS development environment, install the `XCode` and command-line tools.
 2. Install external dependencies.
-   For information on dependencies and installation instructions, see the [related section](https://github.com/heremaps/here-olp-sdk-cpp#dependencies) in the README.md file.
+   For information on dependencies and installation instructions, see the [related section](https://github.com/heremaps/here-data-sdk-cpp#dependencies) in the README.md file.
 3. In `examples/ios/ViewController.mm`, replace the placeholders with your application access key ID, access key secret, catalog HRN, and layer name and specify that the example should run `RunExampleWrite`.
    For instructions on how to get the access key ID and access key secret, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
 


### PR DESCRIPTION
All old URLs from various md files are now pointing to the
new repository name.

Relates-To: OLPEDGE-1886

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>