### PR TITLE
Fix a crash inside InitializeLru

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -341,7 +341,11 @@ void DefaultCacheImpl::InitializeLru() {
       }
 
       if (expiration_key) {
-        props.expiry = std::stol(value.data());
+        // value.data() could point to a value without null character at the
+        // end, this could cause exception in std::stol. This is fixed by
+        // constructing a string, (We rely on small string optimization here).
+        std::string timestamp(value.data(), value.size());
+        props.expiry = std::stol(timestamp.c_str());
       } else {
         props.size = value.size();
       }


### PR DESCRIPTION
During testing was found that function InitializeLru could crash
during expiration parsing, the data length was not taken into account
when it was parsed, and std::stol throw an exception.

Resolves: OLPEDGE-2029

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>