### PR TITLE
Add CMake option OLP_SDK_DISABLE_DEBUG_LOGGING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ option(OLP_SDK_BOOST_THROW_EXCEPTION_EXTERNAL "The boost::throw_exception() is d
 option(OLP_SDK_BUILD_EXTERNAL_DEPS "Download and build external dependencies" ON)
 option(OLP_SDK_BUILD_EXAMPLES "Enable examples targets" OFF)
 option(OLP_SDK_MSVC_PARALLEL_BUILD_ENABLE "Enable parallel build on MSVC" ON)
+option(OLP_SDK_DISABLE_DEBUG_LOGGING "Disable debug and trace level logging" OFF)
 
 # C++ standard version. Minimum supported version is 11.
 set(CMAKE_CXX_STANDARD 11)
@@ -68,7 +69,7 @@ include(common)
 # Include code coverage variables
 include(coverage)
 
-if(OLP_SDK_BUILD_EXTERNAL_DEPS)
+if (OLP_SDK_BUILD_EXTERNAL_DEPS)
     # Add third-party dependencies
     set(EXTERNAL_BINARY_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/install)
     add_subdirectory(external)

--- a/README.md
+++ b/README.md
@@ -164,15 +164,16 @@ cmake --build . --target docs
 
 ### CMake Flags
 
-| Flag                                                | Description                                                                                                                                                                                                                               |
-| :-------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `BUILD_SHARED_LIBS`                                 | Defaults to `OFF`. If enabled, all libraries are built as shared.                                                                                                                                                                         |
-| `OLP_SDK_BUILD_DOC`                                 | Defaults to `OFF`. If enabled, the API reference is generated in your build directory.<br> **Note:** Before you download the API reference, install <a href="http://www.doxygen.nl/" target="_blank">Doxygen</a>.                         |
-| `OLP_SDK_ENABLE_TESTING`                            | Defaults to `ON`. If enabled, unit tests are built for each library.                                                                                                                                                                      |
-| `OLP_SDK_BUILD_EXTERNAL_DEPS`                       | Defaults to `ON`. If enabled, CMake downloads and compiles dependencies.                                                                                                                                                                  |
-| `OLP_SDK_NO_EXCEPTION`                              | Defaults to `OFF`. If enabled, all libraries are built without exceptions.                                                                                                                                                                |
-| `OLP_SDK_BOOST_THROW_EXCEPTION_EXTERNAL`            | Defaults to `OFF`. When `OLP_SDK_NO_EXCEPTION` is `ON`, `boost` requires `boost::throw_exception()` to be defined. If enabled, the external definition of `boost::throw_exception()` is used. Otherwise, the library uses own definition. |
-| `OLP_SDK_MSVC_PARALLEL_BUILD_ENABLE` (Windows Only) | Defaults to `ON`. If enabled, the `/MP` compilation flag is added to build the SDK using multiple cores.                                                                                                                                  |
+| Flag | Description |
+| :- | :- |
+| `BUILD_SHARED_LIBS` | Defaults to `OFF`. If enabled, all libraries are built as shared. |
+| `OLP_SDK_BUILD_DOC` | Defaults to `OFF`. If enabled, the API reference is generated in your build directory.<br> **Note:** Before you download the API reference, install <a href="http://www.doxygen.nl/" target="_blank">Doxygen</a>. |
+| `OLP_SDK_ENABLE_TESTING` | Defaults to `ON`. If enabled, unit tests are built for each library. |
+| `OLP_SDK_BUILD_EXTERNAL_DEPS` | Defaults to `ON`. If enabled, CMake downloads and compiles dependencies. |
+| `OLP_SDK_NO_EXCEPTION` | Defaults to `OFF`. If enabled, all libraries are built without exceptions. |
+| `OLP_SDK_BOOST_THROW_EXCEPTION_EXTERNAL` | Defaults to `OFF`. When `OLP_SDK_NO_EXCEPTION` is `ON`, `boost` requires `boost::throw_exception()` to be defined. If enabled, the external definition of `boost::throw_exception()` is used. Otherwise, the library uses own definition. |
+| `OLP_SDK_MSVC_PARALLEL_BUILD_ENABLE` (Windows Only) | Defaults to `ON`. If enabled, the `/MP` compilation flag is added to build the SDK using multiple cores. |
+| `OLP_SDK_DISABLE_DEBUG_LOGGING`| Defaults to `OFF`. If enabled, The debug and trace level log messages will not be printed. |
 
 ## SDK Usage
 

--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -328,6 +328,12 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
 add_library(${PROJECT_NAME} ${OLP_SDK_CORE_SOURCES} ${OLP_SDK_CORE_HEADERS})
 
+
+if (OLP_SDK_DISABLE_DEBUG_LOGGING)
+    target_compile_definitions(${PROJECT_NAME} 
+        PUBLIC LOGGING_DISABLE_DEBUG_LEVEL)
+endif()
+
 target_compile_definitions(${PROJECT_NAME}
     PRIVATE ${OLP_SDK_DEFAULT_NETWORK_DEFINITION})
 


### PR DESCRIPTION
Users can use it to disable debug/trace log messages. Default is OFF
which mean means that messages are enabled.

Resolves: OLPEDGE-247

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>