### PR TITLE
Auth fallback mechanism when system time is wrong

### DIFF
--- a/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
@@ -137,10 +137,12 @@ std::time_t ParseTime(const std::string& value) {
 }
 
 std::time_t GetTimestampFromHeaders(const olp::http::Headers& headers) {
-  auto it = std::find_if(begin(headers), end(headers),
-                         [](const std::pair<std::string, std::string>& obg) {
-                           return (obg.first.compare(kDate) == 0);
-                         });
+  auto it =
+      std::find_if(begin(headers), end(headers),
+                   [](const std::pair<std::string, std::string>& obg) {
+                     return olp::http::NetworkUtils::CaseInsensitiveCompare(
+                         obg.first, kDate);
+                   });
   if (it != end(headers)) {
     return ParseTime(it->second);
   }

--- a/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
@@ -51,6 +51,7 @@
 #include "olp/core/http/NetworkRequest.h"
 #include "olp/core/http/NetworkResponse.h"
 #include "olp/core/http/NetworkUtils.h"
+#include "olp/core/logging/Log.h"
 #include "olp/core/porting/make_unique.h"
 #include "olp/core/thread/Atomic.h"
 #include "olp/core/thread/TaskScheduler.h"
@@ -122,16 +123,28 @@ constexpr auto kVersion = "1.0";
 constexpr auto kHmac = "HMAC-SHA256";
 constexpr auto kDate = "date";
 constexpr auto kErrorWrongTimestamp = 401204;
+constexpr auto kLogTag = "AuthenticationClient";
+
+#ifdef _WIN32
+#define timegm _mkgmtime
+#endif
 
 std::time_t ParseTime(const std::string& value) {
   std::tm tm = {};
   std::istringstream ss(value);
   ss >> std::get_time(&tm, "%a, %d %b %Y %H:%M:%S %z");
-#ifdef _WIN32
-  return _mkgmtime(&tm);
-#else
   return timegm(&tm);
-#endif
+}
+
+std::time_t GetTimestampFromHeaders(const olp::http::Headers& headers) {
+  auto it = std::find_if(begin(headers), end(headers),
+                         [](const std::pair<std::string, std::string>& obg) {
+                           return (obg.first.compare(kDate) == 0);
+                         });
+  if (it != end(headers)) {
+    return ParseTime(it->second);
+  }
+  return 0;
 }
 
 void ExecuteOrSchedule(
@@ -454,6 +467,14 @@ class AuthenticationClient::Impl final {
       const std::string& reacceptance_token);
   client::OlpClient::RequestBodyType GenerateAuthorizeBody(
       AuthorizeRequest properties);
+  olp::client::HttpResponse CallAuth(
+      const client::OlpClient& client, client::CancellationContext context,
+      const AuthenticationCredentials& credentials,
+      const SignInProperties& properties, std::time_t timestamp);
+  SignInResult ParseAuthResponse(int status, std::stringstream& auth_response);
+  AuthenticationClient::SignInClientResponse FindSingInResponceInCache(
+      int status, const std::string& error_message,
+      AuthenticationCredentials credentials);
 
   std::string GenerateUid();
 
@@ -480,65 +501,117 @@ AuthenticationClient::Impl::Impl(AuthenticationSettings settings)
 
 AuthenticationClient::Impl::~Impl() { pending_requests_->CancelAllAndWait(); }
 
+olp::client::HttpResponse AuthenticationClient::Impl::CallAuth(
+    const client::OlpClient& client, client::CancellationContext context,
+    const AuthenticationCredentials& credentials,
+    const SignInProperties& properties, std::time_t timestamp) {
+  const auto url = settings_.token_endpoint_url + kOauthEndpoint;
+
+  client::OlpClient::ParametersType headers = {
+      {http::kAuthorizationHeader,
+       GenerateHeader(credentials, url, timestamp)}};
+  if (context.IsCancelled()) {
+    return {static_cast<int>(olp::http::ErrorCode::CANCELLED_ERROR),
+            "Sign was cancelled"};
+  }
+  auto auth_response =
+      client.CallApi(kOauthEndpoint, "POST", {}, std::move(headers), {},
+                     GenerateClientBody(properties), kApplicationJson, context);
+  return auth_response;
+}
+
+SignInResult AuthenticationClient::Impl::ParseAuthResponse(
+    int status, std::stringstream& auth_response) {
+  auto document = std::make_shared<rapidjson::Document>();
+  rapidjson::IStreamWrapper stream(auth_response);
+  document->ParseStream(stream);
+  auto resp_impl = std::make_shared<SignInResultImpl>(
+      status, olp::http::HttpErrorToString(status), document);
+  SignInResult response(resp_impl);
+
+  return response;
+}
+
+AuthenticationClient::SignInClientResponse
+AuthenticationClient::Impl::FindSingInResponceInCache(
+    int status, const std::string& error_message,
+    AuthenticationCredentials credentials) {
+  if (status == static_cast<int>(olp::http::ErrorCode::CANCELLED_ERROR)) {
+    return {{status, error_message}};
+  }
+
+  auto cached_response = client_token_cache_->locked(
+      [&](utils::LruCache<std::string, SignInResult>& c)
+          -> boost::optional<SignInResult> {
+        auto it = c.Find(credentials.GetKey());
+        return it != c.end() ? boost::make_optional(it->value()) : boost::none;
+      });
+
+  if (!cached_response) {
+    return {{status, error_message}};
+  }
+
+  return *cached_response;
+}
+
 client::CancellationToken AuthenticationClient::Impl::SignInClient(
     AuthenticationCredentials credentials, SignInProperties properties,
     AuthenticationClient::SignInClientCallback callback) {
   auto sign_in_task =
       [=](client::CancellationContext context) -> SignInClientResponse {
-    if (!settings_.network_request_handler) {
-      return {{static_cast<int>(http::ErrorCode::IO_ERROR),
-               "Cannot sign in while offline"}};
-    }
-
-    client::OlpClient client = CreateOlpClient(settings_, boost::none);
-    using ProcessReturnHeaders = std::function<void(const olp::http::Headers&)>;
-
-    auto call_sign_in_request = [&](std::time_t& in_timestamp,
-                                    ProcessReturnHeaders get_timestamp =
-                                        nullptr) -> SignInClientResponse {
-      const auto url = settings_.token_endpoint_url + kOauthEndpoint;
-
-      client::OlpClient::ParametersType headers = {
-          {http::kAuthorizationHeader,
-           GenerateHeader(credentials, url, in_timestamp)}};
-
-      auto auth_response = client.CallApi(
-          kOauthEndpoint, "POST", {}, std::move(headers), {},
-          GenerateClientBody(properties), kApplicationJson, context);
-
-      if (get_timestamp) {
-        get_timestamp(auth_response.headers);
+    {
+      if (!settings_.network_request_handler) {
+        return {{static_cast<int>(http::ErrorCode::IO_ERROR),
+                 "Cannot sign in while offline"}};
       }
-      const auto status = auth_response.status;
+
+      if (context.IsCancelled()) {
+        return {{static_cast<int>(http::ErrorCode::CANCELLED_ERROR),
+                 "Sign was cancelled"}};
+      }
+
+      client::OlpClient client = CreateOlpClient(settings_, boost::none);
+      std::time_t timestamp = std::chrono::system_clock::to_time_t(
+          std::chrono::system_clock::now());
+
+      if (!settings_.use_system_time) {
+        auto server_time = GetTimeFromServer(context, client);
+        if (server_time.IsSuccessful()) {
+          timestamp = server_time.GetResult();
+        } else {
+          OLP_SDK_LOG_WARNING(
+              kLogTag,
+              "Failed to get time from server, system time will be used");
+        }
+      }
+
+      auto auth_response =
+          CallAuth(client, context, credentials, properties, timestamp);
+
+      auto status = auth_response.status;
 
       if (status < 0) {
-        auto error_message = auth_response.response.str();
-
-        if (status == static_cast<int>(olp::http::ErrorCode::CANCELLED_ERROR)) {
-          return {{status, error_message}};
-        }
-
-        auto cached_response = client_token_cache_->locked(
-            [&](utils::LruCache<std::string, SignInResult>& c)
-                -> boost::optional<SignInResult> {
-              auto it = c.Find(credentials.GetKey());
-              return it != c.end() ? boost::make_optional(it->value())
-                                   : boost::none;
-            });
-
-        if (!cached_response) {
-          return {{status, error_message}};
-        }
-
-        return *cached_response;
+        return FindSingInResponceInCache(status, auth_response.response.str(),
+                                         credentials);
       }
 
-      auto document = std::make_shared<rapidjson::Document>();
-      rapidjson::IStreamWrapper stream(auth_response.response);
-      document->ParseStream(stream);
-      auto resp_impl = std::make_shared<SignInResultImpl>(
-          status, olp::http::HttpErrorToString(status), document);
-      SignInResult response(resp_impl);
+      SignInResult response = ParseAuthResponse(status, auth_response.response);
+
+      if (settings_.use_system_time &&
+          status == http::HttpStatusCode::UNAUTHORIZED &&
+          response.GetErrorResponse().code == kErrorWrongTimestamp) {
+        timestamp = GetTimestampFromHeaders(auth_response.headers);
+        if (timestamp != 0) {
+          auth_response =
+              CallAuth(client, context, credentials, properties, timestamp);
+          status = auth_response.status;
+          if (status < 0) {
+            return FindSingInResponceInCache(
+                status, auth_response.response.str(), credentials);
+          }
+          response = ParseAuthResponse(status, auth_response.response);
+        }
+      }
 
       if (status == http::HttpStatusCode::OK) {
         // Cache the response
@@ -547,44 +620,8 @@ client::CancellationToken AuthenticationClient::Impl::SignInClient(
               return c.InsertOrAssign(credentials.GetKey(), response);
             });
       }
-
       return response;
-    };
-    std::time_t timestamp = 0;
-    std::time_t timestamp_from_header = 0;
-    ProcessReturnHeaders get_timestamp_from_headers = nullptr;
-
-    if (!settings_.use_system_time) {
-      auto server_time = GetTimeFromServer(context, client);
-      if (server_time.IsSuccessful()) {
-        timestamp = server_time.GetResult();
-      }
-    } else {
-      timestamp = std::chrono::system_clock::to_time_t(
-          std::chrono::system_clock::now());
-      get_timestamp_from_headers = [&](const olp::http::Headers& headers) {
-        auto it =
-            std::find_if(begin(headers), end(headers),
-                         [](const std::pair<std::string, std::string>& obg) {
-                           if (obg.first.compare(kDate) == 0) return true;
-                           return false;
-                         });
-        if (it != end(headers)) {
-          timestamp_from_header = ParseTime(it->second);
-        }
-      };
     }
-
-    auto response =
-        call_sign_in_request(timestamp, std::move(get_timestamp_from_headers));
-    if (settings_.use_system_time &&
-        response.GetResult().GetStatus() ==
-            http::HttpStatusCode::UNAUTHORIZED &&
-        response.GetResult().GetErrorResponse().code == kErrorWrongTimestamp &&
-        timestamp_from_header != 0) {
-      response = call_sign_in_request(timestamp_from_header);
-    }
-    return response;
   };
 
   return AddTask(settings_.task_scheduler, pending_requests_,

--- a/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
@@ -25,6 +25,7 @@
 #include <rapidjson/writer.h>
 
 #include <chrono>
+#include <iomanip>
 #include <sstream>
 
 #include <boost/uuid/uuid.hpp>
@@ -119,6 +120,19 @@ constexpr auto kOperator = "operator";
 // Values
 constexpr auto kVersion = "1.0";
 constexpr auto kHmac = "HMAC-SHA256";
+constexpr auto kDate = "date";
+constexpr auto kErrorWrongTimestamp = 401204;
+
+std::time_t ParseTime(const std::string& value) {
+  std::tm tm = {};
+  std::istringstream ss(value);
+  ss >> std::get_time(&tm, "%a, %d %b %Y %H:%M:%S %z");
+#ifdef _WIN32
+  return _mkgmtime(&tm);
+#else
+  return timegm(&tm);
+#endif
+}
 
 void ExecuteOrSchedule(
     const std::shared_ptr<olp::thread::TaskScheduler>& task_scheduler,
@@ -477,66 +491,99 @@ client::CancellationToken AuthenticationClient::Impl::SignInClient(
     }
 
     client::OlpClient client = CreateOlpClient(settings_, boost::none);
+    using ProcessReturnHeaders = std::function<void(const olp::http::Headers&)>;
 
-    std::time_t timestamp =
-        std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    auto call_sign_in_request = [&](std::time_t& in_timestamp,
+                                    ProcessReturnHeaders get_timestamp =
+                                        nullptr) -> SignInClientResponse {
+      const auto url = settings_.token_endpoint_url + kOauthEndpoint;
+
+      client::OlpClient::ParametersType headers = {
+          {http::kAuthorizationHeader,
+           GenerateHeader(credentials, url, in_timestamp)}};
+
+      auto auth_response = client.CallApi(
+          kOauthEndpoint, "POST", {}, std::move(headers), {},
+          GenerateClientBody(properties), kApplicationJson, context);
+
+      if (get_timestamp) {
+        get_timestamp(auth_response.headers);
+      }
+      const auto status = auth_response.status;
+
+      if (status < 0) {
+        auto error_message = auth_response.response.str();
+
+        if (status == static_cast<int>(olp::http::ErrorCode::CANCELLED_ERROR)) {
+          return {{status, error_message}};
+        }
+
+        auto cached_response = client_token_cache_->locked(
+            [&](utils::LruCache<std::string, SignInResult>& c)
+                -> boost::optional<SignInResult> {
+              auto it = c.Find(credentials.GetKey());
+              return it != c.end() ? boost::make_optional(it->value())
+                                   : boost::none;
+            });
+
+        if (!cached_response) {
+          return {{status, error_message}};
+        }
+
+        return *cached_response;
+      }
+
+      auto document = std::make_shared<rapidjson::Document>();
+      rapidjson::IStreamWrapper stream(auth_response.response);
+      document->ParseStream(stream);
+      auto resp_impl = std::make_shared<SignInResultImpl>(
+          status, olp::http::HttpErrorToString(status), document);
+      SignInResult response(resp_impl);
+
+      if (status == http::HttpStatusCode::OK) {
+        // Cache the response
+        client_token_cache_->locked(
+            [&](utils::LruCache<std::string, SignInResult>& c) {
+              return c.InsertOrAssign(credentials.GetKey(), response);
+            });
+      }
+
+      return response;
+    };
+    std::time_t timestamp = 0;
+    std::time_t timestamp_from_header = 0;
+    ProcessReturnHeaders get_timestamp_from_headers = nullptr;
 
     if (!settings_.use_system_time) {
       auto server_time = GetTimeFromServer(context, client);
       if (server_time.IsSuccessful()) {
         timestamp = server_time.GetResult();
       }
+    } else {
+      timestamp = std::chrono::system_clock::to_time_t(
+          std::chrono::system_clock::now());
+      get_timestamp_from_headers = [&](const olp::http::Headers& headers) {
+        auto it =
+            std::find_if(begin(headers), end(headers),
+                         [](const std::pair<std::string, std::string>& obg) {
+                           if (obg.first.compare(kDate) == 0) return true;
+                           return false;
+                         });
+        if (it != end(headers)) {
+          timestamp_from_header = ParseTime(it->second);
+        }
+      };
     }
 
-    const auto url = settings_.token_endpoint_url + kOauthEndpoint;
-
-    client::OlpClient::ParametersType headers = {
-        {http::kAuthorizationHeader,
-         GenerateHeader(credentials, url, timestamp)}};
-
-    auto auth_response = client.CallApi(
-        kOauthEndpoint, "POST", {}, std::move(headers), {},
-        GenerateClientBody(properties), kApplicationJson, context);
-
-    const auto status = auth_response.status;
-
-    if (status < 0) {
-      auto error_message = auth_response.response.str();
-
-      if (status == static_cast<int>(olp::http::ErrorCode::CANCELLED_ERROR)) {
-        return {{status, error_message}};
-      }
-
-      auto cached_response = client_token_cache_->locked(
-          [&](utils::LruCache<std::string, SignInResult>& c)
-              -> boost::optional<SignInResult> {
-            auto it = c.Find(credentials.GetKey());
-            return it != c.end() ? boost::make_optional(it->value())
-                                 : boost::none;
-          });
-
-      if (!cached_response) {
-        return {{status, error_message}};
-      }
-
-      return *cached_response;
+    auto response =
+        call_sign_in_request(timestamp, std::move(get_timestamp_from_headers));
+    if (settings_.use_system_time &&
+        response.GetResult().GetStatus() ==
+            http::HttpStatusCode::UNAUTHORIZED &&
+        response.GetResult().GetErrorResponse().code == kErrorWrongTimestamp &&
+        timestamp_from_header != 0) {
+      response = call_sign_in_request(timestamp_from_header);
     }
-
-    auto document = std::make_shared<rapidjson::Document>();
-    rapidjson::IStreamWrapper stream(auth_response.response);
-    document->ParseStream(stream);
-    auto resp_impl = std::make_shared<SignInResultImpl>(
-        status, olp::http::HttpErrorToString(status), document);
-    SignInResult response(resp_impl);
-
-    if (status == http::HttpStatusCode::OK) {
-      // Cache the response
-      client_token_cache_->locked(
-          [&](utils::LruCache<std::string, SignInResult>& c) {
-            return c.InsertOrAssign(credentials.GetKey(), response);
-          });
-    }
-
     return response;
   };
 

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -58,6 +58,7 @@ class AuthenticationClientTest : public AuthenticationCommonTestFixture {
       now = std::time(nullptr);
 
       AuthenticationClient::SignInProperties props;
+
       props.expires_in = std::chrono::seconds(expires_in);
 
       auto cancel_token = client_->SignInClient(
@@ -220,6 +221,51 @@ class AuthenticationClientTest : public AuthenticationCommonTestFixture {
 TEST_F(AuthenticationClientTest, SignInClient) {
   AuthenticationCredentials credentials(id_, secret_);
   std::time_t now;
+  AuthenticationClient::SignInClientResponse response =
+      SignInClient(credentials, now, kExpiryTime);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response.GetResult().GetStatus());
+  EXPECT_FALSE(response.GetResult().GetAccessToken().empty());
+  EXPECT_GE(now + kMaxExpiry, response.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinExpiry, response.GetResult().GetExpiryTime());
+  EXPECT_FALSE(response.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+
+  now = std::time(nullptr);
+  AuthenticationClient::SignInClientResponse response_2 =
+      SignInClient(credentials, now, kExtendedExpiryTime);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response_2.GetResult().GetStatus());
+  EXPECT_FALSE(response_2.GetResult().GetAccessToken().empty());
+  EXPECT_GE(now + kMaxExtendedExpiry, response_2.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinExtendedExpiry, response_2.GetResult().GetExpiryTime());
+  EXPECT_FALSE(response_2.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response_2.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response_2.GetResult().GetUserIdentifier().empty());
+
+  now = std::time(nullptr);
+  AuthenticationClient::SignInClientResponse response_3 =
+      SignInClient(credentials, now, kCustomExpiryTime);
+  EXPECT_EQ(olp::http::HttpStatusCode::OK, response_3.GetResult().GetStatus());
+  EXPECT_FALSE(response_3.GetResult().GetAccessToken().empty());
+  EXPECT_GE(now + kMaxCustomExpiry, response_3.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinCustomExpiry, response_3.GetResult().GetExpiryTime());
+  EXPECT_FALSE(response_3.GetResult().GetTokenType().empty());
+  EXPECT_TRUE(response_3.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response_3.GetResult().GetUserIdentifier().empty());
+}
+
+TEST_F(AuthenticationClientTest, SignInClientLocalTime) {
+  AuthenticationCredentials credentials(id_, secret_);
+  std::time_t now;
+
+  // Override the default client with new settings.
+  AuthenticationSettings settings;
+  settings.network_request_handler = network_;
+  settings.task_scheduler = task_scheduler_;
+  settings.token_endpoint_url = kHereAccountStagingURL;
+  settings.use_system_time = true;
+  client_ = std::make_unique<AuthenticationClient>(settings);
+
   AuthenticationClient::SignInClientResponse response =
       SignInClient(credentials, now, kExpiryTime);
   EXPECT_EQ(olp::http::HttpStatusCode::OK, response.GetResult().GetStatus());

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -60,8 +60,6 @@ constexpr auto kErrorNoContent = "No Content";
 constexpr auto kErrorFieldsMessage = "Received invalid data.";
 constexpr auto kErrorPreconditionFailedMessage = "Precondition Failed";
 
-constexpr auto kErrorUndefined = "";
-
 constexpr auto kErrorBadRequestMessage = "Invalid JSON.";
 
 constexpr auto kErrorUnathorizedMessage =

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -33,9 +33,9 @@
 #include "AuthenticationMockedResponses.h"
 #include "olp/core/client/OlpClientSettingsFactory.h"
 
+namespace common = olp::tests::common;
 namespace auth = olp::authentication;
 namespace client = olp::client;
-namespace common = olp::tests::common;
 using testing::_;
 
 namespace {
@@ -315,6 +315,93 @@ TEST_F(AuthenticationClientTest, SignInClientUseLocalTime) {
   EXPECT_EQ(response.GetResult().GetScope(), scope_);
 
   ::testing::Mock::VerifyAndClearExpectations(network_.get());
+}
+
+TEST_F(AuthenticationClientTest, SignInClientUseWrongLocalTime) {
+  auth::AuthenticationSettings settings;
+  settings.network_request_handler = network_;
+  settings.use_system_time = true;
+  settings.token_endpoint_url = kTokenEndpointUrl;
+
+  auto client =
+      std::make_unique<auth::AuthenticationClient>(std::move(settings));
+
+  auth::AuthenticationCredentials credentials(key_, secret_);
+  std::promise<auth::AuthenticationClient::SignInClientResponse> request;
+  auto request_future = request.get_future();
+
+  EXPECT_CALL(*network_, Send(common::IsGetRequest(kTimestampUrl), _, _, _, _))
+      .Times(0);
+
+  EXPECT_CALL(*network_,
+              Send(common::IsPostRequest(
+                       "https://authentication.server.url/oauth2/token"),
+                   _, _, _, _))
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
+                    olp::http::Network::Payload payload,
+                    olp::http::Network::Callback callback,
+                    olp::http::Network::HeaderCallback header_callback,
+                    olp::http::Network::DataCallback data_callback) {
+        olp::http::RequestId request_id(5);
+        if (payload) {
+          *payload << kResponseWrongTimestamp;
+        }
+        callback(olp::http::NetworkResponse()
+                     .WithRequestId(request_id)
+                     .WithStatus(olp::http::HttpStatusCode::UNAUTHORIZED));
+        if (data_callback) {
+          auto raw = const_cast<char*>(kResponseWrongTimestamp.c_str());
+          data_callback(reinterpret_cast<uint8_t*>(raw), 0,
+                        kResponseWrongTimestamp.size());
+        }
+        if (header_callback) {
+          header_callback("date", "Fri, 29 May 2020 11:07:45 GMT");
+        }
+
+        return olp::http::SendOutcome(request_id);
+      })
+      .WillOnce([&](olp::http::NetworkRequest /*request*/,
+                    olp::http::Network::Payload payload,
+                    olp::http::Network::Callback callback,
+                    olp::http::Network::HeaderCallback /*header_callback*/,
+                    olp::http::Network::DataCallback data_callback) {
+        olp::http::RequestId request_id(5);
+        if (payload) {
+          *payload << kResponseWithScope;
+        }
+        callback(olp::http::NetworkResponse()
+                     .WithRequestId(request_id)
+                     .WithStatus(olp::http::HttpStatusCode::OK));
+        if (data_callback) {
+          auto raw = const_cast<char*>(kResponseWithScope.c_str());
+          data_callback(reinterpret_cast<uint8_t*>(raw), 0,
+                        kResponseWithScope.size());
+        }
+
+        return olp::http::SendOutcome(request_id);
+      });
+
+  auth::AuthenticationClient::SignInProperties properties;
+  properties.scope = scope_;
+  std::time_t now = std::time(nullptr);
+  client->SignInClient(
+      credentials, properties,
+      [&](const auth::AuthenticationClient::SignInClientResponse& response) {
+        request.set_value(response);
+      });
+  request_future.wait();
+
+  auth::AuthenticationClient::SignInClientResponse response =
+      request_future.get();
+  EXPECT_TRUE(response.IsSuccessful());
+  EXPECT_FALSE(response.GetResult().GetAccessToken().empty());
+  EXPECT_EQ(kResponseToken, response.GetResult().GetAccessToken());
+  EXPECT_GE(now + kMaxExpiryTime, response.GetResult().GetExpiryTime());
+  EXPECT_LT(now + kMinExpiryTime, response.GetResult().GetExpiryTime());
+  EXPECT_EQ("bearer", response.GetResult().GetTokenType());
+  EXPECT_TRUE(response.GetResult().GetRefreshToken().empty());
+  EXPECT_TRUE(response.GetResult().GetUserIdentifier().empty());
+  EXPECT_EQ(response.GetResult().GetScope(), scope_);
 }
 
 TEST_F(AuthenticationClientTest, SignInClientScope) {

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationMockedResponses.h
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationMockedResponses.h
@@ -45,6 +45,10 @@ const std::string kResponseToken =
     "dcYqkJcZh195ojzeAcvDGI6HqS2zUMTdpYUhlwwfpkxGwrFmlAxgx58xKSeVt0sPvtabZBAW8u"
     "h2NGg";
 
+const std::string kResponseWrongTimestamp = R"JSON(
+    {"errorCode":401204, "message":"Time stamp is outside the valid period."}
+    )JSON";
+
 const std::string kResponseInvalidJson = R"JSON({x\})JSON";
 const std::string kResponseNoToken = R"JSON(
    {"tokenType":"bearer","expiresIn":3599}


### PR DESCRIPTION
For case if system time is wrong read time from
headers and send authorization request again with readed timestamp.
Add integration test.

Relates-To: OLPEDGE-1921

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>