### PR TITLE
fv test for VersionedLayerClient::GetAggregatedData()

### DIFF
--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test-mock.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test-mock.sh
@@ -51,7 +51,7 @@ update-ca-certificates
 echo ">>> Starting Functional Test against Mock Server... >>>"
 $REPO_HOME/build/tests/functional/olp-cpp-sdk-functional-tests \
     --gtest_output="xml:$REPO_HOME/reports/olp-functional-test-mock-report.xml" \
-    --gtest_filter="VersionedLayerClientTest.GetPartitions":"CatalogClientTest.*"
+    --gtest_filter="VersionedLayerClientTest.GetPartitions":"VersionedLayerClientTest.GetAggregatedData":"CatalogClientTest.*"
 result=$?
 echo "Functional test with Mock finished with status: ${result}"
 

--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
@@ -20,7 +20,7 @@
 echo ">>> Functional Test ... >>>"
 $REPO_HOME/build/tests/functional/olp-cpp-sdk-functional-tests \
     --gtest_output="xml:$REPO_HOME/reports/olp-functional-test-report.xml" \
-    --gtest_filter="-ArcGisAuthenticationTest.SignInArcGis":"FacebookAuthenticationTest.SignInFacebook":"VersionedLayerClientTest.GetPartitions":"CatalogClientTest.*" 
+    --gtest_filter="-ArcGisAuthenticationTest.SignInArcGis":"FacebookAuthenticationTest.SignInFacebook":"VersionedLayerClientTest.GetPartitions":"VersionedLayerClientTest.GetAggregatedData":"CatalogClientTest.*" 
     #The test VersionedLayerClientTest.GetPartitions uses mock server and it will be started in separate script. (OLPEDGE-732)
 result=$?
 echo "Functional test finished with status: ${result}"

--- a/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -21,11 +21,14 @@
 #include <olp/authentication/AuthenticationCredentials.h>
 #include <olp/authentication/Settings.h>
 #include <olp/authentication/TokenProvider.h>
+#include <olp/core/cache/CacheSettings.h>
+#include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
 #include <olp/core/http/NetworkSettings.h>
 #include <olp/core/logging/Log.h>
 #include <olp/core/porting/make_unique.h>
+#include <olp/dataservice/read/FetchOptions.h>
 #include <olp/dataservice/read/VersionedLayerClient.h>
 #include <string>
 #include <testutils/CustomParameters.hpp>
@@ -48,6 +51,94 @@ const auto kTestHrn = "hrn:here:data::olp-here-test:hereos-internal-test";
 const auto kPartitionsResponsePath =
     "/metadata/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test/"
     "layers/testlayer/partitions";
