### PR TITLE
Remove expired elements during cache eviction

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/CacheSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/CacheSettings.h
@@ -82,7 +82,11 @@ struct CORE_API CacheSettings {
    * @brief Sets the upper limit of the runtime memory (in bytes) before it is
    * written to the disk.
    *
-   * The default value is 32 MB.
+   * Larger values increase performance, especially during bulk loads.
+   * Up to two write buffers may be held in memory at the same time,
+   * so you may wish to adjust this parameter to control memory usage.
+   * Also, a larger write buffer will result in a longer recovery time
+   * the next time the database is opened. The default value is 32 MB.
    */
   size_t max_chunk_size = 1024u * 1024u * 32u;
 

--- a/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
@@ -53,7 +53,9 @@ class DefaultCacheImpl;
  */
 class CORE_API DefaultCache : public KeyValueCache {
  public:
-  /*! The storage open result type */
+  /**
+   * @brief The storage open result type
+   */
   enum StorageOpenResult {
     Success,            /*!< The operation succeeded. */
     OpenDiskPathFailure /*!< The disk cache failure. */
@@ -86,6 +88,23 @@ class CORE_API DefaultCache : public KeyValueCache {
    * @return True if the operation is successful; false otherwise.
    */
   bool Clear();
+
+  /**
+   * @brief Compacts the underlying mutable cache storage.
+   *
+   * In particular, deleted and overwritten versions are discarded, and the data
+   * is rearranged to reduce the cost of operations needed to access the data.
+   * In some cases this operation might take a very long time, so use with care.
+   * You generally don't have to call this, but it can be useful to optimize
+   * preloaded databases or compact before you shut down the system to ensure
+   * quick startup time.
+   *
+   * @note This operation is blocking and under mutex lock blocking any other
+   * operation in parallel for the time of the compacting operation. Be aware
+   * that automatic asynchronous compacting operation is triggered internally
+   * once the database size exceeds the CacheSettings::max_disk_storage size.
+   */
+  void Compact();
 
   /**
    * @brief Stores the key-value pair in the cache.

--- a/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
@@ -17,11 +17,9 @@
  * License-Filename: LICENSE
  */
 
-#include "olp/core/porting/warning_disable.h"
-
 #include "olp/core/cache/DefaultCache.h"
-
 #include "DefaultCacheImpl.h"
+#include "olp/core/porting/warning_disable.h"
 
 namespace olp {
 namespace cache {
@@ -36,6 +34,8 @@ DefaultCache::StorageOpenResult DefaultCache::Open() { return impl_->Open(); }
 void DefaultCache::Close() { impl_->Close(); }
 
 bool DefaultCache::Clear() { return impl_->Clear(); }
+
+void DefaultCache::Compact() { return impl_->Compact(); }
 
 bool DefaultCache::Put(const std::string& key, const boost::any& value,
                        const Encoder& encoder, time_t expiry) {

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -45,8 +45,7 @@ std::string CreateExpiryKey(const std::string& key) {
 }
 
 bool IsExpiryKey(const std::string& key) {
-  auto pos = key.rfind(kExpirySuffix);
-  return pos == 0;
+  return key.rfind(kExpirySuffix) != std::string::npos;
 }
 
 bool IsExpiryValid(time_t expiry) {
@@ -81,8 +80,7 @@ void PurgeDiskItem(const std::string& key, olp::cache::DiskCache& disk_cache,
 size_t StoreExpiry(const std::string& key, leveldb::WriteBatch& batch,
                    time_t expiry) {
   auto expiry_key = CreateExpiryKey(key);
-  auto time_str = std::to_string(
-      expiry + olp::cache::InMemoryCache::DefaultTimeProvider()());
+  auto time_str = std::to_string(expiry);
   batch.Put(expiry_key, time_str);
 
   return expiry_key.size() + time_str.size();
@@ -314,13 +312,36 @@ void DefaultCacheImpl::InitializeLru() {
   auto count = 0u;
   auto it = mutable_cache_->NewIterator(leveldb::ReadOptions());
   for (it->SeekToFirst(); it->Valid(); it->Next()) {
-    const auto key = it->key().ToString();
+    auto key = it->key().ToString();
     const auto& value = it->value();
+
+    // Here we count both expiry keys and regular keys
     mutable_cache_data_size_ += key.size() + value.size();
 
-    if (mutable_cache_lru_ && !IsExpiryKey(key)) {
-      ++count;
-      mutable_cache_lru_->Insert(key, value.size());
+    if (mutable_cache_lru_) {
+      // remove the prefix to restore original key
+      const bool expiration_key = IsExpiryKey(key);
+      if (expiration_key) {
+        key.resize(key.size() - kExpirySuffixLength);
+      }
+
+      ValueProperties props;
+
+      auto iterator = mutable_cache_lru_->FindNoPromote(key);
+      if (iterator != mutable_cache_lru_->end()) {
+        props = iterator->value();
+      }
+
+      if (expiration_key) {
+        props.expiry = std::stol(value.data());
+      } else {
+        props.size = value.size();
+      }
+
+      auto result = mutable_cache_lru_->InsertOrAssign(key, props);
+      if (result.second) {
+        ++count;
+      }
     }
   }
 
@@ -379,24 +400,63 @@ uint64_t DefaultCacheImpl::MaybeEvictData(leveldb::WriteBatch& batch) {
   int64_t evicted = 0u;
   auto count = 0u;
   const auto min_size = kMinDiskUsedThreshold * settings_.max_disk_storage;
+
+  const auto current_time = olp::cache::InMemoryCache::DefaultTimeProvider()();
+
+  // Remove the expired elements first
+  for (auto it = mutable_cache_lru_->begin();
+       it != mutable_cache_lru_->end() &&
+       mutable_cache_data_size_ - evicted > min_size;) {
+    const auto& key = it->key();
+    const auto& properties = it->value();
+
+    const bool expired = (properties.expiry - current_time) <= 0;
+
+    if (!expired) {
+      ++it;
+      continue;
+    }
+
+    // Remove the key
+    batch.Delete(key);
+    evicted += key.size() + properties.size;
+
+    // Remove the key's expiry
+    auto expiry_key = CreateExpiryKey(key);
+    batch.Delete(expiry_key);
+    evicted += expiry_key.size() + kExpiryValueSize;
+
+    ++count;
+
+    if (memory_cache_) {
+      memory_cache_->Remove(key);
+    }
+
+    it = mutable_cache_lru_->Erase(it);
+  }
+
+  // Remove the other elements if needed
   for (auto it = mutable_cache_lru_->rbegin();
        it != mutable_cache_lru_->rend() &&
        mutable_cache_data_size_ - evicted > min_size;) {
     const auto& key = it->key();
-    const auto expiry_key = CreateExpiryKey(key);
-    auto expiry_value = mutable_cache_->Get(expiry_key);
-    if (expiry_value) {
+    const auto& properties = it->value();
+
+    evicted += key.size() + properties.size;
+    batch.Delete(key);
+
+    if (IsExpiryValid(properties.expiry)) {
+      const auto expiry_key = CreateExpiryKey(key);
       evicted += expiry_key.size() + kExpiryValueSize;
       batch.Delete(expiry_key);
     }
-    evicted += key.size() + it->value();
+
     ++count;
 
     if (memory_cache_) {
       memory_cache_->Remove(it->key());
     }
 
-    batch.Delete(key);
     mutable_cache_lru_->Erase(it);
     it = mutable_cache_lru_->rbegin();
   }
@@ -434,6 +494,7 @@ bool DefaultCacheImpl::PutMutableCache(const std::string& key,
   added_data_size += key.size() + item_size;
 
   if (IsExpiryValid(expiry)) {
+    expiry += olp::cache::InMemoryCache::DefaultTimeProvider()();
     added_data_size += StoreExpiry(key, *batch, expiry);
   }
 
@@ -447,7 +508,10 @@ bool DefaultCacheImpl::PutMutableCache(const std::string& key,
   mutable_cache_data_size_ -= removed_data_size;
 
   if (mutable_cache_lru_) {
-    const auto result = mutable_cache_lru_->InsertOrAssign(key, item_size);
+    ValueProperties props;
+    props.size = item_size;
+    props.expiry = expiry;
+    const auto result = mutable_cache_lru_->InsertOrAssign(key, props);
     if (result.first == mutable_cache_lru_->end() && !result.second) {
       OLP_SDK_LOG_WARNING_F(
           kLogTag, "Failed to store value in mutable LRU cache, key %s",
@@ -527,7 +591,10 @@ bool DefaultCacheImpl::GetFromDiskCache(const std::string& key,
     auto result = protected_cache_->Get(key, value);
     if (result && value && !value->empty()) {
       expiry = GetRemainingExpiryTime(key, *protected_cache_);
-      return expiry > 0;
+      if (expiry > 0) {
+        return true;
+      }
+      value = nullptr;
     }
   }
 
@@ -543,7 +610,7 @@ bool DefaultCacheImpl::GetFromDiskCache(const std::string& key,
       }
 
       auto result = mutable_cache_->Get(key, value);
-      return result && value && expiry > 0;
+      return result && value;
     }
 
     // Data expired in cache -> remove

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
@@ -56,9 +56,15 @@ class DefaultCacheImpl {
   bool RemoveKeysWithPrefix(const std::string& key);
 
  protected:
-  /// Alias for the LRU cache using the leveldb keys as key and the value size
+  /// The LRU value property.
+  struct ValueProperties {
+    size_t size{0ull};
+    time_t expiry{KeyValueCache::kDefaultExpiry};
+  };
+
+  /// The LRU cache definition using the leveldb keys as key and the value size
   /// as value.
-  using DiskLruCache = utils::LruCache<std::string, size_t>;
+  using DiskLruCache = utils::LruCache<std::string, ValueProperties>;
 
   /// Returns LRU mutable cache, used for tests.
   const std::unique_ptr<DiskLruCache>& GetMutableCacheLru() const {

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
@@ -41,6 +41,8 @@ class DefaultCacheImpl {
 
   bool Clear();
 
+  void Compact();
+
   bool Put(const std::string& key, const KeyValueCache::ValueTypePtr value,
            time_t expiry);
 


### PR DESCRIPTION
When eviction happens, first we remove all expired elements, and only
then we remove other elements if still needed.
Change the internal LRU representation, so that we have fast access to
key expiration. Saves extra cache lookup during eviction.
Fix the use case when protected cache contains expired data.
    
Relates-To: OLPEDGE-1925

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>
