### PR TITLE
Removed or marked as private deprecated elements.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/HRN.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/HRN.h
@@ -49,15 +49,6 @@ class CORE_API HRN {
    * The passed string must start with `hrn:`.
    *
    * @param input The `HRN` string.
-   */
-  explicit HRN(const std::string& input);
-
-  /**
-   * @brief Creates the `HRN` instance from a string.
-   *
-   * The passed string must start with `hrn:`.
-   *
-   * @param input The `HRN` string.
    *
    * @return The `HRN` instance created from the string.
    */
@@ -74,7 +65,19 @@ class CORE_API HRN {
    */
   static std::unique_ptr<HRN> UniqueFromString(const std::string& input);
 
+  /**
+   * @brief Default constructor which creates an empty invalid HRN.
+   */
   HRN() = default;
+
+  /**
+   * @brief Creates the `HRN` instance from a string.
+   *
+   * The passed string must start with `hrn:`.
+   *
+   * @param input The `HRN` string.
+   */
+  explicit HRN(const std::string& input);
 
   /**
    * @brief Checks whether the values of the `HRN` parameter are
@@ -135,79 +138,116 @@ class CORE_API HRN {
   std::string ToCatalogHRNString() const;
 
   /**
-   * @brief The partition of the HRN.
+   * @brief Returns the partitions of this HRN.
    *
-   * Must be valid when `ServiceType == Data` or when `ServiceType == Pipeline`.
+   * @note Must be valid when `ServiceType == Data` or when `ServiceType ==
+   * Pipeline`.
    *
-   * @deprecated This field will be marked as private by 05.2020.
+   * @return The partition of this HRN.
    */
-  std::string partition;
-  /**
-   * @brief The service type of the HRN.
-   *
-   * @deprecated This field will be marked as private by 05.2020.
-   */
-  ServiceType service{ServiceType::Unknown};
-  /**
-   * @brief The region of the HRN.
-   *
-   * @deprecated This field will be marked as private by 05.2020.
-   */
-  std::string region;
-  /**
-   * @brief The account of the HRN.
-   *
-   * @deprecated This field will be marked as private by 05.2020.
-   */
-  std::string account;
-  /**
-   * @brief The catalog ID.
-   *
-   * Must be valid when `ServiceType == Data`.
-   *
-   * @deprecated This field will be marked as private by 05.2020.
-   */
-  std::string catalogId;
-  /**
-   * @brief (Optional) The layer ID.
-   *
-   * @deprecated This field will be marked as private by 05.2020.
-   */
-  std::string layerId;
+  const std::string& GetPartition() const { return partition_; }
 
   /**
-   * @brief The group ID.
+   * @brief Returns the service type of this HRN.
    *
-   * Must be valid if `ServiceType == Schema`.
-   *
-   * @deprecated This field will be marked as private by 05.2020.
+   * @return The service type enum.
    */
-  std::string groupId;
-  /**
-   * @brief The schema name.
-   *
-   * Must be valid if `ServiceType == Schema`.
-   *
-   * @deprecated This field will be marked as private by 05.2020.
-   */
-  std::string schemaName;
-  /**
-   * @brief The catalog version.
-   *
-   * Must be valid if `ServiceType == Schema`.
-   *
-   * @deprecated This field will be marked as private by 05.2020.
-   */
-  std::string version;
+  ServiceType GetService() const { return service_; }
 
   /**
-   * @brief The pipeline ID. Valid if `HRNServiceType == Pipeline`.
+   * @brief Returns the region of this HRN.
    *
-   * Must be valid if `ServiceType == Schema`.
-   *
-   * @deprecated This field will be marked as private by 05.2020.
+   * @return The region of this HRN.
    */
-  std::string pipelineId;
+  const std::string& GetRegion() const { return region_; }
+
+  /**
+   * @brief Returns the account of this HRN.
+   *
+   * @return The account associated with this HRN.
+   */
+  const std::string& GetAccount() const { return account_; }
+
+  /**
+   * @brief Returns the catalog ID.
+   *
+   * @note Must be valid in case `ServiceType == Data`.
+   *
+   * @return The catalog ID.
+   */
+  const std::string& GetCatalogId() const { return catalog_id_; }
+
+  /**
+   * @brief Returns the layer ID.
+   *
+   * @note This parameter is optional and not always used.
+   *
+   * @return The layer ID or a empty string if not set.
+   */
+  const std::string& GetLayerId() const { return layer_id_; }
+
+  /**
+   * @brief Returns the group ID.
+   *
+   * @return The group ID or a empty string in case `ServiceType != Schema`.
+   */
+  const std::string& GetGroupId() const { return group_id_; }
+
+  /**
+   * @brief Retruns the schema name.
+   *
+   * @return The schema name or a empty string in case `ServiceType != Schema`.
+   */
+  const std::string& GetSchemaName() const { return schema_name_; }
+
+  /**
+   * @brief Returns the catalog version.
+   *
+   * @return The catalog version or a empty string in case `ServiceType !=
+   * Schema`.
+   */
+  const std::string& GetVersion() const { return version_; }
+
+  /**
+   * @brief Returns the pipeline ID.
+   *
+   * @return The pipeline ID or and empty string in case `HRNServiceType !=
+   * Pipeline` and `ServiceType != Schema`.
+   */
+  const std::string& GetPipelineId() const { return pipeline_id_; }
+
+ private:
+  /// The partition of the HRN. Must be valid when `ServiceType == Data` or when
+  /// `ServiceType == Pipeline`.
+  std::string partition_;
+
+  /// The service type of the HRN.
+  ServiceType service_{ServiceType::Unknown};
+
+  /// The region of the HRN.
+  std::string region_;
+
+  /// The account of the HRN.
+  std::string account_;
+
+  /// The catalog ID. Must be valid when `ServiceType == Data`.
+  std::string catalog_id_;
+
+  /// (Optional) The layer ID.
+  std::string layer_id_;
+
+  /// The group ID. Must be valid if `ServiceType == Schema`.
+  std::string group_id_;
+
+  /// The schema name. Must be valid if `ServiceType == Schema`.
+  std::string schema_name_;
+
+  /// The catalog version. Must be valid if `ServiceType == Schema`.
+  std::string version_;
+
+  /// The pipeline ID. Valid if `HRNServiceType == Pipeline`. Must be valid if
+  /// `ServiceType == Schema`.
+  std::string pipeline_id_;
 };
 
 }  // namespace client