+
+void WriteSubquadsToJson(rapidjson::Document& doc,
+                         const olp::geo::TileKey& root_tile,
+                         const std::vector<std::uint16_t>& sub_quads,
+                         rapidjson::Document::AllocatorType& allocator) {
+  rapidjson::Value sub_quads_value;
+  sub_quads_value.SetArray();
+  for (auto quad : sub_quads) {
+    const auto partition = root_tile.AddedSubkey64(quad).ToHereTile();
+    const auto data_handle =
+        mockserver::DefaultResponses::GenerateDataHandle(partition);
+
+    rapidjson::Value item_value;
+    item_value.SetObject();
+    olp::serializer::serialize("subQuadKey", std::to_string(quad), item_value,
+                               allocator);
+    olp::serializer::serialize("version", 0, item_value, allocator);
+    olp::serializer::serialize("dataHandle", data_handle, item_value,
+                               allocator);
+    olp::serializer::serialize("dataSize", 100, item_value, allocator);
+    sub_quads_value.PushBack(std::move(item_value), allocator);
+  }
+  doc.AddMember("subQuads", std::move(sub_quads_value), allocator);
+}
+
+void WriteParentquadsToJson(rapidjson::Document& doc,
+                            const std::vector<std::uint64_t>& parent_quads,
+                            rapidjson::Document::AllocatorType& allocator) {
+  rapidjson::Value parent_quads_value;
+  parent_quads_value.SetArray();
+  for (auto parent : parent_quads) {
+    const auto partition = std::to_string(parent);
+    const auto data_handle =
+        mockserver::DefaultResponses::GenerateDataHandle(partition);
+
+    rapidjson::Value item_value;
+    item_value.SetObject();
+    olp::serializer::serialize("partition", std::to_string(parent), item_value,
+                               allocator);
+    olp::serializer::serialize("version", 0, item_value, allocator);
+    olp::serializer::serialize("dataHandle", data_handle, item_value,
+                               allocator);
+    olp::serializer::serialize("dataSize", 100, item_value, allocator);
+    parent_quads_value.PushBack(std::move(item_value), allocator);
+  }
+  doc.AddMember("parentQuads", std::move(parent_quads_value), allocator);
+}
+
+std::string GenerateQuadTreeResponse(
+    olp::geo::TileKey root_tile, std::uint32_t depth,
+    const std::vector<std::uint32_t>& available_levels) {
+  std::vector<std::uint16_t> sub_quads;
+  std::vector<std::uint64_t> parent_quads;
+
+  // generate data
+  for (auto level : available_levels) {
+    if (level < root_tile.Level()) {
+      auto key = root_tile.ChangedLevelTo(level);
+      parent_quads.push_back(key.ToQuadKey64());
+    } else {
+      const auto level_depth = level - root_tile.Level();
+      if (level_depth > depth) {
+        continue;
+      }
+
+      const auto sub_tile =
+          olp::geo::TileKey::FromRowColumnLevel(0, 0, level_depth);
+      const auto start_level_id = sub_tile.ToQuadKey64();
+      const auto tiles_count =
+          olp::geo::QuadKey64Helper::ChildrenAtLevel(level_depth);
+
+      std::vector<std::uint64_t> layer_ids(tiles_count);
+      std::iota(layer_ids.begin(), layer_ids.end(), start_level_id);
+      sub_quads.insert(sub_quads.end(), layer_ids.begin(), layer_ids.end());
+    }
+  }
+
+  rapidjson::Document doc;
+  auto& allocator = doc.GetAllocator();
+  doc.SetObject();
+  WriteSubquadsToJson(doc, root_tile, sub_quads, allocator);
+  WriteParentquadsToJson(doc, parent_quads, allocator);
+
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  doc.Accept(writer);
+  return buffer.GetString();
+}
 
 class VersionedLayerClientTest : public ::testing::Test {
  protected:
@@ -123,6 +214,186 @@ TEST_F(VersionedLayerClientTest, GetPartitions) {
   EXPECT_SUCCESS(partitions_response);
   ASSERT_EQ(4u, partitions_response.GetResult().GetPartitions().size());
   EXPECT_TRUE(mock_server_client_->Verify());
+}
+
+TEST_F(VersionedLayerClientTest, GetAggregatedData) {
+  olp::client::HRN hrn(kTestHrn);
+
+  constexpr auto kTileId = "5901734";
+  constexpr auto kLayer = "testlayer";
+  constexpr auto kQuadTreeDepth = 4;
+  constexpr auto kVersion = 44;
+
+  const auto root_tile = olp::geo::TileKey::FromHereTile(kTileId);
+  const auto tile = root_tile.ChangedLevelTo(15);
+  const auto request = olp::dataservice::read::TileRequest().WithTileKey(tile);
+
+  // authentification not needed for the test
+  settings_->authentication_settings = boost::none;
+
+  {
+    SCOPED_TRACE("Requested tile");
+    const auto data_handle =
+        mockserver::DefaultResponses::GenerateDataHandle(tile.ToHereTile());
+    const auto data = mockserver::DefaultResponses::GenerateData();
+
+    {
+      mock_server_client_->MockLookupResourceApiResponse(
+          mockserver::DefaultResponses::GenerateResourceApisResponse(kTestHrn));
+      mock_server_client_->MockGetVersionResponse(
+          mockserver::DefaultResponses::GenerateVersionResponse(kVersion));
+      mock_server_client_->MockGetResponse(
+          kLayer, root_tile, kVersion,
+          GenerateQuadTreeResponse(root_tile, kQuadTreeDepth,
+                                   {1, 3, 12, 13, 14, 15}));
+      mock_server_client_->MockGetResponse(kLayer, data_handle, data);
+    }
+
+    auto client =
+        std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+            hrn, kLayer, boost::none, *settings_);
+
+    auto future = client->GetAggregatedData(request).GetFuture();
+    auto response = future.get();
+    const auto result = response.MoveResult();
+    const auto& result_data = result.GetData();
+
+    ASSERT_TRUE(response.IsSuccessful())
+        << response.GetError().GetMessage().c_str();
+    ASSERT_TRUE(result_data);
+    ASSERT_EQ(result_data->size(), data.size());
+    EXPECT_TRUE(std::equal(data.begin(), data.end(), result_data->begin()));
+    EXPECT_EQ(result.GetTile(), tile);
+    EXPECT_TRUE(mock_server_client_->Verify());
+  }
+
+  {
+    SCOPED_TRACE("Ancestor tile");
+    const auto expect_tile = tile.ChangedLevelTo(14);
+    const auto data_handle = mockserver::DefaultResponses::GenerateDataHandle(
+        expect_tile.ToHereTile());
+    const auto data = mockserver::DefaultResponses::GenerateData();
+
+    {
+      SetUpMockServer(settings_->network_request_handler);
+      mock_server_client_->MockLookupResourceApiResponse(
+          mockserver::DefaultResponses::GenerateResourceApisResponse(kTestHrn));
+      mock_server_client_->MockGetVersionResponse(
+          mockserver::DefaultResponses::GenerateVersionResponse(kVersion));
+      mock_server_client_->MockGetResponse(
+          kLayer, root_tile, kVersion,
+          GenerateQuadTreeResponse(root_tile, kQuadTreeDepth,
+                                   {1, 3, 12, 13, 14}));
+      mock_server_client_->MockGetResponse(kLayer, data_handle, data);
+    }
+
+    auto client =
+        std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+            hrn, kLayer, boost::none, *settings_);
+
+    auto future = client->GetAggregatedData(request).GetFuture();
+    auto response = future.get();
+    const auto result = response.MoveResult();
+    const auto& result_data = result.GetData();
+
+    ASSERT_TRUE(response.IsSuccessful())
+        << response.GetError().GetMessage().c_str();
+    ASSERT_TRUE(result.GetData());
+    ASSERT_EQ(result_data->size(), data.size());
+    EXPECT_TRUE(std::equal(data.begin(), data.end(), result_data->begin()));
+    EXPECT_EQ(result.GetTile(), expect_tile);
+    EXPECT_TRUE(mock_server_client_->Verify());
+  }
+
+  {
+    SCOPED_TRACE("Parent tile");
+    const auto expect_tile = tile.ChangedLevelTo(3);
+    const auto data_handle = mockserver::DefaultResponses::GenerateDataHandle(
+        expect_tile.ToHereTile());
+    const auto data = mockserver::DefaultResponses::GenerateData();
+
+    {
+      SetUpMockServer(settings_->network_request_handler);
+      mock_server_client_->MockLookupResourceApiResponse(
+          mockserver::DefaultResponses::GenerateResourceApisResponse(kTestHrn));
+      mock_server_client_->MockGetVersionResponse(
+          mockserver::DefaultResponses::GenerateVersionResponse(kVersion));
+      mock_server_client_->MockGetResponse(
+          kLayer, root_tile, kVersion,
+          GenerateQuadTreeResponse(root_tile, kQuadTreeDepth, {1, 2, 3}));
+      mock_server_client_->MockGetResponse(kLayer, data_handle, data);
+    }
+
+    auto client =
+        std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+            hrn, kLayer, boost::none, *settings_);
+
+    auto future = client->GetAggregatedData(request).GetFuture();
+    auto response = future.get();
+    const auto result = response.MoveResult();
+    const auto& result_data = result.GetData();
+
+    ASSERT_TRUE(response.IsSuccessful())
+        << response.GetError().GetMessage().c_str();
+    ASSERT_TRUE(result.GetData());
+    ASSERT_EQ(result_data->size(), data.size());
+    EXPECT_TRUE(std::equal(data.begin(), data.end(), result_data->begin()));
+    EXPECT_EQ(result.GetTile(), expect_tile);
+    EXPECT_TRUE(mock_server_client_->Verify());
+  }
+
+  {
+    SCOPED_TRACE("Check cache");
+    const auto data_handle =
+        mockserver::DefaultResponses::GenerateDataHandle(tile.ToHereTile());
+    const auto data = mockserver::DefaultResponses::GenerateData();
+
+    {
+      SetUpMockServer(settings_->network_request_handler);
+      mock_server_client_->MockLookupResourceApiResponse(
+          mockserver::DefaultResponses::GenerateResourceApisResponse(kTestHrn));
+      mock_server_client_->MockGetVersionResponse(
+          mockserver::DefaultResponses::GenerateVersionResponse(kVersion));
+      mock_server_client_->MockGetResponse(
+          kLayer, root_tile, kVersion,
+          GenerateQuadTreeResponse(root_tile, kQuadTreeDepth, {15}));
+      mock_server_client_->MockGetResponse(kLayer, data_handle, data);
+    }
+
+    settings_->cache =
+        olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+    auto client =
+        std::make_unique<olp::dataservice::read::VersionedLayerClient>(
+            hrn, kLayer, boost::none, *settings_);
+
+    auto future = client->GetAggregatedData(request).GetFuture();
+    auto response = future.get();
+    auto result = response.MoveResult();
+    auto result_data = result.GetData();
+
+    ASSERT_TRUE(response.IsSuccessful())
+        << response.GetError().GetMessage().c_str();
+    ASSERT_TRUE(result.GetData());
+    ASSERT_EQ(result_data->size(), data.size());
+    EXPECT_TRUE(std::equal(data.begin(), data.end(), result_data->begin()));
+    ASSERT_EQ(result.GetTile(), tile);
+    EXPECT_TRUE(mock_server_client_->Verify());
+
+    const auto request =
+        olp::dataservice::read::TileRequest().WithTileKey(tile).WithFetchOption(
+            olp::dataservice::read::CacheOnly);
+    response = client->GetAggregatedData(request).GetFuture().get();
+    result = response.MoveResult();
+    result_data = result.GetData();
+
+    ASSERT_TRUE(response.IsSuccessful())
+        << response.GetError().GetMessage().c_str();
+    ASSERT_TRUE(result.GetData());
+    ASSERT_EQ(result_data->size(), data.size());
+    EXPECT_TRUE(std::equal(data.begin(), data.end(), result_data->begin()));
+    EXPECT_EQ(result.GetTile(), tile);
+    EXPECT_TRUE(mock_server_client_->Verify());
+  }
 }
 
 }  // namespace

