### PR TITLE
Default expiration in PartitionsCacheRepository

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
 
 #include <olp/core/client/HRN.h>
@@ -37,8 +38,9 @@ namespace repository {
 
 class PartitionsCacheRepository final {
  public:
-  PartitionsCacheRepository(const client::HRN& hrn,
-                            std::shared_ptr<cache::KeyValueCache> cache);
+  PartitionsCacheRepository(
+      const client::HRN& hrn, std::shared_ptr<cache::KeyValueCache> cache,
+      std::chrono::seconds default_expiry = std::chrono::seconds::max());
 
   ~PartitionsCacheRepository() = default;
 
@@ -71,6 +73,7 @@ class PartitionsCacheRepository final {
  private:
   client::HRN hrn_;
   std::shared_ptr<cache::KeyValueCache> cache_;
+  time_t default_expiry_;
 };
 }  // namespace repository
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -127,7 +127,8 @@ PartitionsResponse PartitionsRepository::GetPartitions(
     const client::OlpClientSettings& settings, boost::optional<time_t> expiry) {
   auto fetch_option = request.GetFetchOption();
 
-  repository::PartitionsCacheRepository repository(catalog, settings.cache);
+  repository::PartitionsCacheRepository repository(
+      catalog, settings.cache, settings.default_cache_expiration);
 
   if (fetch_option != OnlineOnly && fetch_option != CacheWithUpdate) {
     auto cached_partitions = repository.Get(request, layer);
@@ -208,7 +209,8 @@ PartitionsResponse PartitionsRepository::GetPartitionById(
   const auto& version = data_request.GetVersion();
 
   std::chrono::seconds timeout{settings.retry_settings.timeout};
-  repository::PartitionsCacheRepository repository(catalog, settings.cache);
+  repository::PartitionsCacheRepository repository(
+      catalog, settings.cache, settings.default_cache_expiration);
 
   const std::vector<std::string> partitions{partition_id.value()};
   PartitionsRequest partition_request;
@@ -364,7 +366,8 @@ PartitionsResponse PartitionsRepository::QueryPartitionForVersionedTile(
 
   if (fetch_option != OnlineOnly && fetch_option != CacheWithUpdate) {
     // add partitions to cache
-    repository::PartitionsCacheRepository repository(catalog, settings.cache);
+    repository::PartitionsCacheRepository repository(
+        catalog, settings.cache, settings.default_cache_expiration);
     repository.Put(PartitionsRequest().WithVersion(version), partitions,
                    layer_id, boost::none);
   }
@@ -381,7 +384,8 @@ model::Partitions PartitionsRepository::GetTileFromCache(
     const TileRequest& request, int64_t version,
     const client::OlpClientSettings& settings) {
   if (request.GetFetchOption() != OnlineOnly) {
-    repository::PartitionsCacheRepository repository(catalog, settings.cache);
+    repository::PartitionsCacheRepository repository(
+        catalog, settings.cache, settings.default_cache_expiration);
 
     auto partition_request = PartitionsRequest()
                                  .WithBillingTag(request.GetBillingTag())

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -220,7 +220,8 @@ SubQuadsResponse PrefetchTilesRepository::GetSubQuads(
   }
 
   // add to cache
-  repository::PartitionsCacheRepository cache(catalog, settings.cache);
+  repository::PartitionsCacheRepository cache(
+      catalog, settings.cache, settings.default_cache_expiration);
   cache.Put(PartitionsRequest().WithVersion(version), partitions, layer_id,
             boost::none, false);
 
@@ -282,7 +283,8 @@ SubQuadsResponse PrefetchTilesRepository::GetVolatileSubQuads(
   }
 
   // add to cache
-  repository::PartitionsCacheRepository cache(catalog, settings.cache);
+  repository::PartitionsCacheRepository cache(
+      catalog, settings.cache, settings.default_cache_expiration);
   cache.Put({}, partitions, layer_id, boost::none, false);
 
   return result;

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     CatalogRepositoryTest.cpp
     DataRepositoryTest.cpp
     ParserTest.cpp
+    PartitionsCacheRepositoryTest.cpp
     PartitionsRepositoryTest.cpp
     PrefetchRepositoryTest.cpp
     PrefetchTilesRequestTest.cpp

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsCacheRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsCacheRepositoryTest.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "repositories/PartitionsCacheRepository.h"
+
+#include <gmock/gmock.h>
+#include <olp/core/cache/CacheSettings.h>
+#include <olp/core/cache/KeyValueCache.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+
+namespace {
+
+using namespace olp;
+using namespace olp::dataservice::read;
+
+constexpr auto kCatalog = "hrn:here:data::olp-here-test:catalog";
+constexpr auto kPartitionId = "1111";
+
+TEST(PartitionsCacheRepositoryTest, DefaultExpiry) {
+  const auto hrn = client::HRN::FromString(kCatalog);
+  const auto layer = "layer";
+  const auto catalog_version = 0;
+
+  const auto request = PartitionsRequest();
+  model::Partition some_partition;
+  some_partition.SetPartition(kPartitionId);
+  model::Partitions partitions;
+  auto& partitions_vector = partitions.GetMutablePartitions();
+  partitions_vector.push_back(some_partition);
+
+  model::LayerVersion layer_version;
+  layer_version.SetLayer(layer);
+  model::LayerVersions versions;
+  auto& versions_vector = versions.GetMutableLayerVersions();
+  versions_vector.push_back(layer_version);
+
+  {
+    SCOPED_TRACE("Disable expiration");
+
+    const auto default_expiry = std::chrono::seconds::max();
+    std::shared_ptr<cache::KeyValueCache> cache =
+        olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+    repository::PartitionsCacheRepository repository(hrn, cache,
+                                                     default_expiry);
+
+    repository.Put(request, partitions, layer, boost::none, true);
+    repository.Put(catalog_version, versions);
+    const auto partitions_result =
+        repository.Get(request, {kPartitionId}, layer);
+    const auto partitions_optional_result = repository.Get(request, layer);
+    const auto versions_result = repository.Get(catalog_version);
+
+    EXPECT_FALSE(partitions_result.GetPartitions().empty());
+    EXPECT_TRUE(partitions_optional_result);
+    EXPECT_TRUE(versions_result);
+  }
+
+  {
+    SCOPED_TRACE("Expired");
+
+    const auto default_expiry = std::chrono::seconds(-1);
+    std::shared_ptr<cache::KeyValueCache> cache =
+        olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+    repository::PartitionsCacheRepository repository(hrn, cache,
+                                                     default_expiry);
+
+    repository.Put(request, partitions, layer, boost::none, true);
+    repository.Put(catalog_version, versions);
+
+    const auto partitions_result =
+        repository.Get(request, {kPartitionId}, layer);
+    const auto partitions_optional_result = repository.Get(request, layer);
+    const auto versions_result = repository.Get(catalog_version);
+
+    EXPECT_TRUE(partitions_result.GetPartitions().empty());
+    EXPECT_FALSE(partitions_optional_result);
+    EXPECT_FALSE(versions_result);
+  }
+
+  {
+    SCOPED_TRACE("Optional not expired");
+
+    const auto default_expiry = std::chrono::seconds(-1);
+    const auto data_expiry = std::numeric_limits<time_t>::max();
+    std::shared_ptr<cache::KeyValueCache> cache =
+        olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+    repository::PartitionsCacheRepository repository(hrn, cache,
+                                                     default_expiry);
+
+    repository.Put(request, partitions, layer, data_expiry, true);
+    const auto partitions_result =
+        repository.Get(request, {kPartitionId}, layer);
+    const auto optional_result = repository.Get(request, layer);
+
+    EXPECT_FALSE(partitions_result.GetPartitions().empty());
+    EXPECT_TRUE(optional_result);
+  }
+
+  {
+    SCOPED_TRACE("Optional expired");
+
+    const auto default_expiry = std::chrono::seconds::max();
+    const auto data_expiry = time_t(-1);
+    std::shared_ptr<cache::KeyValueCache> cache =
+        olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+    repository::PartitionsCacheRepository repository(hrn, cache,
+                                                     default_expiry);
+
+    repository.Put(request, partitions, layer, data_expiry, true);
+    const auto partitions_result =
+        repository.Get(request, {kPartitionId}, layer);
+    const auto optional_result = repository.Get(request, layer);
+
+    EXPECT_TRUE(partitions_result.GetPartitions().empty());
+    EXPECT_FALSE(optional_result);
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
Default cache items expiration time can be controlled through
OlpClientOptions, so PartitionsCacheRepository should use it instead of
maximum time_t value. Added unit tests.

Resolves: OLPEDGE-1916

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>