### PR TITLE
Add prewarm helper to OlpClientSettingsFactory.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettingsFactory.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettingsFactory.h
@@ -19,10 +19,10 @@
 
 #pragma once
 
+#include <memory>
+
 #include <olp/core/CoreApi.h>
 #include <olp/core/thread/TaskScheduler.h>
-
-#include <memory>
 
 namespace olp {
 namespace cache {
@@ -35,6 +35,8 @@ class Network;
 }  // namespace http
 
 namespace client {
+struct OlpClientSettings;
+
 /**
  * @brief Fills in the `OlpClientSettings` structure with
  * default handlers.
@@ -90,6 +92,21 @@ class CORE_API OlpClientSettingsFactory final {
    */
   static std::unique_ptr<cache::KeyValueCache> CreateDefaultCache(
       cache::CacheSettings settings);
+
+  /**
+   * @brief This function helps you prewarm the connection to the
+   * provided host.
+   *
+   * Prewarming includes DNS prefetch and TLS preconnect issued with the
+   * OPTIONS http call without any data up or download and is performed
+   * asynchronously.
+   *
+   * @note This only makes sense on platforms which actually keep TCP
+   * sockets and connections alive for some time and only if you have
+   * max_request_count set to something greater then 1 to allow reusing.
+   */
+  static void PrewarmConnection(const OlpClientSettings& settings,
+                                const std::string& url);
 };
 
 }  // namespace client

--- a/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
@@ -21,15 +21,19 @@
 
 #include "olp/core/cache/CacheSettings.h"
 #include "olp/core/cache/DefaultCache.h"
+#include "olp/core/client/OlpClientSettings.h"
 #include "olp/core/http/Network.h"
+#include "olp/core/http/NetworkConstants.h"
 #include "olp/core/logging/Log.h"
 #include "olp/core/porting/make_unique.h"
 #include "olp/core/thread/ThreadPoolTaskScheduler.h"
 
+namespace {
+auto constexpr kLogTag = "OlpClientSettingsFactory";
+}
+
 namespace olp {
 namespace client {
-
-auto constexpr kLogTag = "OlpClientSettingsFactory";
 
 std::unique_ptr<thread::TaskScheduler>
 OlpClientSettingsFactory::CreateDefaultTaskScheduler(size_t thread_count) {
@@ -56,6 +60,45 @@ OlpClientSettingsFactory::CreateDefaultCache(cache::CacheSettings settings) {
     return nullptr;
   }
   return cache;
+}
+
+void OlpClientSettingsFactory::PrewarmConnection(
+    const OlpClientSettings& settings, const std::string& url) {
+  if (url.empty() || !settings.network_request_handler) {
+    OLP_SDK_LOG_WARNING_F(kLogTag, "PrewarmConnection: invalid input, url='%s'",
+                          url.c_str());
+    return;
+  }
+
+  const auto& retry_settings = settings.retry_settings;
+  auto request_settings =
+      http::NetworkSettings()
+          .WithTransferTimeout(retry_settings.timeout)
+          .WithConnectionTimeout(retry_settings.timeout)
+          .WithProxySettings(
+              settings.proxy_settings.value_or(http::NetworkProxySettings()));
+
+  auto request =
+      http::NetworkRequest(url)
+          .WithVerb(http::NetworkRequest::HttpVerb::OPTIONS)
+          .WithBody(nullptr)
+          .WithSettings(std::move(request_settings))
+          .WithHeader(http::kUserAgentHeader, http::kOlpSdkUserAgent);
+
+  auto outcome = settings.network_request_handler->Send(
+      request, nullptr, [url](http::NetworkResponse response) {
+        OLP_SDK_LOG_INFO_F(
+            kLogTag,
+            "PrewarmConnection: completed for url='%s', status='%d %s'",
+            url.c_str(), response.GetStatus(), response.GetError().c_str());
+      });
+
+  if (!outcome.IsSuccessful()) {
+    OLP_SDK_LOG_WARNING_F(
+        kLogTag,
+        "PrewarmConnection: sending OPTIONS failed, url='%s', error='%s'",
+        url.c_str(), ErrorCodeToString(outcome.GetErrorCode()).c_str());
+  }
 }
 
 }  // namespace client

--- a/olp-cpp-sdk-core/src/http/Network.cpp
+++ b/olp-cpp-sdk-core/src/http/Network.cpp
@@ -60,8 +60,7 @@ Network::Statistics Network::GetStatistics(uint8_t /*bucket_id*/) {
   return Network::Statistics{};
 }
 
-CORE_API std::shared_ptr<Network> CreateDefaultNetwork(
-    size_t max_requests_count) {
+std::shared_ptr<Network> CreateDefaultNetwork(size_t max_requests_count) {
   auto network = CreateDefaultNetworkImpl(max_requests_count);
   if (network) {
     return std::make_shared<DefaultNetwork>(network);


### PR DESCRIPTION
The prewarm helper should be used to prewarm the connection
to certain hosts like authentication and lookup API URLs
so that DNS prefetch and TLS preconnect are already done
and keept alive by the Network layer. This will reduce the
subsequent requests latency in the order of 100-200ms.

Relates-To: OLPEDGE-1995

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>