### PR TITLE
Remove unnecessary allocations in HRN lookup

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
@@ -41,17 +41,21 @@ namespace read {
 namespace {
 constexpr auto kLogTag = "ApiClientLookupRead";
 
-std::string GetDatastoreServerUrl(const std::string& partition) {
-  static const std::map<std::string, std::string> kDatastoreServerUrl = {
+const char* GetDatastoreServerUrl(const std::string& partition) {
+  constexpr struct {
+    const char* partition;
+    const char* url;
+  } kDatastoreServerUrls[] = {
       {"here", "data.api.platform.here.com"},
       {"here-dev", "data.api.platform.in.here.com"},
       {"here-cn", "data.api.platform.hereolp.cn"},
       {"here-cn-dev", "data.api.platform.in.hereolp.cn"}};
 
-  const auto& server_url = kDatastoreServerUrl.find(partition);
-  return (server_url != kDatastoreServerUrl.end())
-             ? "https://api-lookup." + server_url->second + "/lookup/v1"
-             : "";
+  for (const auto& server : kDatastoreServerUrls) {
+    if (server.partition == partition)
+      return server.url;
+  }
+  return "";
 }
 }  // namespace
 


### PR DESCRIPTION
Remove dozens of needless mallocs and also remove the unneeded static
global object, removing the auto-generated memory barrier.

Since all the data we have is static, use a POD. Also, with only 4
items, a linear search is superior.

Signed-off-by: Harald Fernengel <harald.fernengel@here.com>