### PR TITLE
VersionLayerClient adding GetAggregatedData API

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/AggregatedDataResult.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/AggregatedDataResult.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <utility>
+
+#include <olp/core/geo/tiling/TileKey.h>
+#include <olp/dataservice/read/DataServiceReadApi.h>
+#include <olp/dataservice/read/model/Data.h>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+
+/**
+ * @brief Represents the result of a aggregated data operation.
+ */
+class DATASERVICE_READ_API AggregatedDataResult {
+ public:
+  AggregatedDataResult() = default;
+
+  virtual ~AggregatedDataResult() = default;
+
+  /**
+   * @brief Sets the `TileKey` instance of this content.
+   *
+   * @param tile_key The fetched tile key.
+   */
+  void SetTile(const geo::TileKey& tile_key) { tile_key_ = tile_key; }
+
+  /**
+   * @brief Gets the requested TileKey or any of it's closest ancestor which
+   * contains the related data.
+   *
+   * @return The fetched tile key.
+   */
+  const geo::TileKey& GetTile() const { return tile_key_; }
+
+  /**
+   * @brief Sets the data of the tile.
+   *
+   * @param data of the prefetched tile.
+   */
+  void SetData(model::Data data) { data_ = std::move(data); }
+
+  /**
+   * @brief Gets the data of the tile.
+   *
+   * @return The prefetched data of the tile.
+   */
+  const model::Data& GetData() const { return data_; }
+
+  /**
+   * @brief Moves the data.
+   *
+   * @return The forwarding reference to the data.
+   */
+  model::Data&& MoveData() { return std::move(data_); }
+
+ private:
+  geo::TileKey tile_key_;
+  model::Data data_;
+};
+
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
@@ -26,6 +26,7 @@
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
 
+#include <olp/dataservice/read/AggregatedDataResult.h>
 #include <olp/dataservice/read/model/Catalog.h>
 #include <olp/dataservice/read/model/Data.h>
 #include <olp/dataservice/read/model/Messages.h>
@@ -73,6 +74,11 @@ using DataResult = model::Data;
 using DataResponse = Response<DataResult>;
 /// The callback type of the data response.
 using DataResponseCallback = Callback<DataResult>;
+
+/// The aggregated data response alias.
+using AggregatedDataResponse = Response<AggregatedDataResult>;
+/// The callback type of the aggregated data response.
+using AggregatedDataResponseCallback = Callback<AggregatedDataResult>;
 
 /// The alias of the prefetch tiles result.
 using PrefetchTilesResult = std::vector<std::shared_ptr<PrefetchTileResult>>;

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -160,12 +160,12 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    * result and an error). If a partition ID or data handle is not set in
    * the request, the callback is invoked with the following error:
    * `ErrorCode::InvalidRequest`. If the version is not specified, an additional
-   * request to the HERE platform is created to retrieve the latest available partition
-   * version.
+   * request to the HERE platform is created to retrieve the latest available
+   * partition version.
    *
    * @param data_request The `DataRequest` instance that contains a complete set
    * of request parameters.
-   * @note CacheWithUpdate fetch option is not suported.
+   * @note CacheWithUpdate fetch option is not supported.
    * @param callback The `DataResponseCallback` object that is invoked if
    * the `DataResult` object is available or an error is encountered.
    *
@@ -185,7 +185,7 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * @param data_request The `DataRequest` instance that contains a complete set
    * of request parameters.
-   * @note CacheWithUpdate fetch option is not suported.
+   * @note CacheWithUpdate fetch option is not supported.
    *
    * @return `CancellableFuture` that contains the `DataResponse` instance
    * or an error. You can also use `CancellableFuture` to cancel this request.
@@ -208,7 +208,7 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * @param request The `TileRequest` instance that contains a complete set
    * of request parameters.
