### PR TITLE
Switch SignInClient code to task

### DIFF
--- a/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
@@ -452,6 +452,20 @@ AuthenticationClient::Impl::~Impl() { pending_requests_->CancelAllAndWait(); }
 client::CancellationToken AuthenticationClient::Impl::SignInClient(
     AuthenticationCredentials credentials, SignInProperties properties,
     AuthenticationClient::SignInClientCallback callback) {
+  auto create_olp_client =
+      [](const AuthenticationSettings& auth_settings) -> client::OlpClient {
+    client::OlpClientSettings settings;
+    settings.network_request_handler = auth_settings.network_request_handler;
+    settings.proxy_settings = auth_settings.network_proxy_settings;
+    settings.retry_settings.backdown_strategy =
+        olp::client::ExponentialBackdownStrategy();
+
+    client::OlpClient client;
+    client.SetBaseUrl(auth_settings.token_endpoint_url);
+    client.SetSettings(std::move(settings));
+    return client;
+  };
+
   auto sign_in_task =
       [=](client::CancellationContext context) -> SignInClientResponse {
     if (!settings_.network_request_handler) {
@@ -459,15 +473,7 @@ client::CancellationToken AuthenticationClient::Impl::SignInClient(
                "Cannot sign in while offline"}};
     }
 
-    client::OlpClientSettings settings;
-    settings.network_request_handler = settings_.network_request_handler;
-    settings.proxy_settings = settings_.network_proxy_settings;
-    settings.retry_settings.backdown_strategy =
-        olp::client::ExponentialBackdownStrategy();
-
-    client::OlpClient client;
-    client.SetBaseUrl(settings_.token_endpoint_url);
-    client.SetSettings(std::move(settings));
+    client::OlpClient client = create_olp_client(settings_);
 
     std::time_t timestamp =
         std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());

--- a/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
@@ -455,7 +455,7 @@ client::CancellationToken AuthenticationClient::Impl::SignInClient(
       [=](client::CancellationContext context) -> SignInClientResponse {
     if (!settings_.network_request_handler) {
       return {{static_cast<int>(http::ErrorCode::IO_ERROR),
-               "Cannot introspect app while offline"}};
+               "Cannot sign in while offline"}};
     }
 
     client::OlpClientSettings settings;

--- a/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
@@ -392,7 +392,7 @@ class AuthenticationClient::Impl final {
                                       AuthorizeCallback callback);
 
  private:
