### PR TITLE
Change to using system time by default for oauth.

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationSettings.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationSettings.h
@@ -22,9 +22,9 @@
 #include <memory>
 #include <string>
 
-#include <boost/optional.hpp>
-#include <olp/core/http/NetworkProxySettings.h>
 #include <olp/authentication/AuthenticationApi.h>
+#include <olp/core/http/NetworkProxySettings.h>
+#include <boost/optional.hpp>
 
 namespace olp {
 namespace http {
@@ -54,8 +54,8 @@ struct AUTHENTICATION_API AuthenticationSettings {
   boost::optional<http::NetworkProxySettings> network_proxy_settings{};
 
   /**
-   * @brief The network instance that is used to internally operate with the HERE platform
-   * Services.
+   * @brief The network instance that is used to internally operate with the
+   * HERE platform Services.
    */
   std::shared_ptr<http::Network> network_request_handler{nullptr};
 
@@ -82,11 +82,13 @@ struct AUTHENTICATION_API AuthenticationSettings {
    * @brief Uses system system time in authentication requests rather than
    * requesting time from authentication server.
    *
+   * Default is true, which means that system time is used.
+   *
    * @note Please make sure that the system time does not deviate from the
    * official UTC time as it might result in error responses from the
    * authentication server.
    */
-  bool use_system_time{false};
+  bool use_system_time{true};
 };
 
 }  // namespace authentication

--- a/olp-cpp-sdk-authentication/include/olp/authentication/Settings.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/Settings.h
@@ -91,11 +91,13 @@ struct AUTHENTICATION_API Settings {
    * @brief Uses system system time in authentication requests rather than
    * requesting time from authentication server.
    *
+   * Default is true, which means system time is used.
+   *
    * @note Please make sure that the system time does not deviate from the
    * official UTC time as it might result in error responses from the
    * authentication server.
    */
-  bool use_system_time{false};
+  bool use_system_time{true};
 };
 
 }  // namespace authentication

--- a/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
@@ -33,31 +33,31 @@
 PORTING_PUSH_WARNINGS()
 PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
 
-using namespace olp::authentication;
-using namespace olp::tests::common;
+namespace auth = olp::authentication;
+namespace common = olp::tests::common;
 using testing::_;
 
 namespace {
 const std::string kErrorOk = "OK";
 const std::string kTimestampUrl = R"(https://account.api.here.com/timestamp)";
 
-TokenEndpoint::TokenResponse GetTokenFromSyncRequest(
+auth::TokenEndpoint::TokenResponse GetTokenFromSyncRequest(
     olp::client::CancellationToken& cancellationToken,
-    const AutoRefreshingToken& autoToken,
+    const auth::AutoRefreshingToken& autoToken,
     const std::chrono::seconds minimumValidity =
-        kDefaultMinimumValiditySeconds) {
+        auth::kDefaultMinimumValiditySeconds) {
   return autoToken.GetToken(cancellationToken, minimumValidity);
 }
 
-TokenEndpoint::TokenResponse GetTokenFromAsyncRequest(
+auth::TokenEndpoint::TokenResponse GetTokenFromAsyncRequest(
     olp::client::CancellationToken& cancellationToken,
-    const AutoRefreshingToken& autoToken,
+    const auth::AutoRefreshingToken& autoToken,
     const std::chrono::seconds minimumValidity =
-        kDefaultMinimumValiditySeconds) {
-  std::promise<TokenEndpoint::TokenResponse> promise;
+        auth::kDefaultMinimumValiditySeconds) {
+  std::promise<auth::TokenEndpoint::TokenResponse> promise;
   auto future = promise.get_future();
   cancellationToken = autoToken.GetToken(
-      [&promise](TokenEndpoint::TokenResponse tokenResponse) {
+      [&promise](auth::TokenEndpoint::TokenResponse tokenResponse) {
         promise.set_value(tokenResponse);
       },
       minimumValidity);
@@ -65,16 +65,16 @@ TokenEndpoint::TokenResponse GetTokenFromAsyncRequest(
 }
 
 void TestAutoRefreshingTokenCancel(
-    TokenEndpoint& token_endpoint,
-    std::function<TokenEndpoint::TokenResponse(
+    auth::TokenEndpoint& token_endpoint,
+    std::function<auth::TokenEndpoint::TokenResponse(
         olp::client::CancellationToken& cancellationToken,
-        const AutoRefreshingToken& autoToken,
+        const auth::AutoRefreshingToken& autoToken,
         const std::chrono::seconds minimumValidity)>
         func) {
   auto autoToken = token_endpoint.RequestAutoRefreshingToken();
 
   std::thread threads[2];
-  auto tokenResponses = std::vector<TokenEndpoint::TokenResponse>();
+  auto tokenResponses = std::vector<auth::TokenEndpoint::TokenResponse>();
   std::mutex tokenResponsesMutex;
   olp::client::CancellationToken cancellationToken;
 
@@ -87,11 +87,11 @@ void TestAutoRefreshingTokenCancel(
   threads[0] = std::thread([&]() {
     std::lock_guard<std::mutex> guard(tokenResponsesMutex);
     tokenResponses.emplace_back(
-        func(cancellationToken, autoToken, kForceRefresh));
+        func(cancellationToken, autoToken, auth::kForceRefresh));
   });
 
-  // Cancel the refresh from another thread so that the response will come back
-  // with the same old token
+  // Cancel the refresh from another thread so that the response will come
+  // back with the same old token
   threads[1] = std::thread([&]() {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     cancellationToken.Cancel();
@@ -113,16 +113,17 @@ class HereAccountOauth2Test : public ::testing::Test {
  public:
   HereAccountOauth2Test() : key_("key"), secret_("secret") {}
   void SetUp() {
-    network_ = std::make_shared<NetworkMock>();
+    network_ = std::make_shared<common::NetworkMock>();
     task_scheduler_ =
         olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
 
-    AuthenticationSettings settings;
+    auth::AuthenticationSettings settings;
     settings.network_request_handler = network_;
     settings.task_scheduler = task_scheduler_;
+    settings.use_system_time = true;
     settings.token_endpoint_url = "https://authentication.server.url";
 
-    client_ = std::make_unique<AuthenticationClient>(settings);
+    client_ = std::make_unique<auth::AuthenticationClient>(settings);
   }
 
   void TearDown() {
@@ -131,7 +132,7 @@ class HereAccountOauth2Test : public ::testing::Test {
   }
 
  protected:
-  std::shared_ptr<NetworkMock> network_;
+  std::shared_ptr<common::NetworkMock> network_;
   std::unique_ptr<olp::authentication::AuthenticationClient> client_;
   std::shared_ptr<olp::thread::TaskScheduler> task_scheduler_;
   const std::string key_;
@@ -163,36 +164,14 @@ TEST_F(HereAccountOauth2Test, AutoRefreshingTokenCancelSync) {
 
             return olp::http::SendOutcome(request_id);
           });
-  EXPECT_CALL(*network_, Send(IsGetRequest(kTimestampUrl), _, _, _, _))
-      .Times(2)
-      .WillRepeatedly(
-          [&](olp::http::NetworkRequest /*request*/,
-              olp::http::Network::Payload payload,
-              olp::http::Network::Callback callback,
-              olp::http::Network::HeaderCallback /*header_callback*/,
-              olp::http::Network::DataCallback data_callback) {
-            olp::http::RequestId request_id(5);
-            if (payload) {
-              *payload << kResponseTime;
-            }
-            callback(olp::http::NetworkResponse()
-                         .WithRequestId(request_id)
-                         .WithStatus(olp::http::HttpStatusCode::OK));
-            if (data_callback) {
-              auto raw = const_cast<char*>(kResponseTime.c_str());
-              data_callback(reinterpret_cast<uint8_t*>(raw), 0,
-                            kResponseTime.size());
-            }
 
-            return olp::http::SendOutcome(request_id);
-          });
-  Settings settings({key_, secret_});
+  auth::Settings settings({key_, secret_});
   settings.network_request_handler = network_;
-  TokenEndpoint token_endpoint(settings);
+  auth::TokenEndpoint token_endpoint(settings);
 
   TestAutoRefreshingTokenCancel(
       token_endpoint, [](olp::client::CancellationToken& cancellationToken,
-                         const AutoRefreshingToken& autoToken,
+                         const auth::AutoRefreshingToken& autoToken,
                          const std::chrono::seconds minimumValidity) {
         return GetTokenFromSyncRequest(cancellationToken, autoToken,
                                        minimumValidity)
@@ -223,35 +202,15 @@ TEST_F(HereAccountOauth2Test, AutoRefreshingTokenBackendError) {
 
         return olp::http::SendOutcome(request_id);
       });
-  EXPECT_CALL(*network_, Send(IsGetRequest(kTimestampUrl), _, _, _, _))
-      .WillOnce([&](olp::http::NetworkRequest /*request*/,
-                    olp::http::Network::Payload payload,
-                    olp::http::Network::Callback callback,
-                    olp::http::Network::HeaderCallback /*header_callback*/,
-                    olp::http::Network::DataCallback data_callback) {
-        olp::http::RequestId request_id(5);
-        if (payload) {
-          *payload << kResponseTime;
-        }
-        callback(olp::http::NetworkResponse()
-                     .WithRequestId(request_id)
-                     .WithStatus(olp::http::HttpStatusCode::OK));
-        if (data_callback) {
-          auto raw = const_cast<char*>(kResponseTime.c_str());
-          data_callback(reinterpret_cast<uint8_t*>(raw), 0,
-                        kResponseTime.size());
-        }
 
-        return olp::http::SendOutcome(request_id);
-      });
-  Settings settings({key_, secret_});
+  auth::Settings settings({key_, secret_});
   settings.network_request_handler = network_;
-  TokenEndpoint token_endpoint(settings);
+  auth::TokenEndpoint token_endpoint(settings);
   olp::client::CancellationToken cancellationToken;
 
   auto token = GetTokenFromSyncRequest(
       cancellationToken, token_endpoint.RequestAutoRefreshingToken(),
-      kDefaultMinimumValiditySeconds);
+      auth::kDefaultMinimumValiditySeconds);
 
   EXPECT_TRUE(token.IsSuccessful());
   EXPECT_NE(token.GetResult().GetErrorResponse().code, 0);
@@ -284,36 +243,14 @@ TEST_F(HereAccountOauth2Test, AutoRefreshingTokenCancelAsync) {
 
             return olp::http::SendOutcome(request_id);
           });
-  EXPECT_CALL(*network_, Send(IsGetRequest(kTimestampUrl), _, _, _, _))
-      .Times(2)
-      .WillRepeatedly(
-          [&](olp::http::NetworkRequest /*request*/,
-              olp::http::Network::Payload payload,
-              olp::http::Network::Callback callback,
-              olp::http::Network::HeaderCallback /*header_callback*/,
-              olp::http::Network::DataCallback data_callback) {
-            olp::http::RequestId request_id(5);
-            if (payload) {
-              *payload << kResponseTime;
-            }
-            callback(olp::http::NetworkResponse()
-                         .WithRequestId(request_id)
-                         .WithStatus(olp::http::HttpStatusCode::OK));
-            if (data_callback) {
-              auto raw = const_cast<char*>(kResponseTime.c_str());
-              data_callback(reinterpret_cast<uint8_t*>(raw), 0,
-                            kResponseTime.size());
-            }
 
-            return olp::http::SendOutcome(request_id);
-          });
-  Settings settings({key_, secret_});
+  auth::Settings settings({key_, secret_});
   settings.network_request_handler = network_;
-  TokenEndpoint token_endpoint(settings);
+  auth::TokenEndpoint token_endpoint(settings);
 
   TestAutoRefreshingTokenCancel(
       token_endpoint, [](olp::client::CancellationToken& cancellationToken,
-                         const AutoRefreshingToken& autoToken,
+                         const auth::AutoRefreshingToken& autoToken,
                          const std::chrono::seconds minimumValidity) {
         return GetTokenFromAsyncRequest(cancellationToken, autoToken,
                                         minimumValidity)


### PR DESCRIPTION
Until now the default behaviour for oauth trough TokenProvider or
AuthenticationClient was to use the server timestamp and only on user
request or on error use the system time as an alternative.
This behaviour is now reversed so that as a default system time is
used and users need to explicitly change the use_system_time variable
in AuthenticationSettings or TokenProvider Settings to false to use
server time in case they know that the system time is not to be trusted.

Relates-To: OLPEDGE-2009

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>