### PR TITLE
Move the authorization header function to utils

### DIFF
--- a/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.h
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.h
@@ -126,12 +126,6 @@ class AuthenticationClientImpl final {
 
   static TimeResponse ParseTimeResponse(std::stringstream& payload);
 
-  std::string Base64Encode(const std::vector<uint8_t>& vector);
-
-  std::string GenerateHeader(const AuthenticationCredentials& credentials,
-                             const std::string& url,
-                             const time_t& timestamp = std::time(nullptr));
-
   std::string GenerateBearerHeader(const std::string& bearer_token);
 
   client::OlpClient::RequestBodyType GenerateClientBody(

--- a/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.h
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.h
@@ -25,6 +25,7 @@
 
 #include <rapidjson/document.h>
 
+#include "olp/authentication/AuthenticationCredentials.h"
 #include "olp/authentication/AuthenticationSettings.h"
 #include "olp/authentication/AuthorizeResult.h"
 #include "olp/authentication/ErrorResponse.h"
@@ -128,6 +129,20 @@ std::time_t ParseTime(const std::string& value);
 client::OlpClient CreateOlpClient(
     const AuthenticationSettings& auth_settings,
     boost::optional<client::AuthenticationSettings> authentication_settings);
+
+/*
+ * @brief Generate authorization header.
+ *
+ * @param credentials Client credentials.
+ * @param url Authorization endpoint URL.
+ * @param timestamp Current time.
+ * @param nonce A unique value, must be used once. (Refer to OAuth docs).
+ *
+ * @return The authorization header string.
+ */
+std::string GenerateAuthorizationHeader(
+    const AuthenticationCredentials& credentials, const std::string& url,
+    time_t timestamp, std::string nonce);
 
 }  // namespace authentication
 }  // namespace olp

--- a/olp-cpp-sdk-authentication/tests/AuthenticationClientTest.cpp
+++ b/olp-cpp-sdk-authentication/tests/AuthenticationClientTest.cpp
@@ -28,10 +28,27 @@ namespace {
 constexpr auto kTime = "Fri, 29 May 2020 11:07:45 GMT";
 }  // namespace
 
+namespace auth = olp::authentication;
+
 TEST(AuthenticationClientTest, TimeParsing) {
   {
     SCOPED_TRACE("Parse time");
-
-    EXPECT_EQ(olp::authentication::ParseTime(kTime), 1590750465);
+    EXPECT_EQ(auth::ParseTime(kTime), 1590750465);
   }
+}
+
+TEST(AuthenticationClientTest, GenerateAuthorizationHeader) {
+  auth::AuthenticationCredentials credentials("key", "secret");
+  const auto url = "https://auth.server.com";
+  auto sig = auth::GenerateAuthorizationHeader(credentials, url, 0, "unique");
+  auto expected_sig =
+      "oauth_consumer_key=key&oauth_nonce=unique&oauth_signature_method=HMAC-"
+      "SHA256&oauth_timestamp=0&oauth_version=1.0POST&https%3A%2F%2Fauth."
+      "server.com&oauth_consumer_key%3Dkey%26oauth_nonce%3Dunique%26oauth_"
+      "signature_method%3DHMAC-SHA256%26oauth_timestamp%3D0%26oauth_version%"
+      "3D1.0OAuth "
+      "oauth_consumer_key=\"key\",oauth_nonce=\"unique\",oauth_signature_"
+      "method=\"HMAC-SHA256\",oauth_timestamp=\"0\",oauth_version=\"1.0\","
+      "oauth_signature=\"ncwRtcqRSM04FIFch8Ay4l7bRmp96lifuHEops4AqEw%3D\"";
+  EXPECT_EQ(sig, expected_sig);
 }


### PR DESCRIPTION
This is needed to enable testing and enabled new code to reuse it.
Adapt function to coding style, switch from string concatenation to
reusable string stream.
Remove a needless auth namespace.

Resolves: OLPEDGE-2030

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>