--- a/tests/functional/utils/DefaultResponses.h
+++ b/tests/functional/utils/DefaultResponses.h
@@ -19,9 +19,15 @@
 
 #pragma once
 
+#include <random>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
 
 #include "generated/model/Api.h"
 #include "olp/dataservice/read/model/Partitions.h"
@@ -98,6 +104,20 @@ class DefaultResponses {
     olp::dataservice::read::model::Partitions partitions;
     partitions.SetPartitions(partitions_vect);
     return partitions;
+  }
+
+  static std::string GenerateDataHandle(const std::string& partition) {
+    return partition + "-data-handle";
+  }
+
+  static std::string GenerateData() {
+    std::string result =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    std::random_device device;
+    std::mt19937 generator(device());
+    std::shuffle(result.begin(), result.end(), generator);
+
+    return result;
   }
 };
 

--- a/tests/functional/utils/MockServerHelper.cpp
+++ b/tests/functional/utils/MockServerHelper.cpp
@@ -66,6 +66,27 @@ void MockServerHelper::MockLookupPlatformApiResponse(
       std::move(data), "/lookup/v1/platform/apis");
 }
 
+void MockServerHelper::MockGetResponse(const std::string& layer,
+                                       const std::string& data_handle,
+                                       const std::string& data) {
+  mock_server_client_.MockResponse("GET",
+                                   "/blob/v1/catalogs/" + catalog_ +
+                                       "/layers/" + layer + "/data/" +
+                                       data_handle,
+                                   data);
+}
+
+void MockServerHelper::MockGetResponse(const std::string& layer,
+                                       olp::geo::TileKey tile, int64_t version,
+                                       const std::string& tree) {
+  mock_server_client_.MockResponse("GET",
+                                   "/query/v1/catalogs/" + catalog_ +
+                                       "/layers/" + layer + "/versions/" +
+                                       std::to_string(version) + "/quadkeys/" +
+                                       tile.ToHereTile() + "/depths/4",
+                                   tree);
+}
+
 bool MockServerHelper::Verify() {
   return mock_server_client_.VerifySequence(paths_);
 }