-  using TimeResponse = client::ApiResponse<time_t, AuthenticationError>;
+  using TimeResponse = client::ApiResponse<time_t, client::ApiError>;
   using TimeCallback = std::function<void(TimeResponse)>;
 
   TimeResponse GetTimeFromServer(client::CancellationContext context,

--- a/olp-cpp-sdk-core/include/olp/core/client/TaskContext.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/TaskContext.h
@@ -122,8 +122,7 @@ class CORE_API TaskContext {
    */
   void SetExecutors(Exec execute_func, Callback callback,
                     client::CancellationContext context) {
-    impl_ = std::make_shared<TaskContextImpl<typename ExecResult::ResultType,
-                                             typename ExecResult::ErrorType>>(
+    impl_ = std::make_shared<TaskContextImpl<typename ExecResult::ResultType>>(
         std::move(execute_func), std::move(callback), std::move(context));
   }
 
@@ -168,11 +167,11 @@ class CORE_API TaskContext {
    *
    * @tparam T The result type.
    */
-  template <typename T, typename ErrorType = client::ApiError>
+  template <typename T>
   class TaskContextImpl : public Impl {
    public:
     /// Wraps the `T` typename in the API response.
-    using Response = client::ApiResponse<T, ErrorType>;
+    using Response = client::ApiResponse<T, client::ApiError>;
     /// The task that produces the `Response` instance.
     using ExecuteFunc = std::function<Response(client::CancellationContext)>;
     /// Consumes the `Response` instance.
@@ -218,7 +217,7 @@ class CORE_API TaskContext {
       }
 
       Response user_response =
-          ErrorType(client::ErrorCode::Cancelled, "Cancelled");
+          client::ApiError(client::ErrorCode::Cancelled, "Cancelled");
 
       if (function && !context_.IsCancelled()) {
         auto response = function(context_);

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -223,6 +223,8 @@ TEST_F(AuthenticationClientTest, SignInClient) {
   AuthenticationClient::SignInClientResponse response =
       SignInClient(credentials, now, kExpiryTime);
   EXPECT_EQ(olp::http::HttpStatusCode::OK, response.GetResult().GetStatus());
+  EXPECT_STREQ(kErrorOk.c_str(),
+               response.GetResult().GetErrorResponse().message.c_str());
   EXPECT_FALSE(response.GetResult().GetAccessToken().empty());
   EXPECT_GE(now + kMaxExpiry, response.GetResult().GetExpiryTime());
   EXPECT_LT(now + kMinExpiry, response.GetResult().GetExpiryTime());
@@ -261,6 +263,8 @@ TEST_F(AuthenticationClientTest, SignInClientMaxExpiration) {
   AuthenticationClient::SignInClientResponse response =
       SignInClient(credentials, now);
   EXPECT_EQ(olp::http::HttpStatusCode::OK, response.GetResult().GetStatus());
+  EXPECT_STREQ(kErrorOk.c_str(),
+               response.GetResult().GetErrorResponse().message.c_str());
   EXPECT_FALSE(response.GetResult().GetAccessToken().empty());
   EXPECT_GE(now + kMaxLimitExpiry, response.GetResult().GetExpiryTime());
   EXPECT_LT(now + kMinLimitExpiry, response.GetResult().GetExpiryTime());
@@ -351,6 +355,8 @@ TEST_F(AuthenticationClientTest, SignUpInUser) {
 
   AuthenticationClient::SignInUserResponse response3 = SignInUser(email);
   EXPECT_EQ(olp::http::HttpStatusCode::OK, response3.GetResult().GetStatus());
+  EXPECT_STREQ(kErrorOk.c_str(),
+               response3.GetResult().GetErrorResponse().message.c_str());
   EXPECT_FALSE(response3.GetResult().GetAccessToken().empty());
   EXPECT_FALSE(response3.GetResult().GetTokenType().empty());
   EXPECT_FALSE(response3.GetResult().GetRefreshToken().empty());
@@ -631,6 +637,7 @@ TEST_F(AuthenticationClientTest, NetworkProxySettings) {
   EXPECT_FALSE(response.IsSuccessful());
   EXPECT_TRUE(response.GetError().GetErrorCode() ==
               olp::client::ErrorCode::ServiceUnavailable);
+  EXPECT_STRNE(response.GetError().GetMessage().c_str(), kErrorOk.c_str());
 }
 
 TEST_F(AuthenticationClientTest, ErrorFields) {

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -368,10 +368,10 @@ TEST_F(AuthenticationClientTest, SignUpInUser) {
 
   AuthenticationClient::SignInUserResponse response5 = SignInUser(email);
   // According to the AAA team, we should expect one of 401 or 404 status.
-  using namespace testing;
-  EXPECT_THAT(response5.GetResult().GetStatus(),
-              AnyOf(Eq(olp::http::HttpStatusCode::UNAUTHORIZED),
-                    Eq(olp::http::HttpStatusCode::NOT_FOUND)))
+  EXPECT_THAT(
+      response5.GetResult().GetStatus(),
+      testing::AnyOf(testing::Eq(olp::http::HttpStatusCode::UNAUTHORIZED),
+                     testing::Eq(olp::http::HttpStatusCode::NOT_FOUND)))
       << GetErrorId(response5);
   EXPECT_EQ(kErrorAccountNotFoundCode,
             response5.GetResult().GetErrorResponse().code)
@@ -520,10 +520,10 @@ TEST_F(AuthenticationClientTest, SignInRefresh) {
 
   AuthenticationClient::SignInUserResponse response7 = SignInUser(email);
   // According to the AAA team, we should expect one of 401 or 404 status.
-  using namespace testing;
-  EXPECT_THAT(response7.GetResult().GetStatus(),
-              AnyOf(Eq(olp::http::HttpStatusCode::UNAUTHORIZED),
-                    Eq(olp::http::HttpStatusCode::NOT_FOUND)))
+  EXPECT_THAT(
+      response7.GetResult().GetStatus(),
+      testing::AnyOf(testing::Eq(olp::http::HttpStatusCode::UNAUTHORIZED),
+                     testing::Eq(olp::http::HttpStatusCode::NOT_FOUND)))
       << GetErrorId(response7);
   EXPECT_EQ(kErrorAccountNotFoundCode,
             response7.GetResult().GetErrorResponse().code)

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -46,8 +46,8 @@ class AuthenticationClientTest : public AuthenticationCommonTestFixture {
     unsigned int retry = 0u;
     do {
       if (retry > 0u) {
-        OLP_SDK_LOG_WARNING(__func__, "Request retry attempted (" << retry
-                                                                  << ")");
+        OLP_SDK_LOG_WARNING(__func__,
+                            "Request retry attempted (" << retry << ")");
         std::this_thread::sleep_for(
             std::chrono::seconds(retry * kRetryDelayInSecs));
       }
@@ -88,8 +88,8 @@ class AuthenticationClientTest : public AuthenticationCommonTestFixture {
     unsigned int retry = 0u;
     do {
       if (retry > 0u) {
-        OLP_SDK_LOG_WARNING(__func__, "Request retry attempted (" << retry
-                                                                  << ")");
+        OLP_SDK_LOG_WARNING(__func__,
+                            "Request retry attempted (" << retry << ")");
         std::this_thread::sleep_for(
             std::chrono::seconds(retry * kRetryDelayInSecs));
       }
@@ -126,8 +126,8 @@ class AuthenticationClientTest : public AuthenticationCommonTestFixture {
     unsigned int retry = 0u;
     do {
       if (retry > 0u) {
-        OLP_SDK_LOG_WARNING(__func__, "Request retry attempted (" << retry
-                                                                  << ")");
+        OLP_SDK_LOG_WARNING(__func__,
+                            "Request retry attempted (" << retry << ")");
         std::this_thread::sleep_for(
             std::chrono::seconds(retry * kRetryDelayInSecs));
       }
@@ -223,8 +223,6 @@ TEST_F(AuthenticationClientTest, SignInClient) {
   AuthenticationClient::SignInClientResponse response =
       SignInClient(credentials, now, kExpiryTime);
   EXPECT_EQ(olp::http::HttpStatusCode::OK, response.GetResult().GetStatus());
-  EXPECT_STREQ(kErrorOk.c_str(),
-               response.GetResult().GetErrorResponse().message.c_str());
   EXPECT_FALSE(response.GetResult().GetAccessToken().empty());
   EXPECT_GE(now + kMaxExpiry, response.GetResult().GetExpiryTime());
   EXPECT_LT(now + kMinExpiry, response.GetResult().GetExpiryTime());
@@ -264,8 +262,6 @@ TEST_F(AuthenticationClientTest, SignInClientMaxExpiration) {
       SignInClient(credentials, now);
   EXPECT_EQ(olp::http::HttpStatusCode::OK, response.GetResult().GetStatus());
   EXPECT_FALSE(response.GetResult().GetAccessToken().empty());
-  EXPECT_STREQ(kErrorOk.c_str(),
-               response.GetResult().GetErrorResponse().message.c_str());
   EXPECT_GE(now + kMaxLimitExpiry, response.GetResult().GetExpiryTime());
   EXPECT_LT(now + kMinLimitExpiry, response.GetResult().GetExpiryTime());
 
@@ -355,8 +351,6 @@ TEST_F(AuthenticationClientTest, SignUpInUser) {
 
   AuthenticationClient::SignInUserResponse response3 = SignInUser(email);
   EXPECT_EQ(olp::http::HttpStatusCode::OK, response3.GetResult().GetStatus());
-  EXPECT_STREQ(kErrorOk.c_str(),
-               response3.GetResult().GetErrorResponse().message.c_str());
   EXPECT_FALSE(response3.GetResult().GetAccessToken().empty());
   EXPECT_FALSE(response3.GetResult().GetTokenType().empty());
   EXPECT_FALSE(response3.GetResult().GetRefreshToken().empty());
@@ -637,7 +631,6 @@ TEST_F(AuthenticationClientTest, NetworkProxySettings) {
   EXPECT_FALSE(response.IsSuccessful());
   EXPECT_TRUE(response.GetError().GetErrorCode() ==
               olp::client::ErrorCode::ServiceUnavailable);
-  EXPECT_STRNE(response.GetError().GetMessage().c_str(), kErrorOk.c_str());
 }
 
 TEST_F(AuthenticationClientTest, ErrorFields) {

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -24,6 +24,7 @@
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/core/http/HttpStatusCode.h>
 #include <olp/core/http/NetworkConstants.h>
+#include <olp/core/http/NetworkUtils.h>
 #include <olp/core/porting/make_unique.h>
 
 #include <future>
@@ -1083,111 +1084,98 @@ TEST_F(AuthenticationClientTest, TestInvalidResponses) {
 }
 
 TEST_F(AuthenticationClientTest, TestHttpRequestErrorCodes) {
-  ExecuteSigninRequest(olp::http::HttpStatusCode::ACCEPTED,
-                       olp::http::HttpStatusCode::ACCEPTED, kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::CREATED,
-                       olp::http::HttpStatusCode::CREATED, kErrorUndefined,
+  auto status = olp::http::HttpStatusCode::ACCEPTED;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::CREATED;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status),
                        kResponseCreated);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::NON_AUTHORITATIVE_INFORMATION,
-                       olp::http::HttpStatusCode::NON_AUTHORITATIVE_INFORMATION,
-                       kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::NO_CONTENT,
-                       olp::http::HttpStatusCode::NO_CONTENT, kErrorUndefined,
+  status = olp::http::HttpStatusCode::NON_AUTHORITATIVE_INFORMATION;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::NO_CONTENT;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status),
                        kResponseNoContent);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::RESET_CONTENT,
-                       olp::http::HttpStatusCode::RESET_CONTENT,
-                       kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::PARTIAL_CONTENT,
-                       olp::http::HttpStatusCode::PARTIAL_CONTENT,
-                       kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::MULTIPLE_CHOICES,
-                       olp::http::HttpStatusCode::MULTIPLE_CHOICES,
-                       kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::MOVED_PERMANENTLY,
-                       olp::http::HttpStatusCode::MOVED_PERMANENTLY,
-                       kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::FOUND,
-                       olp::http::HttpStatusCode::FOUND, kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::SEE_OTHER,
-                       olp::http::HttpStatusCode::SEE_OTHER, kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::NOT_MODIFIED,
-                       olp::http::HttpStatusCode::NOT_MODIFIED,
-                       kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::USE_PROXY,
-                       olp::http::HttpStatusCode::USE_PROXY, kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::BAD_REQUEST,
-                       olp::http::HttpStatusCode::BAD_REQUEST,
-                       kErrorBadRequestMessage, kResponseBadRequest,
+  status = olp::http::HttpStatusCode::RESET_CONTENT;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::PARTIAL_CONTENT;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::MULTIPLE_CHOICES;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::MOVED_PERMANENTLY;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::FOUND;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::SEE_OTHER;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::NOT_MODIFIED;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::USE_PROXY;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::BAD_REQUEST;
+  ExecuteSigninRequest(status, status, "Invalid JSON.", kResponseBadRequest,
                        kErrorBadRequestCode);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::UNAUTHORIZED,
-                       olp::http::HttpStatusCode::UNAUTHORIZED,
-                       kErrorUnathorizedMessage, kResponseUnauthorized,
-                       kErrorUnauthorizedCode);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::PAYMENT_REQUIRED,
-                       olp::http::HttpStatusCode::PAYMENT_REQUIRED,
-                       kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::NOT_FOUND,
-                       olp::http::HttpStatusCode::NOT_FOUND, kErrorUserNotFound,
+  status = olp::http::HttpStatusCode::UNAUTHORIZED;
+  ExecuteSigninRequest(status, status,
+                       "Signature mismatch. Authorization signature or client "
+                       "credential is wrong.",
+                       kResponseUnauthorized, kErrorUnauthorizedCode);
+  status = olp::http::HttpStatusCode::PAYMENT_REQUIRED;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::NOT_FOUND;
+  ExecuteSigninRequest(status, status,
+                       "User for the given access token cannot be found.",
                        kResponseNotFound, kErrorNotFoundCode);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::METHOD_NOT_ALLOWED,
-                       olp::http::HttpStatusCode::METHOD_NOT_ALLOWED,
-                       kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::FORBIDDEN,
-                       olp::http::HttpStatusCode::FORBIDDEN, kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::NOT_ACCEPTABLE,
-                       olp::http::HttpStatusCode::NOT_ACCEPTABLE,
-                       kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::PROXY_AUTHENTICATION_REQUIRED,
-                       olp::http::HttpStatusCode::PROXY_AUTHENTICATION_REQUIRED,
-                       kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::REQUEST_TIMEOUT,
-                       olp::http::HttpStatusCode::REQUEST_TIMEOUT,
-                       kErrorUndefined);
+  status = olp::http::HttpStatusCode::METHOD_NOT_ALLOWED;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::FORBIDDEN;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::NOT_ACCEPTABLE;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::PROXY_AUTHENTICATION_REQUIRED;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::REQUEST_TIMEOUT;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::CONFLICT;
   ExecuteSigninRequest(
-      olp::http::HttpStatusCode::CONFLICT, olp::http::HttpStatusCode::CONFLICT,
-      kErrorConfliceMessage, kResponseConflict, kErrorConfliceCode);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::GONE,
-                       olp::http::HttpStatusCode::GONE, kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::LENGTH_REQUIRED,
-                       olp::http::HttpStatusCode::LENGTH_REQUIRED,
-                       kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::PRECONDITION_FAILED,
-                       olp::http::HttpStatusCode::PRECONDITION_FAILED,
-                       kErrorPreconditionFailedMessage,
+      status, status,
+      "A password account with the specified email address already exists.",
+      kResponseConflict, kErrorConfliceCode);
+
+  status = olp::http::HttpStatusCode::GONE;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::LENGTH_REQUIRED;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::PRECONDITION_FAILED;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status),
                        kResponsePreconditionFailed);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::REQUEST_ENTITY_TOO_LARGE,
-                       olp::http::HttpStatusCode::REQUEST_ENTITY_TOO_LARGE,
-                       kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::REQUEST_URI_TOO_LONG,
-                       olp::http::HttpStatusCode::REQUEST_URI_TOO_LONG,
-                       kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::UNSUPPORTED_MEDIA_TYPE,
-                       olp::http::HttpStatusCode::UNSUPPORTED_MEDIA_TYPE,
-                       kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::TOO_MANY_REQUESTS,
-                       olp::http::HttpStatusCode::TOO_MANY_REQUESTS,
-                       kErrorTooManyRequestsMessage, kResponseTooManyRequests,
-                       kErrorTooManyRequestsCode);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::INTERNAL_SERVER_ERROR,
-                       olp::http::HttpStatusCode::INTERNAL_SERVER_ERROR,
-                       kErrorInternvalServerMessage,
+  status = olp::http::HttpStatusCode::REQUEST_ENTITY_TOO_LARGE;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::REQUEST_URI_TOO_LONG;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::UNSUPPORTED_MEDIA_TYPE;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::TOO_MANY_REQUESTS;
+  ExecuteSigninRequest(status, status,
+                       "Request blocked because too many requests were made. "
+                       "Please wait for a while before making a new request.",
+                       kResponseTooManyRequests, kErrorTooManyRequestsCode);
+  status = olp::http::HttpStatusCode::INTERNAL_SERVER_ERROR;
+  ExecuteSigninRequest(status, status, "Missing Thing Encrypted Secret.",
                        kResponseInternalServerError, kErrorInternalServerCode);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::NOT_IMPLEMENTED,
-                       olp::http::HttpStatusCode::NOT_IMPLEMENTED,
-                       kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::BAD_GATEWAY,
-                       olp::http::HttpStatusCode::BAD_GATEWAY, kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::SERVICE_UNAVAILABLE,
-                       olp::http::HttpStatusCode::SERVICE_UNAVAILABLE,
-                       kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::GATEWAY_TIMEOUT,
-                       olp::http::HttpStatusCode::GATEWAY_TIMEOUT,
-                       kErrorUndefined);
-  ExecuteSigninRequest(olp::http::HttpStatusCode::VERSION_NOT_SUPPORTED,
-                       olp::http::HttpStatusCode::VERSION_NOT_SUPPORTED,
-                       kErrorUndefined);
-  ExecuteSigninRequest(100000, 100000, kErrorUndefined);
-  ExecuteSigninRequest(-100000, -100000, kErrorUndefined);
+
+  status = olp::http::HttpStatusCode::NOT_IMPLEMENTED;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::BAD_GATEWAY;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::SERVICE_UNAVAILABLE;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::GATEWAY_TIMEOUT;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  status = olp::http::HttpStatusCode::VERSION_NOT_SUPPORTED;
+  ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
+  auto st = 100000;
+  ExecuteSigninRequest(st, st, olp::http::HttpErrorToString(st));
+  st = -100000;
+  ExecuteSigninRequest(st, st, olp::http::HttpErrorToString(st));
 }
 
 TEST_F(AuthenticationClientTest, IntrospectApp) {

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -1111,19 +1111,16 @@ TEST_F(AuthenticationClientTest, TestHttpRequestErrorCodes) {
   status = olp::http::HttpStatusCode::USE_PROXY;
   ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
   status = olp::http::HttpStatusCode::BAD_REQUEST;
-  ExecuteSigninRequest(status, status, "Invalid JSON.", kResponseBadRequest,
-                       kErrorBadRequestCode);
+  ExecuteSigninRequest(status, status, kErrorBadRequestMessage,
+                       kResponseBadRequest, kErrorBadRequestCode);
   status = olp::http::HttpStatusCode::UNAUTHORIZED;
-  ExecuteSigninRequest(status, status,
-                       "Signature mismatch. Authorization signature or client "
-                       "credential is wrong.",
+  ExecuteSigninRequest(status, status, kErrorUnathorizedMessage,
                        kResponseUnauthorized, kErrorUnauthorizedCode);
   status = olp::http::HttpStatusCode::PAYMENT_REQUIRED;
   ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
   status = olp::http::HttpStatusCode::NOT_FOUND;
-  ExecuteSigninRequest(status, status,
-                       "User for the given access token cannot be found.",
-                       kResponseNotFound, kErrorNotFoundCode);
+  ExecuteSigninRequest(status, status, kErrorUserNotFound, kResponseNotFound,
+                       kErrorNotFoundCode);
   status = olp::http::HttpStatusCode::METHOD_NOT_ALLOWED;
   ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
   status = olp::http::HttpStatusCode::FORBIDDEN;
@@ -1135,10 +1132,8 @@ TEST_F(AuthenticationClientTest, TestHttpRequestErrorCodes) {
   status = olp::http::HttpStatusCode::REQUEST_TIMEOUT;
   ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
   status = olp::http::HttpStatusCode::CONFLICT;
-  ExecuteSigninRequest(
-      status, status,
-      "A password account with the specified email address already exists.",
-      kResponseConflict, kErrorConfliceCode);
+  ExecuteSigninRequest(status, status, kErrorConfliceMessage, kResponseConflict,
+                       kErrorConfliceCode);
 
   status = olp::http::HttpStatusCode::GONE;
   ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
@@ -1154,12 +1149,10 @@ TEST_F(AuthenticationClientTest, TestHttpRequestErrorCodes) {
   status = olp::http::HttpStatusCode::UNSUPPORTED_MEDIA_TYPE;
   ExecuteSigninRequest(status, status, olp::http::HttpErrorToString(status));
   status = olp::http::HttpStatusCode::TOO_MANY_REQUESTS;
-  ExecuteSigninRequest(status, status,
-                       "Request blocked because too many requests were made. "
-                       "Please wait for a while before making a new request.",
+  ExecuteSigninRequest(status, status, kErrorTooManyRequestsMessage,
                        kResponseTooManyRequests, kErrorTooManyRequestsCode);
   status = olp::http::HttpStatusCode::INTERNAL_SERVER_ERROR;
-  ExecuteSigninRequest(status, status, "Missing Thing Encrypted Secret.",
+  ExecuteSigninRequest(status, status, kErrorInternvalServerMessage,
                        kResponseInternalServerError, kErrorInternalServerCode);
 
   status = olp::http::HttpStatusCode::NOT_IMPLEMENTED;


### PR DESCRIPTION
Change sign in functionality from async ExecuteOrCancelled
to OlpClient CallApi. Add task to task sceduler.
Update tests.

Relates-To: OLPEDGE-2012

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>