### PR TITLE
Reduce excesive logging in API repositories.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/ApiCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/ApiCacheRepository.cpp
@@ -24,6 +24,7 @@
 
 namespace {
 constexpr auto kLogTag = "ApiCacheRepository";
+constexpr time_t kLookupApiExpiryTime = 3600;
 
 std::string CreateKey(const std::string& hrn, const std::string& service,
                       const std::string& serviceVersion) {
@@ -35,26 +36,26 @@ namespace olp {
 namespace dataservice {
 namespace read {
 namespace repository {
-using namespace olp::client;
 ApiCacheRepository::ApiCacheRepository(
-    const HRN& hrn, std::shared_ptr<cache::KeyValueCache> cache)
+    const client::HRN& hrn, std::shared_ptr<cache::KeyValueCache> cache)
     : hrn_(hrn), cache_(cache) {}
 
 void ApiCacheRepository::Put(const std::string& service,
-                             const std::string& serviceVersion,
-                             const std::string& serviceUrl) {
+                             const std::string& version,
+                             const std::string& url) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  auto key = CreateKey(hrn, service, serviceVersion);
-  OLP_SDK_LOG_TRACE_F(kLogTag, "Put '%s'", key.c_str());
-  cache_->Put(CreateKey(hrn, service, serviceVersion), serviceUrl,
-              [serviceUrl]() { return serviceUrl; }, 3600);
+  auto key = CreateKey(hrn, service, version);
+  OLP_SDK_LOG_DEBUG_F(kLogTag, "Put -> '%s'", key.c_str());
+
+  cache_->Put(key, url, [&]() { return url; }, kLookupApiExpiryTime);
 }
 
 boost::optional<std::string> ApiCacheRepository::Get(
-    const std::string& service, const std::string& serviceVersion) {
+    const std::string& service, const std::string& version) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  auto key = CreateKey(hrn, service, serviceVersion);
-  OLP_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
+  auto key = CreateKey(hrn, service, version);
+  OLP_SDK_LOG_DEBUG_F(kLogTag, "Get -> '%s'", key.c_str());
+
   auto url = cache_->Get(key, [](const std::string& value) { return value; });
   if (url.empty()) {
     return boost::none;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
@@ -19,6 +19,9 @@
 
 #include "DataCacheRepository.h"
 
+#include <limits>
+#include <string>
+
 #include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/logging/Log.h>
 
@@ -41,9 +44,8 @@ namespace olp {
 namespace dataservice {
 namespace read {
 namespace repository {
-using namespace olp::client;
 DataCacheRepository::DataCacheRepository(
-    const HRN& hrn, std::shared_ptr<cache::KeyValueCache> cache,
+    const client::HRN& hrn, std::shared_ptr<cache::KeyValueCache> cache,
     std::chrono::seconds default_expiry)
     : hrn_(hrn), cache_(cache), default_expiry_(ConvertTime(default_expiry)) {}
 
@@ -52,7 +54,8 @@ void DataCacheRepository::Put(const model::Data& data,
                               const std::string& data_handle) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, layer_id, data_handle);
-  OLP_SDK_LOG_TRACE_F(kLogTag, "Put '%s'", key.c_str());
+  OLP_SDK_LOG_DEBUG_F(kLogTag, "Put -> '%s'", key.c_str());
+
   cache_->Put(key, data, default_expiry_);
 }
 
@@ -60,20 +63,22 @@ boost::optional<model::Data> DataCacheRepository::Get(
     const std::string& layer_id, const std::string& data_handle) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, layer_id, data_handle);
-  OLP_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
-  auto cachedData = cache_->Get(key);
-  if (!cachedData) {
+  OLP_SDK_LOG_DEBUG_F(kLogTag, "Get '%s'", key.c_str());
+
+  auto cached_data = cache_->Get(key);
+  if (!cached_data) {
     return boost::none;
   }
 
-  return cachedData;
+  return cached_data;
 }
 
 bool DataCacheRepository::Clear(const std::string& layer_id,
                                 const std::string& data_handle) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, layer_id, data_handle);
-  OLP_SDK_LOG_INFO_F(kLogTag, "Clear '%s'", key.c_str());
+  OLP_SDK_LOG_INFO_F(kLogTag, "Clear -> '%s'", key.c_str());
+
   return cache_->RemoveKeysWithPrefix(key);
 }
 

--- a/scripts/misc/cpplint_ci.sh
+++ b/scripts/misc/cpplint_ci.sh
@@ -65,7 +65,6 @@ CPPLINT_BLOCKING_FILTER="\
      -runtime/explicit,\
      -runtime/arrays,\
      -runtime/threadsafe_fn,\
-     -build/namespaces,\
      -build/include_subdir,\
      -build/include_order,\
      -build/include_what_you_use,\


### PR DESCRIPTION
The SDK logs too much and too often especially in the API repositories.
This commit removes some of the duplicated logs, aligns all logs to a
common structure, and adds additional info like HRN and key to all
important logs. All other logs that are not important are now on level
debug. All previous trace logs which are actually printing debug level
information are now raised to debug level.

One very important fix that needs highlight is the capture by copy
which was removed from most of the cache repositories while putting
into the cache. It is not necessary to capture model data by copy as
the KeyValueCache::Put() is pure sync and will not leave the context
so that the model faces deletion. This additional copy is not needed
and might even bring performance decreases. This is now fixed and all
models are captured by reference when added to the cache.

Additionally, this commit also enables ccplint namespace check.

Resolves: OLPSUP-10501

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>