### PR TITLE
Fix the incorrect lock() call.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
@@ -63,11 +63,11 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApi(
 
   // This mutex is required to avoid concurrent requests to online.
   repository::NamedMutex mutex(catalog.ToString());
-  std::unique_lock<repository::NamedMutex> lock(mutex, std::adopt_lock);
+  std::unique_lock<repository::NamedMutex> lock(mutex, std::defer_lock);
 
-  // If we are not planning to go online or access the cache, release the lock.
+  // If we are not planning to go online or access the cache, do not lock.
   if (options != CacheOnly && options != OnlineOnly) {
-    mutex.lock();
+    lock.lock();
   }
 
   repository::ApiCacheRepository repository(catalog, settings.cache);


### PR DESCRIPTION
lock should be called on unique_lock instead of mutex.
unique_lock itself should be constructed with defer_lock.

Resolves: OLPEDGE-2023

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>