### PR TITLE
GetAggregatedPartition for PartitionRepository.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.cpp
@@ -134,6 +134,34 @@ QueryApi::QuadTreeIndexResponse QueryApi::QuadTreeIndex(
   return olp::parser::parse<model::Index>(response.response);
 }
 
+olp::client::HttpResponse QueryApi::QuadTreeIndex(
+    const client::OlpClient& client, const std::string& layer_id,
+    const std::string& quad_key, boost::optional<int64_t> version,
+    int32_t depth, boost::optional<std::vector<std::string>> additional_fields,
+    boost::optional<std::string> billing_tag,
+    client::CancellationContext context) {
+  std::multimap<std::string, std::string> header_params;
+  header_params.emplace("Accept", "application/json");
+
+  std::multimap<std::string, std::string> query_params;
+  if (additional_fields) {
+    query_params.emplace("additionalFields",
+                         ConcatStringArray(*additional_fields, ","));
+  }
+  if (billing_tag) {
+    query_params.emplace("billingTag", *billing_tag);
+  }
+
+  std::string metadata_uri =
+      "/layers/" + layer_id +
+      (version ? "/versions/" + std::to_string(version.get()) : "") +
+      "/quadkeys/" + quad_key + "/depths/" + std::to_string(depth);
+
+  return client.CallApi(metadata_uri, "GET", std::move(query_params),
+                        std::move(header_params), {}, nullptr, std::string{},
+                        std::move(context));
+}
+
 QueryApi::QuadTreeIndexResponse QueryApi::QuadTreeIndexVolatile(
     const client::OlpClient& client, const std::string& layer_id,
     const std::string& quad_key, int32_t depth,

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.h
@@ -25,6 +25,7 @@
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/CancellationContext.h>
+#include <olp/core/client/HttpResponse.h>
 #include <boost/optional.hpp>
 #include "generated/model/Index.h"
 #include "olp/dataservice/read/model/Partitions.h"
@@ -109,6 +110,14 @@ class QueryApi {
   static QuadTreeIndexResponse QuadTreeIndex(
       const client::OlpClient& client, const std::string& layer_id,
       int64_t version, const std::string& quad_key, int32_t depth,
+      boost::optional<std::vector<std::string>> additional_fields,
+      boost::optional<std::string> billing_tag,
+      client::CancellationContext context);
+
+  static olp::client::HttpResponse QuadTreeIndex(
+      const client::OlpClient& client, const std::string& layer_id,
+      const std::string& quad_key, boost::optional<int64_t> version,
+      int32_t depth,
       boost::optional<std::vector<std::string>> additional_fields,
       boost::optional<std::string> billing_tag,
       client::CancellationContext context);

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -26,6 +26,7 @@
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettings.h>
+#include "QuadTreeIndex.h"
 #include "generated/model/Index.h"
 #include "olp/dataservice/read/DataRequest.h"
 #include "olp/dataservice/read/PartitionsRequest.h"
@@ -39,6 +40,9 @@ namespace repository {
 class ApiRepository;
 class CatalogRepository;
 class PartitionsCacheRepository;
+
+/// The partition metadata response type.
+using PartitionResponse = Response<model::Partition>;
 
 class PartitionsRepository {
  public:
@@ -59,6 +63,12 @@ class PartitionsRepository {
 
   static model::Partition PartitionFromSubQuad(
       const model::SubQuad& sub_quad, const std::string& partition);
+
+  static PartitionResponse GetAggregatedTile(
+      const client::HRN& catalog, const std::string& layer,
+      client::CancellationContext cancellation_context,
+      const TileRequest& request, boost::optional<int64_t> version,
+      const client::OlpClientSettings& settings);
 
   static PartitionsResponse GetPartitionForVersionedTile(
       const client::HRN& catalog, const std::string& layer_id,


### PR DESCRIPTION
This is a part of GetAggregatedData API update. PartitionRepository
handle loading quad tree and storing it into the cache, so it can be
used by clients further.

Resolves: OLPEDGE-1932

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>