--- a/olp-cpp-sdk-core/src/client/HRN.cpp
+++ b/olp-cpp-sdk-core/src/client/HRN.cpp
@@ -40,24 +40,24 @@ namespace client {
 std::string HRN::ToString() const {
   std::ostringstream ret;
   const auto generic_part =
-      kSeparator + region + kSeparator + account + kSeparator;
-  ret << kHrnTag << partition << kSeparator;
+      kSeparator + region_ + kSeparator + account_ + kSeparator;
+  ret << kHrnTag << partition_ << kSeparator;
 
-  switch (service) {
+  switch (service_) {
     case ServiceType::Data: {
-      ret << kDataTag << generic_part << catalogId;
-      if (!layerId.empty()) {
-        ret << kSeparator << layerId;
+      ret << kDataTag << generic_part << catalog_id_;
+      if (!layer_id_.empty()) {
+        ret << kSeparator << layer_id_;
       }
       break;
     }
     case ServiceType::Schema: {
-      ret << kSchemaTag << generic_part << groupId << kSeparator << schemaName
-          << kSeparator << version;
+      ret << kSchemaTag << generic_part << group_id_ << kSeparator
+          << schema_name_ << kSeparator << version_;
       break;
     }
     case ServiceType::Pipeline: {
-      ret << kPipelineTag << generic_part << pipelineId;
+      ret << kPipelineTag << generic_part << pipeline_id_;
       break;
     }
     default: {
@@ -70,13 +70,13 @@ std::string HRN::ToString() const {
 }
 
 std::string HRN::ToCatalogHRNString() const {
-  if (service != ServiceType::Data) {
+  if (service_ != ServiceType::Data) {
     OLP_SDK_LOG_WARNING_F(kLogTag, "ToCatalogHRNString: ServiceType != Data");
     return {};
   }
 
-  return kHrnTag + partition + kSeparator + kDataTag + kSeparator + region +
-         kSeparator + account + kSeparator + catalogId;
+  return kHrnTag + partition_ + kSeparator + kDataTag + kSeparator + region_ +
+         kSeparator + account_ + kSeparator + catalog_id_;
 }
 
 HRN::HRN(const std::string& input) {
@@ -93,17 +93,17 @@ HRN::HRN(const std::string& input) {
   }
 
   if (tokenizer.HasNext()) {
-    partition = tokenizer.Next();
+    partition_ = tokenizer.Next();
   }
 
   if (tokenizer.HasNext()) {
     auto service_str = tokenizer.Next();
     if (service_str == kDataTag) {
-      service = ServiceType::Data;
+      service_ = ServiceType::Data;
     } else if (service_str == kSchemaTag) {
-      service = ServiceType::Schema;
+      service_ = ServiceType::Schema;
     } else if (service_str == kPipelineTag) {
-      service = ServiceType::Pipeline;
+      service_ = ServiceType::Pipeline;
     } else {
       OLP_SDK_LOG_WARNING_F(kLogTag, "Constructor: invalid service=%s",
                             service_str.c_str());
@@ -112,38 +112,38 @@ HRN::HRN(const std::string& input) {
   }
 
   if (tokenizer.HasNext()) {
-    region = tokenizer.Next();
+    region_ = tokenizer.Next();
   }
 
   if (tokenizer.HasNext()) {
-    account = tokenizer.Next();
+    account_ = tokenizer.Next();
   }
 
-  switch (service) {
+  switch (service_) {
     case ServiceType::Data: {
       if (tokenizer.HasNext()) {
-        catalogId = tokenizer.Next();
+        catalog_id_ = tokenizer.Next();
       }
       if (tokenizer.HasNext()) {
-        layerId = tokenizer.Tail();
+        layer_id_ = tokenizer.Tail();
       }
       break;
     }
     case ServiceType::Schema: {
       if (tokenizer.HasNext()) {
-        groupId = tokenizer.Next();
+        group_id_ = tokenizer.Next();
       }
       if (tokenizer.HasNext()) {
-        schemaName = tokenizer.Next();
+        schema_name_ = tokenizer.Next();
       }
       if (tokenizer.HasNext()) {
-        version = tokenizer.Tail();
+        version_ = tokenizer.Tail();
       }
       break;
     }
     case ServiceType::Pipeline: {
       if (tokenizer.HasNext()) {
-        pipelineId = tokenizer.Tail();
+        pipeline_id_ = tokenizer.Tail();
       }
       break;
     }
@@ -154,21 +154,21 @@ HRN::HRN(const std::string& input) {
 
 bool HRN::operator==(const HRN& rhs) const {
   // Common sections need to match for all types
-  if (partition != rhs.partition || service != rhs.service ||
-      region != rhs.region || account != rhs.account) {
+  if (partition_ != rhs.partition_ || service_ != rhs.service_ ||
+      region_ != rhs.region_ || account_ != rhs.account_) {
     return false;
   }
 
-  switch (service) {
+  switch (service_) {
     case ServiceType::Data: {
-      return (catalogId == rhs.catalogId && layerId == rhs.layerId);
+      return (catalog_id_ == rhs.catalog_id_ && layer_id_ == rhs.layer_id_);
     }
     case ServiceType::Schema: {
-      return (groupId == rhs.groupId && schemaName == rhs.schemaName &&
-              version == rhs.version);
+      return (group_id_ == rhs.group_id_ && schema_name_ == rhs.schema_name_ &&
+              version_ == rhs.version_);
     }
     case ServiceType::Pipeline: {
-      return (pipelineId == rhs.pipelineId);
+      return (pipeline_id_ == rhs.pipeline_id_);
     }
     default: { return false; }
   }
@@ -177,17 +177,17 @@ bool HRN::operator==(const HRN& rhs) const {
 bool HRN::operator!=(const HRN& rhs) const { return !operator==(rhs); }
 
 bool HRN::IsNull() const {
-  switch (service) {
+  switch (service_) {
     case ServiceType::Data:
       // Note: region, account, layerId fields are optional.
-      return partition.empty() || catalogId.empty();
+      return partition_.empty() || catalog_id_.empty();
     case ServiceType::Schema:
       // Note: region, account fields are optional.
-      return partition.empty() || groupId.empty() || schemaName.empty() ||
-             version.empty();
+      return partition_.empty() || group_id_.empty() || schema_name_.empty() ||
+             version_.empty();
     case ServiceType::Pipeline:
       // Note: region, account fields are optional.
-      return partition.empty() || pipelineId.empty();
+      return partition_.empty() || pipeline_id_.empty();
     default:
       return true;
   }

--- a/olp-cpp-sdk-core/tests/client/HRNTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/HRNTest.cpp
@@ -160,31 +160,31 @@ TEST(HRNTest, Parsing) {
   {
     SCOPED_TRACE("Valid Catalog HRN");
     HRN hrn("hrn:here:data:EU:test:hereos-internal-test-v2");
-    EXPECT_EQ(hrn.partition, "here");
-    EXPECT_EQ(hrn.service, HRN::ServiceType::Data);
-    EXPECT_EQ(hrn.region, "EU");
-    EXPECT_EQ(hrn.account, "test");
-    EXPECT_EQ(hrn.catalogId, "hereos-internal-test-v2");
+    EXPECT_EQ(hrn.GetPartition(), "here");
+    EXPECT_EQ(hrn.GetService(), HRN::ServiceType::Data);
+    EXPECT_EQ(hrn.GetRegion(), "EU");
+    EXPECT_EQ(hrn.GetAccount(), "test");
+    EXPECT_EQ(hrn.GetCatalogId(), "hereos-internal-test-v2");
   }
   {
     SCOPED_TRACE("Valid Schema HRN");
     HRN hrn("hrn:here:schema:CH:test:group_id:artifact_id:version");
-    EXPECT_EQ(hrn.partition, "here");
-    EXPECT_EQ(hrn.service, HRN::ServiceType::Schema);
-    EXPECT_EQ(hrn.region, "CH");
-    EXPECT_EQ(hrn.account, "test");
-    EXPECT_EQ(hrn.groupId, "group_id");
-    EXPECT_EQ(hrn.schemaName, "artifact_id");
-    EXPECT_EQ(hrn.version, "version");
+    EXPECT_EQ(hrn.GetPartition(), "here");
+    EXPECT_EQ(hrn.GetService(), HRN::ServiceType::Schema);
+    EXPECT_EQ(hrn.GetRegion(), "CH");
+    EXPECT_EQ(hrn.GetAccount(), "test");
+    EXPECT_EQ(hrn.GetGroupId(), "group_id");
+    EXPECT_EQ(hrn.GetSchemaName(), "artifact_id");
+    EXPECT_EQ(hrn.GetVersion(), "version");
   }
   {
     SCOPED_TRACE("Valid Pipeline HRN");
     HRN hrn("hrn:here:pipeline:US:test:test_pipeline");
-    EXPECT_EQ(hrn.partition, "here");
-    EXPECT_EQ(hrn.service, HRN::ServiceType::Pipeline);
-    EXPECT_EQ(hrn.region, "US");
-    EXPECT_EQ(hrn.account, "test");
-    EXPECT_EQ(hrn.pipelineId, "test_pipeline");
+    EXPECT_EQ(hrn.GetPartition(), "here");
+    EXPECT_EQ(hrn.GetService(), HRN::ServiceType::Pipeline);
+    EXPECT_EQ(hrn.GetRegion(), "US");
+    EXPECT_EQ(hrn.GetAccount(), "test");
+    EXPECT_EQ(hrn.GetPipelineId(), "test_pipeline");
   }
 }
 

--- a/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
@@ -60,7 +60,6 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApi(
     client::CancellationContext cancellation_context, std::string service,
     std::string service_version, FetchOptions options,
     client::OlpClientSettings settings) {
-
   // This mutex is required to avoid concurrent requests to online.
   repository::NamedMutex mutex(catalog.ToString());
   std::unique_lock<repository::NamedMutex> lock(mutex, std::defer_lock);
@@ -93,7 +92,7 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApi(
                      "LookupApi(%s/%s) cache miss, requesting, hrn='%s'",
                      service.c_str(), service_version.c_str(), hrn.c_str());
 
-  const auto& base_url = GetDatastoreServerUrl(catalog.partition);
+  const auto& base_url = GetDatastoreServerUrl(catalog.GetPartition());
   client::OlpClient client;
   client.SetBaseUrl(base_url);
   // Do not move settings, we still need them later on!

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/IndexLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/IndexLayerClient.h
@@ -59,7 +59,7 @@ using UpdateIndexCallback = std::function<void(UpdateIndexResponse response)>;
 /**
  * @brief Client that is responsible for writing data to
  * a HERE platform index layer.
- * 
+ *
  */
 class DATASERVICE_WRITE_API IndexLayerClient {
  public:
@@ -71,12 +71,6 @@ class DATASERVICE_WRITE_API IndexLayerClient {
    * instance.
    */
   IndexLayerClient(client::HRN catalog, client::OlpClientSettings settings);
-
-  /// @brief Cancels all pending requests.
-  /// @deprecated Use \ref CancelPendingRequests intead.
-  OLP_SDK_DEPRECATED(
-      "Use CancelPendingRequests instead. Will be removed in 05.2020")
-  void CancelAll();
 
   /**
    * @brief Cancels all the ongoing operations that this client started.

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VersionedLayerClient.h
@@ -175,17 +175,6 @@ class DATASERVICE_WRITE_API VersionedLayerClient {
                                              CancelBatchCallback callback);
 
   /**
-   * @brief Cancel all pending operations started by this client. This will only
-   * cancel operations that have been started, so you will need to call
-   * CancelBatch after this if you have a batch operation in progress
-   * (StartBatch successfully completed).
-   * @deprecated Use \ref CancelPendingRequests intead.
-   */
-  OLP_SDK_DEPRECATED(
-      "Use CancelPendingRequests instead. Will be removed in 05.2020")
-  void CancelAll();
-
-  /**
    * @brief Cancels all the ongoing operations that this client started.
    *
    * Returns instantly and does not wait for the callbacks.

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/VolatileLayerClient.h
@@ -19,8 +19,8 @@
 
 #pragma once
 
-#include <vector>
 #include <memory>
+#include <vector>
 
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiNoResult.h>
@@ -79,7 +79,8 @@ using CompleteBatchCallback =
     std::function<void(CompleteBatchResponse response)>;
 
 /**
- * @brief Client responsible for writing data into a HERE platform volatile layer.
+ * @brief Client responsible for writing data into a HERE platform volatile
+ * layer.
  */
 class DATASERVICE_WRITE_API VolatileLayerClient {
  public:
@@ -90,14 +91,6 @@ class DATASERVICE_WRITE_API VolatileLayerClient {
    * instance. Volatile.
    */
   VolatileLayerClient(client::HRN catalog, client::OlpClientSettings settings);
-
-  /**
-   * @brief Cancel all pending requests.
-   * @deprecated Use \ref CancelPendingRequests intead.
-   */
-  OLP_SDK_DEPRECATED(
-      "Use CancelPendingRequests instead. Will be removed in 05.2020")
-  void CancelAll();
 
   /**
    * @brief Cancels all the ongoing operations that this client started.

--- a/olp-cpp-sdk-dataservice-write/src/IndexLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/IndexLayerClient.cpp
@@ -28,8 +28,6 @@ IndexLayerClient::IndexLayerClient(client::HRN catalog,
                                    client::OlpClientSettings settings)
     : impl_(std::make_shared<IndexLayerClientImpl>(catalog, settings)) {}
 
-void IndexLayerClient::CancelAll() { impl_->CancelAll(); }
-
 void IndexLayerClient::CancelPendingRequests() {
   impl_->CancelPendingRequests();
 }

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClient.cpp
@@ -80,8 +80,6 @@ olp::client::CancellationToken VersionedLayerClient::CancelBatch(
   return impl_->CancelBatch(pub, std::move(callback));
 }
 
-void VersionedLayerClient::CancelAll() { impl_->CancelAll(); }
-
 void VersionedLayerClient::CancelPendingRequests() {
   impl_->CancelPendingRequests();
 }

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.cpp
@@ -57,7 +57,7 @@ VersionedLayerClientImpl::VersionedLayerClientImpl(
       init_in_progress_(false) {}
 
 VersionedLayerClientImpl::~VersionedLayerClientImpl() {
-  CancelAll();
+  tokenList_.CancelAll();
   pending_requests_->CancelAllAndWait();
 }
 
@@ -497,9 +497,10 @@ olp::client::CancellationToken VersionedLayerClientImpl::CancelBatch(
   return token;
 }
 
-void VersionedLayerClientImpl::CancelAll() { tokenList_.CancelAll(); }
-
-void VersionedLayerClientImpl::CancelPendingRequests() { CancelAll(); }
+void VersionedLayerClientImpl::CancelPendingRequests() {
+  pending_requests_->CancelAll();
+  tokenList_.CancelAll();
+}
 
 olp::client::CancellableFuture<PublishPartitionDataResponse>
 VersionedLayerClientImpl::PublishToBatch(

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.h
@@ -89,8 +89,6 @@ class VersionedLayerClientImpl
   client::CancellationToken CancelBatch(const model::Publication& pub,
                                         CancelBatchCallback callback);
 
-  void CancelAll();
-
   void CancelPendingRequests();
 
   client::CancellableFuture<PublishPartitionDataResponse> PublishToBatch(

--- a/olp-cpp-sdk-dataservice-write/src/VolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VolatileLayerClient.cpp
@@ -29,8 +29,6 @@ VolatileLayerClient::VolatileLayerClient(client::HRN catalog,
     : impl_(std::make_shared<VolatileLayerClientImpl>(std::move(catalog),
                                                       std::move(settings))) {}
 
-void VolatileLayerClient::CancelAll() { impl_->CancelAll(); }
-
 void VolatileLayerClient::CancelPendingRequests() {
   impl_->CancelPendingRequests();
 }


### PR DESCRIPTION
This commit takes care of the deprecated elements which were marked as
to be removed or move to private by 05.2020.

This includes the following changes:

 * Moved all members of HRN class to private and adapted to coding style
 * Removed dataservice::write::VersionedLayerClient::CancelAll()
 * Removed dataservice::write::VolatileLayerClient::CancelAll()
 * Removed dataservice::write::IndexLayerClient::CancelAll()

Relates-To: OLPEDGE-1457

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>