### PR TITLE
Default expiration in CatalogCacheRepository

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogCacheRepository.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
 
 #include <olp/core/client/HRN.h>
@@ -36,8 +37,9 @@ namespace repository {
 
 class CatalogCacheRepository final {
  public:
-  CatalogCacheRepository(const client::HRN& hrn,
-                         std::shared_ptr<cache::KeyValueCache> cache);
+  CatalogCacheRepository(
+      const client::HRN& hrn, std::shared_ptr<cache::KeyValueCache> cache,
+      std::chrono::seconds default_expiry = std::chrono::seconds::max());
 
   ~CatalogCacheRepository() = default;
 
@@ -54,6 +56,7 @@ class CatalogCacheRepository final {
  private:
   client::HRN hrn_;
   std::shared_ptr<cache::KeyValueCache> cache_;
+  time_t default_expiry_;
 };
 }  // namespace repository
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
@@ -52,7 +52,8 @@ CatalogResponse CatalogRepository::GetCatalog(
 
   OLP_SDK_LOG_TRACE_F(kLogTag, "getCatalog '%s'", request_key.c_str());
 
-  repository::CatalogCacheRepository repository{catalog, settings.cache};
+  repository::CatalogCacheRepository repository{
+      catalog, settings.cache, settings.default_cache_expiration};
 
   if (fetch_options != OnlineOnly && fetch_options != CacheWithUpdate) {
     auto cached = repository.Get();

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -17,6 +17,7 @@
 
 set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     ApiClientLookupTest.cpp
+    CatalogCacheRepositoryTest.cpp
     CatalogClientTest.cpp
     CatalogRepositoryTest.cpp
     DataCacheRepositoryTest.cpp

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogCacheRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogCacheRepositoryTest.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "repositories/CatalogCacheRepository.h"
+
+#include <gmock/gmock.h>
+#include <olp/core/cache/CacheSettings.h>
+#include <olp/core/cache/KeyValueCache.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+
+namespace {
+
+using namespace olp;
+using namespace olp::dataservice::read;
+
+constexpr auto kCatalog = "hrn:here:data::olp-here-test:catalog";
+
+TEST(PartitionsCacheRepositoryTest, DefaultExpiry) {
+  const auto hrn = client::HRN::FromString(kCatalog);
+
+  model::Catalog model_catalog;
+
+  {
+    SCOPED_TRACE("Disable expiration");
+
+    const auto default_expiry = std::chrono::seconds::max();
+    std::shared_ptr<cache::KeyValueCache> cache =
+        olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+    repository::CatalogCacheRepository repository(hrn, cache, default_expiry);
+
+    repository.Put(model_catalog);
+    const auto result = repository.Get();
+
+    EXPECT_TRUE(result);
+  }
+
+  {
+    SCOPED_TRACE("Expired");
+
+    const auto default_expiry = std::chrono::seconds(-1);
+    std::shared_ptr<cache::KeyValueCache> cache =
+        olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+    repository::CatalogCacheRepository repository(hrn, cache, default_expiry);
+
+    repository.Put(model_catalog);
+    const auto result = repository.Get();
+
+    EXPECT_FALSE(result);
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
Default cache items expiration time can be controlled through
OlpClientOptions, so CatalogCacheRepository should use it instead of
maximum time_t value. Added unit tests.

Resolves: OLPEDGE-1917

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>