### PR TITLE
Move some function bodies to cpp

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
@@ -285,8 +285,8 @@ class AUTHENTICATION_API AuthenticationClient {
   // Non-copyable but movable
   AuthenticationClient(const AuthenticationClient&) = delete;
   AuthenticationClient& operator=(const AuthenticationClient&) = delete;
-  AuthenticationClient(AuthenticationClient&&) noexcept = default;
-  AuthenticationClient& operator=(AuthenticationClient&&) noexcept = default;
+  AuthenticationClient(AuthenticationClient&&) noexcept;
+  AuthenticationClient& operator=(AuthenticationClient&&) noexcept;
 
   /**
    * @brief Signs in with your HERE Account client credentials and requests

--- a/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
@@ -37,6 +37,11 @@ AuthenticationClient::AuthenticationClient(AuthenticationSettings settings)
 
 AuthenticationClient::~AuthenticationClient() = default;
 
+AuthenticationClient::AuthenticationClient(AuthenticationClient&&) noexcept =
+    default;
+AuthenticationClient& AuthenticationClient::operator=(
+    AuthenticationClient&&) noexcept = default;
+
 client::CancellationToken AuthenticationClient::SignInClient(
     AuthenticationCredentials credentials, SignInProperties properties,
     SignInClientCallback callback) {


### PR DESCRIPTION
Move operator= and move constructor of AuthenticationClient class
to cpp file to prevent 'use of undeclared AuthenticationClientImpl'
error.

Resolves: OLPEDGE-2079

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>