### PR TITLE
Default expiration in DataCacheRepository

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
 
 #include <olp/core/client/HRN.h>
@@ -35,8 +36,9 @@ namespace repository {
 
 class DataCacheRepository final {
  public:
-  DataCacheRepository(const client::HRN& hrn,
-                         std::shared_ptr<cache::KeyValueCache> cache);
+  DataCacheRepository(
+      const client::HRN& hrn, std::shared_ptr<cache::KeyValueCache> cache,
+      std::chrono::seconds default_expiry = std::chrono::seconds::max());
 
   ~DataCacheRepository() = default;
 
@@ -51,6 +53,7 @@ class DataCacheRepository final {
  private:
   client::HRN hrn_;
   std::shared_ptr<cache::KeyValueCache> cache_;
+  time_t default_expiry_;
 };
 }  // namespace repository
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -144,7 +144,8 @@ DataResponse DataRepository::GetBlobData(
     return ApiError(ErrorCode::PreconditionFailed, "Data handle is missing");
   }
 
-  repository::DataCacheRepository repository(catalog, settings.cache);
+  repository::DataCacheRepository repository(catalog, settings.cache,
+                                             settings.default_cache_expiration);
 
   if (fetch_option != OnlineOnly && fetch_option != CacheWithUpdate) {
     auto cached_data = repository.Get(layer, data_handle.value());

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     ApiClientLookupTest.cpp
     CatalogClientTest.cpp
     CatalogRepositoryTest.cpp
+    DataCacheRepositoryTest.cpp
     DataRepositoryTest.cpp
     ParserTest.cpp
     PartitionsCacheRepositoryTest.cpp

--- a/olp-cpp-sdk-dataservice-read/tests/DataCacheRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/DataCacheRepositoryTest.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "repositories/DataCacheRepository.h"
+
+#include <gmock/gmock.h>
+#include <olp/core/cache/CacheSettings.h>
+#include <olp/core/cache/KeyValueCache.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+
+namespace {
+
+using namespace olp;
+using namespace olp::dataservice::read;
+
+constexpr auto kCatalog = "hrn:here:data::olp-here-test:catalog";
+constexpr auto kDataHandle = "4eed6ed1-0d32-43b9-ae79-043cb4256432";
+
+TEST(PartitionsCacheRepositoryTest, DefaultExpiry) {
+  const auto hrn = client::HRN::FromString(kCatalog);
+  const auto layer = "layer";
+
+  const auto data = std::vector<unsigned char>{1, 2, 3};
+  const auto model_data = std::make_shared<std::vector<unsigned char>>(data);
+
+  {
+    SCOPED_TRACE("Disable expiration");
+
+    const auto default_expiry = std::chrono::seconds::max();
+    std::shared_ptr<cache::KeyValueCache> cache =
+        olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+    repository::DataCacheRepository repository(hrn, cache, default_expiry);
+
+    repository.Put(model_data, layer, kDataHandle);
+    const auto result = repository.Get(layer, kDataHandle);
+
+    EXPECT_TRUE(result);
+  }
+
+  {
+    SCOPED_TRACE("Expired");
+
+    const auto default_expiry = std::chrono::seconds(-1);
+    std::shared_ptr<cache::KeyValueCache> cache =
+        olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+    repository::DataCacheRepository repository(hrn, cache, default_expiry);
+
+    repository.Put(model_data, layer, kDataHandle);
+    const auto result = repository.Get(layer, kDataHandle);
+
+    EXPECT_FALSE(result);
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
Default cache items expiration time can be controlled through
OlpClientOptions, so DataCacheRepository should use it instead of
maximum time_t value. Added unit tests.

Resolves: OLPEDGE-1915

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>