--- a/tests/functional/utils/MockServerHelper.h
+++ b/tests/functional/utils/MockServerHelper.h
@@ -30,6 +30,9 @@
 #include "generated/serializer/VersionResponseSerializer.h"
 #include "generated/serializer/JsonSerializer.h"
 // clang-format on
+#include "olp/core/geo/tiling/TileKey.h"
+#include "olp/dataservice/read/model/Partitions.h"
+#include "olp/dataservice/read/model/VersionResponse.h"
 
 namespace mockserver {
 /**
@@ -86,6 +89,30 @@ class MockServerHelper {
    * @param Apis to be returned by server.
    */
   void MockLookupPlatformApiResponse(olp::dataservice::read::model::Apis data);
+
+  /**
+   * @brief Mock get blob data request.
+   *
+   * @note keep order of mocks for future use of Verify function.
+   *
+   * @param layer blob corresponds to.
+   * @param data_handle of the blob.
+   * @param data of the blob.
+   */
+  void MockGetResponse(const std::string& layer, const std::string& data_handle,
+                       const std::string& data);
+
+  /**
+   * @brief Mock get quad tree index request.
+   *
+   * @note keep order of mocks for future use of Verify function.
+   *
+   * @param layer quad tree corresponds to.
+   * @param tile root of the tree.
+   * @param tree json  response.
+   */
+  void MockGetResponse(const std::string& layer, olp::geo::TileKey tile,
+                       int64_t version, const std::string& tree);
 
   /**
    * @brief Verify if all calls were called on server and its order.


### PR DESCRIPTION
Added GenerateQuadTreeResponse() mock server default response.
Added functional test for GetAggregatedData using mock server.

Resolves: OLPEDGE-1933

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>