### PR TITLE
Add compression to CacheSettings.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/CacheSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/CacheSettings.h
@@ -46,6 +46,15 @@ enum class EvictionPolicy : unsigned char {
 };
 
 /**
+ * @brief Options for database compression.
+ */
+enum class CompressionType {
+  kNoCompression,     /*!< No compression applied on the data before storing. */
+  kDefaultCompression /*!< Default compression will be applied to data before
+                        storing. */
+};
+
+/**
  * @brief Settings for memory and disk caching.
  */
 struct CORE_API CacheSettings {
@@ -112,6 +121,20 @@ struct CORE_API CacheSettings {
    * is EvictionPolicy::kLeastRecentlyUsed.
    */
   EvictionPolicy eviction_policy = EvictionPolicy::kLeastRecentlyUsed;
+
+  /**
+   * @brief This flag sets the compression policy to be applied on the database.
+   *
+   * In some cases though, when all the data to be inserted is already
+   * compressed by any means, e.g. protobuf or other serialization protocols, it
+   * might not be worth to enable any compression at all as it will eat up some
+   * CPU to compress and decompress the metadata without major gain. This
+   * parameter is dynamic and can be changed between runs. If changed only new
+   * values which are added will be using the new compression policy all
+   * existing entries will remain unchanged. The default value is
+   * CompressionType::kDefaultCompression.
+   */
+  CompressionType compression = CompressionType::kDefaultCompression;
 
   /**
    * @brief The path to the protected (read-only) cache.

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -85,6 +85,13 @@ size_t StoreExpiry(const std::string& key, leveldb::WriteBatch& batch,
   return expiry_key.size() + time_str.size();
 }
 
+leveldb::CompressionType GetCompression(
+    olp::cache::CompressionType compression) {
+  return (compression == olp::cache::CompressionType::kNoCompression)
+             ? leveldb::kNoCompression
+             : leveldb::kSnappyCompression;
+}
+
 }  // namespace
 
 namespace olp {
@@ -471,6 +478,7 @@ DefaultCache::StorageOpenResult DefaultCacheImpl::SetupStorage() {
     storage_settings.enforce_immediate_flush =
         settings_.enforce_immediate_flush;
     storage_settings.max_file_size = settings_.max_file_size;
+    storage_settings.compression = GetCompression(settings_.compression);
 
     mutable_cache_ = std::make_unique<DiskCache>();
     auto status = mutable_cache_->Open(settings_.disk_path_mutable.get(),

--- a/olp-cpp-sdk-core/src/cache/DiskCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.cpp
@@ -183,8 +183,10 @@ OpenResult DiskCache::Open(const std::string& data_path,
   max_size_ = settings.max_disk_storage;
 
   leveldb::Options open_options;
+  open_options.compression = settings.compression;
   open_options.info_log = leveldb_logger_.get();
   open_options.write_buffer_size = settings.max_chunk_size;
+  open_options.filter_policy = leveldb::NewBloomFilterPolicy(10);
   if (settings.max_file_size != 0) {
     open_options.max_file_size = settings.max_file_size;
   }

--- a/olp-cpp-sdk-core/src/cache/DiskCache.h
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.h
@@ -60,16 +60,23 @@ enum class OpenResult {
 struct StorageSettings {
   /// The maximum allowed size of storage on disk in bytes.
   uint64_t max_disk_storage = 0u;
+
   /// The maximum size of data in memory before it gets flushed to disk.
   /// Data is kept in memory until its size reaches this value and then data is
   /// flushed to disk. A maximum write buffer of 32 MB is most optimal even for
   /// batch imports.
   uint64_t max_chunk_size = 32 * 1024u * 1024u;
+
   /// Flag to enable double-writes to disk to avoid data losses between ignition
   /// cycles.
   bool enforce_immediate_flush = true;
+
   /// Maximum size of one file in storage, default 2MBytes.
   size_t max_file_size = 2 * 1024u * 1024u;
+
+  /// Compression type to be applied on the data before storing it.
+  leveldb::CompressionType compression =
+      leveldb::CompressionType::kSnappyCompression;
 };
 
 /**


### PR DESCRIPTION
This commit adds the possible compression settings to the CacheSettings
structure to be passed on to leveldb. Possible values so far are only
no compression or Snappy compression. Nevertheless there are user who
will profit from not applying any compression if the data added to the
cache is already compressed, e.g. protobuf.

Additionally this commit adds filter policy to bloom filter with 10
bits precision which will enhance reading speeds.

Relates-To: OLPEDGE-1984, OLPEDGE-1983

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>