### PR TITLE
Remove expired elements during cache eviction

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
@@ -53,7 +53,9 @@ class DefaultCacheImpl;
  */
 class CORE_API DefaultCache : public KeyValueCache {
  public:
-  /*! The storage open result type */
+  /**
+   * @brief The storage open result type
+   */
   enum StorageOpenResult {
     Success,            /*!< The operation succeeded. */
     OpenDiskPathFailure /*!< The disk cache failure. */
@@ -86,6 +88,23 @@ class CORE_API DefaultCache : public KeyValueCache {
    * @return True if the operation is successful; false otherwise.
    */
   bool Clear();
+
+  /**
+   * @brief Compacts the underlying mutable cache storage.
+   *
+   * In particular, deleted and overwritten versions are discarded, and the data
+   * is rearranged to reduce the cost of operations needed to access the data.
+   * In some cases this operation might take a very long time, so use with care.
+   * You generally don't have to call this, but it can be useful to optimize
+   * preloaded databases or compact before you shut down the system to ensure
+   * quick startup time.
+   *
+   * @note This operation is blocking and under mutex lock blocking any other
+   * operation in parallel for the time of the compacting operation. Be aware
+   * that automatic asynchronous compacting operation is triggered internally
+   * once the database size exceeds the CacheSettings::max_disk_storage size.
+   */
+  void Compact();
 
   /**
    * @brief Stores the key-value pair in the cache.

--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkRequest.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkRequest.h
@@ -40,12 +40,13 @@ class CORE_API NetworkRequest final {
 
   /// The HTTP method, as specified at https://tools.ietf.org/html/rfc2616.
   enum class HttpVerb {
-    GET = 0,    ///< The GET method (RFC2616, section-9.3).
-    POST = 1,   ///< The POST method (RFC2616, section-9.5).
-    HEAD = 2,   ///< The HEAD method (RFC2616 section-9.4).
-    PUT = 3,    ///< The PUT method (RFC2616 section-9.6).
-    DEL = 4,    ///< The DELETE method (RFC2616 section-9.7).
-    PATCH = 5,  ///< The PATCH method (RFC2068 section-19.6.1.1).
+    GET = 0,     ///< The GET method (RFC2616, section-9.3).
+    POST = 1,    ///< The POST method (RFC2616, section-9.5).
+    HEAD = 2,    ///< The HEAD method (RFC2616 section-9.4).
+    PUT = 3,     ///< The PUT method (RFC2616 section-9.6).
+    DEL = 4,     ///< The DELETE method (RFC2616 section-9.7).
+    PATCH = 5,   ///< The PATCH method (RFC2068 section-19.6.1.1).
+    OPTIONS = 6, ///< The OPTIONS method (RFC2616 section-9.2).
   };
 
   /**

--- a/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
@@ -17,11 +17,9 @@
  * License-Filename: LICENSE
  */
 
-#include "olp/core/porting/warning_disable.h"
-
 #include "olp/core/cache/DefaultCache.h"
-
 #include "DefaultCacheImpl.h"
+#include "olp/core/porting/warning_disable.h"
 
 namespace olp {
 namespace cache {
@@ -36,6 +34,8 @@ DefaultCache::StorageOpenResult DefaultCache::Open() { return impl_->Open(); }
 void DefaultCache::Close() { impl_->Close(); }
 
 bool DefaultCache::Clear() { return impl_->Clear(); }
+
+void DefaultCache::Compact() { return impl_->Compact(); }
 
 bool DefaultCache::Put(const std::string& key, const boost::any& value,
                        const Encoder& encoder, time_t expiry) {

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -151,6 +151,13 @@ bool DefaultCacheImpl::Clear() {
   return SetupStorage() == DefaultCache::StorageOpenResult::Success;
 }
 
+void DefaultCacheImpl::Compact() {
+  std::lock_guard<std::mutex> lock(cache_lock_);
+  if (mutable_cache_) {
+    mutable_cache_->Compact();
+  }
+}
+
 bool DefaultCacheImpl::Put(const std::string& key, const boost::any& value,
                            const Encoder& encoder, time_t expiry) {
   std::lock_guard<std::mutex> lock(cache_lock_);
@@ -466,7 +473,7 @@ uint64_t DefaultCacheImpl::MaybeEvictData(leveldb::WriteBatch& batch) {
                         .count();
   OLP_SDK_LOG_INFO_F(kLogTag,
                      "Evicted from mutable cache, items=%" PRId32
-                     ", time=%" PRId64 " ms, size=%" PRIu64,
+                     ", time=%" PRId64 "ms, size=%" PRIu64,
                      count, elapsed, evicted);
 
   return evicted;

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -45,8 +45,7 @@ std::string CreateExpiryKey(const std::string& key) {
 }
 
 bool IsExpiryKey(const std::string& key) {
-  auto pos = key.rfind(kExpirySuffix);
-  return pos == 0;
+  return key.rfind(kExpirySuffix) != std::string::npos;
 }
 
 bool IsExpiryValid(time_t expiry) {
@@ -81,8 +80,7 @@ void PurgeDiskItem(const std::string& key, olp::cache::DiskCache& disk_cache,
 size_t StoreExpiry(const std::string& key, leveldb::WriteBatch& batch,
                    time_t expiry) {
   auto expiry_key = CreateExpiryKey(key);
-  auto time_str = std::to_string(
-      expiry + olp::cache::InMemoryCache::DefaultTimeProvider()());
+  auto time_str = std::to_string(expiry);
   batch.Put(expiry_key, time_str);
 
   return expiry_key.size() + time_str.size();
@@ -314,13 +312,36 @@ void DefaultCacheImpl::InitializeLru() {
   auto count = 0u;
   auto it = mutable_cache_->NewIterator(leveldb::ReadOptions());
   for (it->SeekToFirst(); it->Valid(); it->Next()) {
-    const auto key = it->key().ToString();
+    auto key = it->key().ToString();
     const auto& value = it->value();
+
+    // Here we count both expiry keys and regular keys
     mutable_cache_data_size_ += key.size() + value.size();
 
-    if (mutable_cache_lru_ && !IsExpiryKey(key)) {
-      ++count;
-      mutable_cache_lru_->Insert(key, value.size());
+    if (mutable_cache_lru_) {
+      // remove the prefix to restore original key
+      const bool expiration_key = IsExpiryKey(key);
+      if (expiration_key) {
+        key.resize(key.size() - kExpirySuffixLength);
+      }
+
+      ValueProperties props;
+
+      auto iterator = mutable_cache_lru_->FindNoPromote(key);
+      if (iterator != mutable_cache_lru_->end()) {
+        props = iterator->value();
+      }
+
+      if (expiration_key) {
+        props.expiry = std::stol(value.data());
+      } else {
+        props.size = value.size();
+      }
+
+      auto result = mutable_cache_lru_->InsertOrAssign(key, props);
+      if (result.second) {
+        ++count;
+      }
     }
   }
 
@@ -379,24 +400,63 @@ uint64_t DefaultCacheImpl::MaybeEvictData(leveldb::WriteBatch& batch) {
   int64_t evicted = 0u;
   auto count = 0u;
   const auto min_size = kMinDiskUsedThreshold * settings_.max_disk_storage;
+
+  const auto current_time = olp::cache::InMemoryCache::DefaultTimeProvider()();
+
+  // Remove the expired elements first
+  for (auto it = mutable_cache_lru_->begin();
+       it != mutable_cache_lru_->end() &&
+       mutable_cache_data_size_ - evicted > min_size;) {
+    const auto& key = it->key();
+    const auto& properties = it->value();
+
+    const bool expired = (properties.expiry - current_time) <= 0;
+
+    if (!expired) {
+      ++it;
+      continue;
+    }
+
+    // Remove the key
+    batch.Delete(key);
+    evicted += key.size() + properties.size;
+
+    // Remove the key's expiry
+    auto expiry_key = CreateExpiryKey(key);
+    batch.Delete(expiry_key);
+    evicted += expiry_key.size() + kExpiryValueSize;
+
+    ++count;
+
+    if (memory_cache_) {
+      memory_cache_->Remove(key);
+    }
+
+    it = mutable_cache_lru_->Erase(it);
+  }
+
+  // Remove the other elements if needed
   for (auto it = mutable_cache_lru_->rbegin();
        it != mutable_cache_lru_->rend() &&
        mutable_cache_data_size_ - evicted > min_size;) {
     const auto& key = it->key();
-    const auto expiry_key = CreateExpiryKey(key);
-    auto expiry_value = mutable_cache_->Get(expiry_key);
-    if (expiry_value) {
+    const auto& properties = it->value();
+
+    evicted += key.size() + properties.size;
+    batch.Delete(key);
+
+    if (IsExpiryValid(properties.expiry)) {
+      const auto expiry_key = CreateExpiryKey(key);
       evicted += expiry_key.size() + kExpiryValueSize;
       batch.Delete(expiry_key);
     }
-    evicted += key.size() + it->value();
+
     ++count;
 
     if (memory_cache_) {
       memory_cache_->Remove(it->key());
     }
 
-    batch.Delete(key);
     mutable_cache_lru_->Erase(it);
     it = mutable_cache_lru_->rbegin();
   }
@@ -434,6 +494,7 @@ bool DefaultCacheImpl::PutMutableCache(const std::string& key,
   added_data_size += key.size() + item_size;
 
   if (IsExpiryValid(expiry)) {
+    expiry += olp::cache::InMemoryCache::DefaultTimeProvider()();
     added_data_size += StoreExpiry(key, *batch, expiry);
   }
 
@@ -447,7 +508,10 @@ bool DefaultCacheImpl::PutMutableCache(const std::string& key,
   mutable_cache_data_size_ -= removed_data_size;
 
   if (mutable_cache_lru_) {
-    const auto result = mutable_cache_lru_->InsertOrAssign(key, item_size);
+    ValueProperties props;
+    props.size = item_size;
+    props.expiry = expiry;
+    const auto result = mutable_cache_lru_->InsertOrAssign(key, props);
     if (result.first == mutable_cache_lru_->end() && !result.second) {
       OLP_SDK_LOG_WARNING_F(
           kLogTag, "Failed to store value in mutable LRU cache, key %s",
@@ -527,7 +591,10 @@ bool DefaultCacheImpl::GetFromDiskCache(const std::string& key,
     auto result = protected_cache_->Get(key, value);
     if (result && value && !value->empty()) {
       expiry = GetRemainingExpiryTime(key, *protected_cache_);
-      return expiry > 0;
+      if (expiry > 0) {
+        return true;
+      }
+      value = nullptr;
     }
   }
 
@@ -543,7 +610,7 @@ bool DefaultCacheImpl::GetFromDiskCache(const std::string& key,
       }
 
       auto result = mutable_cache_->Get(key, value);
-      return result && value && expiry > 0;
+      return result && value;
     }
 
     // Data expired in cache -> remove

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
@@ -56,9 +56,15 @@ class DefaultCacheImpl {
   bool RemoveKeysWithPrefix(const std::string& key);
 
  protected:
-  /// Alias for the LRU cache using the leveldb keys as key and the value size
+  /// The LRU value property.
+  struct ValueProperties {
+    size_t size{0ull};
+    time_t expiry{KeyValueCache::kDefaultExpiry};
+  };
+
+  /// The LRU cache definition using the leveldb keys as key and the value size
   /// as value.
-  using DiskLruCache = utils::LruCache<std::string, size_t>;
+  using DiskLruCache = utils::LruCache<std::string, ValueProperties>;
 
   /// Returns LRU mutable cache, used for tests.
   const std::unique_ptr<DiskLruCache>& GetMutableCacheLru() const {

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
@@ -41,6 +41,8 @@ class DefaultCacheImpl {
 
   bool Clear();
 
+  void Compact();
+
   bool Put(const std::string& key, const KeyValueCache::ValueTypePtr value,
            time_t expiry);
 

--- a/olp-cpp-sdk-core/src/cache/DiskCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.cpp
@@ -160,10 +160,14 @@ void DiskCache::LevelDBLogger::Logv(const char* format, va_list ap) {
   OLP_SDK_LOG_DEBUG_F("Storage.LevelDB.leveldb", format, ap);
 }
 
-void DiskCache::Close() { database_.reset(); }
+void DiskCache::Close() {
+  database_.reset();
+  filter_policy_.reset();
+}
 
 bool DiskCache::Clear() {
   database_.reset();
+  filter_policy_.reset();
   if (!disk_cache_path_.empty()) {
     return olp::utils::Dir::remove(disk_cache_path_);
   }
@@ -188,6 +192,7 @@ OpenResult DiskCache::Open(const std::string& data_path,
   open_options.info_log = leveldb_logger_.get();
   open_options.write_buffer_size = settings.max_chunk_size;
   open_options.filter_policy = leveldb::NewBloomFilterPolicy(10);
+  filter_policy_.reset(open_options.filter_policy);
   if (settings.max_file_size != 0) {
     open_options.max_file_size = settings.max_file_size;
   }

--- a/olp-cpp-sdk-core/src/cache/DiskCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.cpp
@@ -41,7 +41,7 @@ namespace olp {
 namespace cache {
 
 namespace {
-constexpr auto kLogTag = "Storage.LevelDB";
+constexpr auto kLogTag = "DiskCache";
 
 leveldb::Slice ToLeveldbSlice(const std::string& slice) {
   return leveldb::Slice(slice);
@@ -153,7 +153,6 @@ client::ApiError GetApiError(const leveldb::Status& status) {
 }  // anonymous namespace
 
 DiskCache::DiskCache() = default;
-
 DiskCache::~DiskCache() { Close(); }
 
 void DiskCache::LevelDBLogger::Logv(const char* format, va_list ap) {
@@ -161,17 +160,31 @@ void DiskCache::LevelDBLogger::Logv(const char* format, va_list ap) {
 }
 
 void DiskCache::Close() {
+  if (compaction_thread_.joinable()) {
+    compaction_thread_.join();
+  }
+
   database_.reset();
   filter_policy_.reset();
 }
 
 bool DiskCache::Clear() {
-  database_.reset();
-  filter_policy_.reset();
+  Close();
+
   if (!disk_cache_path_.empty()) {
     return olp::utils::Dir::remove(disk_cache_path_);
   }
+
   return true;
+}
+
+void DiskCache::Compact() {
+  // Lets make sure that the parallel thread which is running the compact is not
+  // doing it already. We don't need two at the same time.
+  if (!compacting_.exchange(true)) {
+    database_->CompactRange(nullptr, nullptr);
+    compacting_ = false;
+  }
 }
 
 OpenResult DiskCache::Open(const std::string& data_path,
@@ -251,7 +264,7 @@ OpenResult DiskCache::Open(const std::string& data_path,
 
 bool DiskCache::Put(const std::string& key, leveldb::Slice slice) {
   if (!database_) {
-    OLP_SDK_LOG_ERROR(kLogTag, "Put: Database is uninitialized");
+    OLP_SDK_LOG_ERROR(kLogTag, "Put: Database is not initialized");
     return false;
   }
 
@@ -266,7 +279,7 @@ bool DiskCache::Put(const std::string& key, leveldb::Slice slice) {
 
 boost::optional<std::string> DiskCache::Get(const std::string& key) {
   if (!database_) {
-    OLP_SDK_LOG_ERROR(kLogTag, "Get: Database is uninitialized");
+    OLP_SDK_LOG_ERROR(kLogTag, "Get: Database is not initialized");
     return boost::none;
   }
 
@@ -281,7 +294,7 @@ boost::optional<std::string> DiskCache::Get(const std::string& key) {
 bool DiskCache::Get(const std::string& key,
                     KeyValueCache::ValueTypePtr& value) {
   if (!database_) {
-    OLP_SDK_LOG_ERROR(kLogTag, "Get: Database not initialized");
+    OLP_SDK_LOG_ERROR(kLogTag, "Get: Database is not initialized");
     return false;
   }
 
@@ -304,9 +317,8 @@ bool DiskCache::Get(const std::string& key,
 
 bool DiskCache::Remove(const std::string& key, uint64_t& removed_data_size) {
   if (!database_) {
+    OLP_SDK_LOG_ERROR(kLogTag, "Remove: Database is not initialized");
     removed_data_size = 0;
-
-    OLP_SDK_LOG_ERROR(kLogTag, "Remove: Database is uninitialized");
     return false;
   }
 
@@ -328,7 +340,7 @@ bool DiskCache::Remove(const std::string& key, uint64_t& removed_data_size) {
 std::unique_ptr<leveldb::Iterator> DiskCache::NewIterator(
     leveldb::ReadOptions options) {
   if (!database_) {
-    OLP_SDK_LOG_ERROR(kLogTag, "NewIterator: Database is uninitialized");
+    OLP_SDK_LOG_ERROR(kLogTag, "NewIterator: Database is not initialized");
     return nullptr;
   }
   return std::unique_ptr<leveldb::Iterator>(database_->NewIterator(options));
@@ -337,19 +349,37 @@ std::unique_ptr<leveldb::Iterator> DiskCache::NewIterator(
 DiskCache::OperationOutcome DiskCache::ApplyBatch(
     std::unique_ptr<leveldb::WriteBatch> batch) {
   if (!database_) {
-    OLP_SDK_LOG_ERROR(kLogTag, "ApplyBatch: Database is uninitialized");
+    OLP_SDK_LOG_ERROR(kLogTag, "ApplyBatch: Database is not initialized");
     return client::ApiError(client::ErrorCode::PreconditionFailed,
                             "Database is not initialized");
   }
+
   if (!batch) {
-    OLP_SDK_LOG_ERROR(kLogTag, "ApplyBatch: failed, batch is null");
+    OLP_SDK_LOG_WARNING(kLogTag, "ApplyBatch: Batch is null");
     return client::ApiError(client::ErrorCode::PreconditionFailed,
                             "Batch can't be null");
   }
+
+  if (max_size_ != kSizeMax && environment_ &&
+      environment_->Size() >= max_size_) {
+    if (!compacting_.exchange(true)) {
+      if (compaction_thread_.joinable()) {
+        compaction_thread_.join();
+      }
+
+      compaction_thread_ = std::thread([this]() {
+        OLP_SDK_LOG_INFO(kLogTag, "Compacting database started");
+        database_->CompactRange(nullptr, nullptr);
+        compacting_ = false;
+        OLP_SDK_LOG_INFO(kLogTag, "Compacting database finished");
+      });
+    }
+  }
+
   const auto status = database_->Write(leveldb::WriteOptions(), batch.get());
   if (!status.ok()) {
-    OLP_SDK_LOG_ERROR(kLogTag,
-                      "ApplyBatch: failed, status=" << status.ToString());
+    OLP_SDK_LOG_WARNING(kLogTag,
+                        "ApplyBatch: failed, status=" << status.ToString());
     return GetApiError(status);
   }
   return NoError{};

--- a/olp-cpp-sdk-core/src/cache/DiskCache.h
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.h
@@ -136,6 +136,7 @@ class DiskCache {
  private:
   std::string disk_cache_path_;
   std::unique_ptr<leveldb::DB> database_;
+  std::unique_ptr<const leveldb::FilterPolicy> filter_policy_;
   std::unique_ptr<DiskCacheSizeLimitEnv> environment_;
   std::unique_ptr<LevelDBLogger> leveldb_logger_;
   uint64_t max_size_{kSizeMax};

--- a/olp-cpp-sdk-core/src/client/OlpClient.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClient.cpp
@@ -133,6 +133,8 @@ http::NetworkRequest::HttpVerb GetHttpVerb(const std::string& verb) {
     return http::NetworkRequest::HttpVerb::POST;
   } else if (verb.compare("DELETE") == 0) {
     return http::NetworkRequest::HttpVerb::DEL;
+  } else if (verb.compare("OPTIONS") == 0) {
+    return http::NetworkRequest::HttpVerb::OPTIONS;
   }
 
   return http::NetworkRequest::HttpVerb::GET;

--- a/olp-cpp-sdk-core/src/http/android/HttpClient.java
+++ b/olp-cpp-sdk-core/src/http/android/HttpClient.java
@@ -66,7 +66,8 @@ public class HttpClient {
     HEAD,
     PUT,
     DELETE,
-    PATCH
+    PATCH,
+    OPTIONS
   };
 
   public static HttpVerb toHttpVerb(int verb) {
@@ -83,6 +84,8 @@ public class HttpClient {
         return HttpVerb.DELETE;
       case 5:
         return HttpVerb.PATCH;
+      case 6:
+        return HttpVerb.OPTIONS;
       default:
         return HttpVerb.GET;
     }
@@ -270,6 +273,9 @@ public class HttpClient {
                   break;
                 case PATCH:
                   httpConn.setRequestMethod("PATCH");
+                  break;
+                case OPTIONS:
+                  httpConn.setRequestMethod("OPTIONS");
                   break;
                 default:
                   httpConn.setRequestMethod("GET");

--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
@@ -493,6 +493,8 @@ ErrorCode NetworkCurl::SendImplementation(
     }
   } else if (verb == NetworkRequest::HttpVerb::DEL) {
     curl_easy_setopt(handle->handle, CURLOPT_CUSTOMREQUEST, "DELETE");
+  } else if (verb == NetworkRequest::HttpVerb::OPTIONS) {
+    curl_easy_setopt(handle->handle, CURLOPT_CUSTOMREQUEST, "OPTIONS");
   } else {  // GET or HEAD
     curl_easy_setopt(handle->handle, CURLOPT_POST, 0L);
 

--- a/olp-cpp-sdk-core/src/http/ios/OLPNetworkConstants.h
+++ b/olp-cpp-sdk-core/src/http/ios/OLPNetworkConstants.h
@@ -27,3 +27,4 @@ FOUNDATION_EXPORT NSString* const OLPHttpMethodHead;
 FOUNDATION_EXPORT NSString* const OLPHttpMethodPut;
 FOUNDATION_EXPORT NSString* const OLPHttpMethodDelete;
 FOUNDATION_EXPORT NSString* const OLPHttpMethodPatch;
+FOUNDATION_EXPORT NSString* const OLPHttpMethodOptions;

--- a/olp-cpp-sdk-core/src/http/ios/OLPNetworkConstants.mm
+++ b/olp-cpp-sdk-core/src/http/ios/OLPNetworkConstants.mm
@@ -25,3 +25,4 @@ NSString* const OLPHttpMethodHead = @"HEAD";
 NSString* const OLPHttpMethodPut = @"PUT";
 NSString* const OLPHttpMethodDelete = @"DELETE";
 NSString* const OLPHttpMethodPatch = @"PATCH";
+NSString* const OLPHttpMethodOptions = @"OPTIONS";

--- a/olp-cpp-sdk-core/src/http/ios/OLPNetworkIOS.mm
+++ b/olp-cpp-sdk-core/src/http/ios/OLPNetworkIOS.mm
@@ -82,6 +82,8 @@ NSString* ParseHttpMethodFromRequest(const olp::http::NetworkRequest& request) {
       return OLPHttpMethodPatch;
     case NetworkRequest::HttpVerb::HEAD:
       return OLPHttpMethodHead;
+    case NetworkRequest::HttpVerb::OPTIONS:
+      return OLPHttpMethodOptions;
     default:
       return nil;
   }

--- a/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
+++ b/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
@@ -168,23 +168,22 @@ bool ConvertMultiByteToWideChar(const std::string& in, std::wstring& out) {
 }
 
 std::wstring ProxyString(const olp::http::NetworkProxySettings& proxy) {
-  using namespace olp::http;
   std::wostringstream proxy_string_stream;
 
   switch (proxy.GetType()) {
-    case NetworkProxySettings::Type::NONE:
+    case olp::http::NetworkProxySettings::Type::NONE:
       proxy_string_stream << "http://";
       break;
-    case NetworkProxySettings::Type::SOCKS4:
+    case olp::http::NetworkProxySettings::Type::SOCKS4:
       proxy_string_stream << "socks4://";
       break;
-    case NetworkProxySettings::Type::SOCKS5:
+    case olp::http::NetworkProxySettings::Type::SOCKS5:
       proxy_string_stream << "socks5://";
       break;
-    case NetworkProxySettings::Type::SOCKS4A:
+    case olp::http::NetworkProxySettings::Type::SOCKS4A:
       proxy_string_stream << "socks4a://";
       break;
-    case NetworkProxySettings::Type::SOCKS5_HOSTNAME:
+    case olp::http::NetworkProxySettings::Type::SOCKS5_HOSTNAME:
       proxy_string_stream << "socks5h://";
       break;
     default:
@@ -416,6 +415,8 @@ SendOutcome NetworkWinHttp::Send(NetworkRequest request,
     http_verb = L"DELETE";
   } else if (request_verb == NetworkRequest::HttpVerb::PATCH) {
     http_verb = L"PATCH";
+  } else if (request_verb == NetworkRequest::HttpVerb::OPTIONS) {
+    http_verb = L"OPTIONS";
   }
 
   LPCSTR content = WINHTTP_NO_REQUEST_DATA;


### PR DESCRIPTION
When eviction happens, first we remove all expired elements, and only
then we remove other elements if still needed.
Change the internal LRU representation, so that we have fast access to
key expiration. Saves extra cache lookup during eviction.
Fix the use case when protected cache contains expired data.

Relates-To: OLPEDGE-1925

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>