### PR TITLE
Clean-up VersionedLayerClientTest.cpp

### DIFF
--- a/tests/common/mocks/NetworkMock.h
+++ b/tests/common/mocks/NetworkMock.h
@@ -97,6 +97,10 @@ NetworkCallback ReturnHttpResponse(olp::http::NetworkResponse response,
                                    const std::string& response_body,
                                    const http::Headers& headers = {});
 
+inline olp::http::NetworkResponse GetResponse(int status) {
+  return olp::http::NetworkResponse().WithStatus(status);
+}
+
 }  // namespace common
 }  // namespace tests
 }  // namespace olp


### PR DESCRIPTION
Enhance readability.
Use short namespaces.
Remove GetArgument method, use constants.

Relates-To: OLPEDGE-2057

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>