### PR TITLE
Fix type conversion issue

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.cpp
@@ -208,7 +208,7 @@ void QuadTreeIndex::CreateBlob(olp::geo::TileKey root, int depth,
 
   data_->root_tilekey = root.ToQuadKey64();
   data_->blob_version = 0;
-  data_->depth = static_cast<uint8_t>(depth);
+  data_->depth = static_cast<int8_t>(depth);
   data_->subkey_count = static_cast<uint16_t>(subs.size());
   data_->parent_count = static_cast<uint8_t>(parents.size());
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.h
@@ -88,7 +88,7 @@ class QuadTreeIndex {
   struct DataHeader {
     std::uint64_t root_tilekey;
     std::uint16_t blob_version;
-    std::uint8_t depth;
+    std::int8_t depth;
     std::uint8_t parent_count;
     std::uint16_t subkey_count;
     SubEntry entries[1];


### PR DESCRIPTION
Fix type conversion issue in QuadTreeIndex by changing
DataHeader::depth to unsgined type

Resolves: OLPEDGE-2033

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>