### PR TITLE
Put/Get QuadTreeIndex into cache.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
@@ -26,6 +26,7 @@
 #include <olp/dataservice/read/PartitionsRequest.h>
 #include <olp/dataservice/read/model/Partitions.h>
 #include <boost/optional.hpp>
+#include "QuadTreeIndex.h"
 #include "generated/model/LayerVersions.h"
 
 namespace olp {
@@ -58,6 +59,13 @@ class PartitionsCacheRepository final {
   void Put(int64_t catalogVersion, const model::LayerVersions& layerVersions);
 
   boost::optional<model::LayerVersions> Get(int64_t catalogVersion);
+
+  void Put(const std::string& layer, geo::TileKey key, int32_t depth,
+           const QuadTreeIndex& quad_tree,
+           const boost::optional<int64_t>& version);
+
+  QuadTreeIndex Get(const std::string& layer, geo::TileKey key, int32_t depth,
+                    const boost::optional<int64_t>& version);
 
   void Clear(const std::string& layer_id);
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.cpp
@@ -81,6 +81,7 @@ QuadTreeIndex::QuadTreeIndex(cache::KeyValueCache::ValueTypePtr data) {
     return;
   }
   data_ = reinterpret_cast<DataHeader*>(data->data());
+  raw_data_ = data;
   size_ = data->size();
 }
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.h
@@ -65,7 +65,9 @@ class QuadTreeIndex {
   boost::optional<IndexData> Find(const olp::geo::TileKey& tileKey,
                                   bool aggregated) const;
 
-  inline cache::KeyValueCache::ValueTypePtr GetRawData() { return raw_data_; }
+  inline const cache::KeyValueCache::ValueTypePtr GetRawData() const {
+    return raw_data_;
+  }
 
  private:
   struct SubEntry {

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsCacheRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsCacheRepositoryTest.cpp
@@ -20,24 +20,30 @@
 #include "repositories/PartitionsCacheRepository.h"
 
 #include <gmock/gmock.h>
+#include <mocks/CacheMock.h>
 #include <olp/core/cache/CacheSettings.h>
 #include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
 
 namespace {
-
-using namespace olp;
-using namespace olp::dataservice::read;
+namespace read = olp::dataservice::read;
+namespace model = olp::dataservice::read::model;
+namespace repository = olp::dataservice::read::repository;
+using olp::cache::KeyValueCache;
+using olp::client::HRN;
+using olp::tests::common::CacheMock;
 
 constexpr auto kCatalog = "hrn:here:data::olp-here-test:catalog";
 constexpr auto kPartitionId = "1111";
+constexpr auto kQuadkeyResponse =
+    R"jsonString({"subQuads": [{"subQuadKey": "4","version":282,"dataHandle":"7636348E50215979A39B5F3A429EDDB4.282","dataSize":277},{"subQuadKey":"5","version":282,"dataHandle":"8C9B3E08E294ADB2CD07EBC8412062FE.282","dataSize":271},{"subQuadKey": "6","version":282,"dataHandle":"9772F5E1822DFF25F48F150294B1ECF5.282","dataSize":289},{"subQuadKey":"7","version":282,"dataHandle":"BF84D8EC8124B96DBE5C4DB68B05918F.282","dataSize":283},{"subQuadKey":"1","version":48,"dataHandle":"BD53A6D60A34C20DC42ACAB2650FE361.48","dataSize":89}],"parentQuads":[{"partition":"23","version":282,"dataHandle":"F8F4C3CB09FBA61B927256CBCB8441D1.282","dataSize":52438},{"partition":"5","version":282,"dataHandle":"13E2C624E0136C3357D092EE7F231E87.282","dataSize":99151},{"partition":"95","version":253,"dataHandle":"B6F7614316BB8B81478ED7AE370B22A6.253","dataSize":6765}]})jsonString";
 
 TEST(PartitionsCacheRepositoryTest, DefaultExpiry) {
-  const auto hrn = client::HRN::FromString(kCatalog);
+  const auto hrn = HRN::FromString(kCatalog);
   const auto layer = "layer";
   const auto catalog_version = 0;
 
-  const auto request = PartitionsRequest();
+  const auto request = read::PartitionsRequest();
   model::Partition some_partition;
   some_partition.SetPartition(kPartitionId);
   model::Partitions partitions;
@@ -54,7 +60,7 @@ TEST(PartitionsCacheRepositoryTest, DefaultExpiry) {
     SCOPED_TRACE("Disable expiration");
 
     const auto default_expiry = std::chrono::seconds::max();
-    std::shared_ptr<cache::KeyValueCache> cache =
+    std::shared_ptr<KeyValueCache> cache =
         olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
     repository::PartitionsCacheRepository repository(hrn, cache,
                                                      default_expiry);
@@ -75,7 +81,7 @@ TEST(PartitionsCacheRepositoryTest, DefaultExpiry) {
     SCOPED_TRACE("Expired");
 
     const auto default_expiry = std::chrono::seconds(-1);
-    std::shared_ptr<cache::KeyValueCache> cache =
+    std::shared_ptr<KeyValueCache> cache =
         olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
     repository::PartitionsCacheRepository repository(hrn, cache,
                                                      default_expiry);
@@ -98,7 +104,7 @@ TEST(PartitionsCacheRepositoryTest, DefaultExpiry) {
 
     const auto default_expiry = std::chrono::seconds(-1);
     const auto data_expiry = std::numeric_limits<time_t>::max();
-    std::shared_ptr<cache::KeyValueCache> cache =
+    std::shared_ptr<KeyValueCache> cache =
         olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
     repository::PartitionsCacheRepository repository(hrn, cache,
                                                      default_expiry);
@@ -117,7 +123,7 @@ TEST(PartitionsCacheRepositoryTest, DefaultExpiry) {
 
     const auto default_expiry = std::chrono::seconds::max();
     const auto data_expiry = time_t(-1);
-    std::shared_ptr<cache::KeyValueCache> cache =
+    std::shared_ptr<KeyValueCache> cache =
         olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
     repository::PartitionsCacheRepository repository(hrn, cache,
                                                      default_expiry);
@@ -129,6 +135,54 @@ TEST(PartitionsCacheRepositoryTest, DefaultExpiry) {
 
     EXPECT_TRUE(partitions_result.GetPartitions().empty());
     EXPECT_FALSE(optional_result);
+  }
+}
+
+TEST(PartitionsCacheRepositoryTest, QuadTree) {
+  using testing::_;
+  using testing::Return;
+  using testing::SaveArg;
+
+  const auto hrn = HRN::FromString(kCatalog);
+  const auto layer = "layer";
+  const auto version = 0;
+  const auto tile_key = olp::geo::TileKey::FromHereTile("23618364");
+  const auto depth = 2;
+
+  {
+    SCOPED_TRACE("Put/Get quad tree");
+
+    auto stream = std::stringstream(kQuadkeyResponse);
+    read::QuadTreeIndex quad_tree(tile_key, depth, stream);
+    auto cache = std::make_shared<CacheMock>();
+    repository::PartitionsCacheRepository repository(hrn, cache);
+    std::string key;
+
+    EXPECT_CALL(*cache, Put(_, _, _))
+        .WillOnce(DoAll(SaveArg<0>(&key), Return(true)));
+    repository.Put(layer, tile_key, depth, quad_tree, version);
+
+    // mocking after Put call, so the `key` is already known
+    EXPECT_CALL(*cache, Get(key)).WillOnce(Return(quad_tree.GetRawData()));
+    const auto result = repository.Get(layer, tile_key, depth, version);
+
+    ASSERT_FALSE(result.IsNull());
+    ASSERT_EQ(*result.GetRawData(), *quad_tree.GetRawData());
+  }
+
+  {
+    SCOPED_TRACE("Empty quad tree");
+
+    read::QuadTreeIndex quad_tree;
+    auto cache = std::make_shared<CacheMock>();
+    repository::PartitionsCacheRepository repository(hrn, cache);
+
+    EXPECT_CALL(*cache, Get(_)).WillOnce(Return(KeyValueCache::ValueTypePtr()));
+
+    repository.Put(layer, tile_key, depth, quad_tree, version);
+    const auto result = repository.Get(layer, tile_key, depth, version);
+
+    ASSERT_TRUE(result.IsNull());
   }
 }
 


### PR DESCRIPTION
This is a part of GetAggregatedData API update. The method will cache
QuadTreeIndex.

Resolves: OLPEDGE-1932

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>