### PR TITLE
Replace AuthenticationError class with ApiError

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationError.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationError.h
@@ -21,8 +21,8 @@
 
 #include <string>
 
+#include <olp/core/client/ApiError.h>
 #include "AuthenticationApi.h"
-#include "olp/core/http/HttpStatusCode.h"
 
 namespace olp {
 namespace authentication {
@@ -32,63 +32,10 @@ namespace authentication {
  *
  * You can get the following information on the authentication error: the error
  * code ( \ref GetErrorCode ) and error message ( \ref GetMessage ).
+ *
+ * @deprecated Will be removed by 12.2020. Use `client::ApiError` instead.
  */
-class AUTHENTICATION_API AuthenticationError {
- public:
-  /**
-   * @brief Creates the default `AuthenticationError` instance.
-   */
-  AuthenticationError() = default;
-
-  /**
-   * @brief Creates a new `AuthenticationError` instance.
-   * 
-   * @param network_code The error code.
-   * @param message The error message.
-   */
-  AuthenticationError(int network_code, const std::string& message)
-      : error_code_(http::HttpStatusCode::GetErrorCode(network_code)),
-        message_(message),
-        is_retryable_(IsRetryableNetworkCode(network_code)) {}
-
-  /**
-   * @brief Gets the error code.
-   *
-   * @return The error code.
-   */
-  inline const client::ErrorCode& GetErrorCode() const { return error_code_; }
-
-  /**
-   * @brief Gets the error message.
-   *
-   * @return The error message.
-   */
-  inline const std::string& GetMessage() const { return message_; }
-
-  /**
-   * @brief Determines if the request should be retried for this error.
-   *
-   * @return True if the request can be retried for this error; false otherwise.
-   */
-  inline bool ShouldRetry() const { return is_retryable_; }
-
- private:
-  static bool IsRetryableNetworkCode(int network_code) {
-    switch (static_cast<olp::http::ErrorCode>(network_code)) {
-      case olp::http::ErrorCode::OFFLINE_ERROR:
-      case olp::http::ErrorCode::CANCELLED_ERROR:
-      case olp::http::ErrorCode::TIMEOUT_ERROR:
-        return true;
-      default:
-        return false;
-    }
-  }
-
- private:
-  client::ErrorCode error_code_{client::ErrorCode::Unknown};
-  std::string message_{};
-  bool is_retryable_{false};
-};
+using AuthenticationError = client::ApiError;
 
 }  // namespace authentication
 }  // namespace olp


### PR DESCRIPTION
Class AuthenticationError duplicates the ApiError class.
Class is removed, but the alias to ApiError is still present and
deprecated.

Relates-To: OLPEDGE-1027

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>