-   * @note CacheWithUpdate fetch option is not suported.
+   * @note CacheWithUpdate fetch option is not supported.
    * @param callback The `DataResponseCallback` object that is invoked if
    * the `DataResult` object is available or an error is encountered.
    *
@@ -232,12 +232,42 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * @param request The `TileRequest` instance that contains a complete set
    * of request parameters.
-   * @note CacheWithUpdate fetch option is not suported.
+   * @note CacheWithUpdate fetch option is not supported.
    *
    * @return `CancellableFuture` that contains the `DataResponse` instance
    * or an error. You can also use `CancellableFuture` to cancel this request.
    */
   client::CancellableFuture<DataResponse> GetData(TileRequest request);
+
+  /**
+   * @brief Fetches data of a tile or its closest ancestor.
+   *
+   * @param request The `TileRequest` instance that contains a complete set
+   * of request parameters.
+   * @note CacheWithUpdate fetch option is not supported.
+   * @param callback The `AggregatedDataResponseCallback` object that is invoked
+   * if the `AggregatedDataResult` object is available or an error is
+   * encountered.
+   *
+   * @return A token that can be used to cancel this request.
+   */
+  client::CancellationToken GetAggregatedData(
+      TileRequest request, AggregatedDataResponseCallback callback);
+
+  /**
+   * @brief Fetches data of a tile or its closest ancestor.
+   *
+   * @param request The `TileRequest` instance that contains a complete set
+   * of request parameters.
+   * @note CacheWithUpdate fetch option is not supported.
+   *
+   * @return `CancellableFuture` that contains the `AggregatedDataResponse`
+   * instance or an error. You can also use `CancellableFuture` to cancel this
+   * request.
+   */
+  client::CancellableFuture<AggregatedDataResponse> GetAggregatedData(
+      TileRequest request);
+
   /**
    * @brief Fetches a list of partitions of the given generic layer
    * asynchronously.
@@ -248,7 +278,7 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * @param partitions_request The `PartitionsRequest` instance that contains
    * a complete set of request parameters.
-   * @note CacheWithUpdate fetch option is not suported.
+   * @note CacheWithUpdate fetch option is not supported.
    * @param callback The `PartitionsResponseCallback` object that is invoked if
    * the list of partitions is available or an error is encountered.
    *
@@ -267,7 +297,7 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * @param partitions_request The `PartitionsRequest` instance that contains
    * a complete set of request parameters.
-   * @note CacheWithUpdate fetch option is not suported.
+   * @note CacheWithUpdate fetch option is not supported.
    *
    * @return `CancellableFuture` that contains the `PartitionsResponse` instance
    * with data or an error. You can also use `CancellableFuture` to cancel this

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -102,6 +102,15 @@ bool VersionedLayerClient::RemoveFromCache(const geo::TileKey& tile) {
   return impl_->RemoveFromCache(tile);
 }
 
+client::CancellationToken VersionedLayerClient::GetAggregatedData(
+    TileRequest request, AggregatedDataResponseCallback callback) {
+  return impl_->GetAggregatedData(std::move(request), std::move(callback));
+}
+
+client::CancellableFuture<AggregatedDataResponse>
+VersionedLayerClient::GetAggregatedData(TileRequest request) {
+  return impl_->GetAggregatedData(std::move(request));
+}
 
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -85,6 +85,12 @@ class VersionedLayerClientImpl {
 
   virtual bool RemoveFromCache(const geo::TileKey& tile);
 
+  virtual client::CancellationToken GetAggregatedData(
+      TileRequest request, AggregatedDataResponseCallback callback);
+
+  virtual client::CancellableFuture<AggregatedDataResponse> GetAggregatedData(
+      TileRequest request);
+
  private:
   CatalogVersionResponse GetVersion(boost::optional<std::string> billing_tag,
                                     const FetchOptions& fetch_options,

--- a/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
@@ -201,6 +201,9 @@
 #define URL_QUADKEYS_92259 \
   R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/92259/depths/4)"
 
+#define URL_QUADKEYS_AGGREGATE_92259 \
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/testlayer/versions/108/quadkeys/92259/depths/4)"
+
 #define URL_QUADKEYS_VOLATILE_23618364 \
   R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/quadkeys/23618364/depths/0)"
 
@@ -267,6 +270,9 @@
 #define URL_BLOB_DATA_VOLATILE_PREFETCH_7 \
   R"(https://volatile-blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/data/95c5c703-e00e-4c38-841e-e419367474f1)"
 
+#define URL_BLOB_AGGREGATE_DATA \
+  R"(https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/f9a9fd8e-eb1b-48e5-bfdb-4392b3826443)"
+
 #define URL_VOLATILE_BLOB_DATA \
   R"(https://volatile-blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer_volatile/data/4eed6ed1-0d32-43b9-ae79-043cb4256410)"
 
@@ -287,6 +293,18 @@
 
 #define HTTP_RESPONSE_QUADKEYS_92259 \
 R"jsonString({"subQuads": [{"subQuadKey":"19","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"311","version":4,"dataHandle":"2d696e1f-4145-4bc9-b2b0-7420d1bc78c2"},{"subQuadKey":"316","version":4,"dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"},{"subQuadKey":"317","version":4,"dataHandle":"e119d20e-c7c6-4563-ae88-8aa5c6ca75c3"},{"subQuadKey":"318","version":4,"dataHandle":"a7a1afdf-db7e-4833-9627-d38bee6e2f81"},{"subQuadKey":"319","version":4,"dataHandle":"9d515348-afce-44e8-bc6f-3693cfbed104"},{"subQuadKey":"79","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString"
+
+#define HTTP_RESPONSE_QUADKEYS_92259_ROOT_ONLY \
+  R"jsonString({"subQuads": [{"subQuadKey":"1","version":4,"dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"}],"parentQuads": []})jsonString"
+
+#define HTTP_RESPONSE_QUADKEYS_92259_NO_ANCESTORS \
+  R"jsonString({"subQuads": [{"subQuadKey":"311","version":4,"dataHandle":"2d696e1f-4145-4bc9-b2b0-7420d1bc78c2"},{"subQuadKey":"317","version":4,"dataHandle":"e119d20e-c7c6-4563-ae88-8aa5c6ca75c3"},{"subQuadKey":"318","version":4,"dataHandle":"a7a1afdf-db7e-4833-9627-d38bee6e2f81"},{"subQuadKey":"319","version":4,"dataHandle":"9d515348-afce-44e8-bc6f-3693cfbed104"}],"parentQuads": []})jsonString"
+
+#define HTTP_RESPONSE_QUADKEYS_92259_PARENT \
+  R"jsonString({"subQuads": [{"subQuadKey":"311","version":4,"dataHandle":"2d696e1f-4145-4bc9-b2b0-7420d1bc78c2"},{"subQuadKey":"317","version":4,"dataHandle":"e119d20e-c7c6-4563-ae88-8aa5c6ca75c3"},{"subQuadKey":"318","version":4,"dataHandle":"a7a1afdf-db7e-4833-9627-d38bee6e2f81"},{"subQuadKey":"319","version":4,"dataHandle":"9d515348-afce-44e8-bc6f-3693cfbed104"}],"parentQuads": [{"partition":"22","version":282,"dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443","dataSize":52438}]})jsonString"
+
+#define HTTP_RESPONSE_NO_QUADS \
+  R"jsonString({"subQuads": [],"parentQuads": []})jsonString"
 
 #define HTTP_RESPONSE_BLOB_DATA_PREFETCH_1 \
   R"(--644ff000-704a-4f45-9988-c628602b7064)"


### PR DESCRIPTION
New API fetches data of a tile or its closest ancestor. It can be useful
when need to load most detailed available data for specified tile. Added
integration tests to cover the API.

Resolves: OLPEDGE-1932

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>