### PR TITLE
Merge concurrent lookup API requests.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/NamedMutex.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/NamedMutex.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "NamedMutex.h"
+
+#include <unordered_map>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+namespace repository {
+
+namespace {
+
+static std::mutex gMutex;
+
+struct RefCounterMutex {
+  std::mutex mutex;
+  uint32_t use_count{0};
+};
+
+static std::unordered_map<std::string, RefCounterMutex> gMutexes;
+
+std::mutex& AquireLock(const std::string& resource) {
+  std::unique_lock<std::mutex> lock(gMutex);
+  RefCounterMutex& ref_mutex = gMutexes[resource];
+  ref_mutex.use_count++;
+  return ref_mutex.mutex;
+}
+
+void ReleaseLock(const std::string& resource) {
+  std::unique_lock<std::mutex> lock(gMutex);
+  RefCounterMutex& ref_mutex = gMutexes[resource];
+  if (--ref_mutex.use_count == 0) {
+    gMutexes.erase(resource);
+  }
+}
+
+}  // namespace
+
+NamedMutex::NamedMutex(const std::string& name)
+    : name_{name}, mutex_{AquireLock(name_)} {}
+
+NamedMutex::~NamedMutex() { ReleaseLock(name_); }
+
+void NamedMutex::lock() { mutex_.lock(); }
+
+bool NamedMutex::try_lock() { return mutex_.try_lock(); }
+
+void NamedMutex::unlock() { mutex_.unlock(); }
+
+}  // namespace repository
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/repositories/NamedMutex.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/NamedMutex.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <mutex>
+#include <string>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+namespace repository {
+
+/*
+ * @brief A synchronization primitive that can be used to protect shared data
+ * from being simultaneously accessed by multiple threads.
+ */
+class NamedMutex final {
+ public:
+  explicit NamedMutex(const std::string& name);
+
+  NamedMutex(const NamedMutex&) = delete;
+  NamedMutex(NamedMutex&&) = delete;
+  NamedMutex& operator=(const NamedMutex&) = delete;
+  NamedMutex& operator=(NamedMutex&&) = delete;
+
+  void lock();
+  bool try_lock();
+  void unlock();
+
+  ~NamedMutex();
+
+ private:
+  std::string name_;
+  std::mutex& mutex_;
+};
+
+}  // namespace repository
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp


### PR DESCRIPTION
Used to speedup the cold start, when multiple clients concurrently
tries to download the services URLs.
The callers are blocked until the first caller downloads the content.

Relates-To: OLPEDGE-1986

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>