### PR TITLE
Change hard-coded values to HttpStatusCodes

### DIFF
--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientTest.cpp
@@ -34,6 +34,7 @@
 #include <olp/core/client/OlpClient.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/http/HttpStatusCode.h>
 #include <olp/dataservice/write/StreamLayerClient.h>
 #include <olp/dataservice/write/model/PublishDataRequest.h>
 #include <olp/dataservice/write/model/PublishSdiiRequest.h>
@@ -41,6 +42,7 @@
 #include "Utils.h"
 
 namespace model = olp::dataservice::write::model;
+namespace http = olp::http;
 using olp::dataservice::write::PublishDataResponse;
 using olp::dataservice::write::PublishSdiiResponse;
 using olp::dataservice::write::StreamLayerClient;
@@ -119,7 +121,7 @@ template <typename T>
 void PublishFailureAssertions(
     const olp::client::ApiResponse<T, olp::client::ApiError>& result) {
   EXPECT_FALSE(result.IsSuccessful());
-  EXPECT_NE(result.GetError().GetHttpStatusCode(), 200);
+  EXPECT_NE(result.GetError().GetHttpStatusCode(), http::HttpStatusCode::OK);
   // EXPECT_FALSE(result.GetError().GetMessage().empty());
 }
 
@@ -274,9 +276,11 @@ TEST_F(DataserviceWriteStreamLayerClientTest, PublishDataCancel) {
       PublishDataRequest().WithData(data_).WithLayerId(GetTestLayer()));
 
   std::thread([cancel_future]() {
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(http::HttpStatusCode::OK));
     cancel_future.GetCancellationToken().Cancel();
-  }).detach();
+  })
+      .detach();
 
   auto response = cancel_future.GetFuture().get();
 
@@ -301,7 +305,8 @@ TEST_F(DataserviceWriteStreamLayerClientTest, PublishDataCancelLongDelay) {
   std::thread([cancel_future]() {
     std::this_thread::sleep_for(std::chrono::milliseconds(1200));
     cancel_future.GetCancellationToken().Cancel();
-  }).detach();
+  })
+      .detach();
 
   auto response = cancel_future.GetFuture().get();
 
@@ -325,9 +330,11 @@ TEST_F(DataserviceWriteStreamLayerClientTest,
       PublishDataRequest().WithData(data_).WithLayerId(GetTestLayer()));
 
   std::thread([cancel_future]() {
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(http::HttpStatusCode::OK));
     cancel_future.GetCancellationToken().Cancel();
-  }).detach();
+  })
+      .detach();
 
   std::this_thread::sleep_for(std::chrono::milliseconds(400));
   auto response = cancel_future.GetFuture().get();
@@ -357,7 +364,8 @@ TEST_F(DataserviceWriteStreamLayerClientTest,
   std::thread([cancel_future]() {
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
     cancel_future.GetCancellationToken().Cancel();
-  }).detach();
+  })
+      .detach();
 
   auto response = cancel_future.GetFuture().get();
 
@@ -587,9 +595,11 @@ TEST_F(DataserviceWriteStreamLayerClientTest, PublishSdiiCancel) {
                                .WithLayerId(GetTestLayerSdii()));
 
   std::thread([cancel_future]() {
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(http::HttpStatusCode::OK));
     cancel_future.GetCancellationToken().Cancel();
-  }).detach();
+  })
+      .detach();
 
   auto response = cancel_future.GetFuture().get();
 
@@ -616,7 +626,8 @@ TEST_F(DataserviceWriteStreamLayerClientTest, PublishSdiiCancelLongDelay) {
   std::thread([cancel_future]() {
     std::this_thread::sleep_for(std::chrono::milliseconds(1200));
     cancel_future.GetCancellationToken().Cancel();
-  }).detach();
+  })
+      .detach();
 
   auto response = cancel_future.GetFuture().get();
 

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
@@ -29,8 +29,8 @@
 
 namespace {
 
-using namespace olp::dataservice::write;
-using namespace olp::dataservice::write::model;
+namespace write = olp::dataservice::write;
+namespace model = olp::dataservice::write::model;
 
 const std::string kEndpoint = "endpoint";
 const std::string kAppid = "dataservice_write_test_appid";
@@ -58,7 +58,7 @@ class DataserviceWriteVersionedLayerClientTest : public ::testing::Test {
 
   void TearDown() override { client_ = nullptr; }
 
-  std::shared_ptr<VersionedLayerClient> CreateVersionedLayerClient() {
+  std::shared_ptr<write::VersionedLayerClient> CreateVersionedLayerClient() {
     auto network = s_network;
 
     const auto key_id = CustomParameters::getArgument(kAppid);
@@ -78,11 +78,11 @@ class DataserviceWriteVersionedLayerClientTest : public ::testing::Test {
     settings.authentication_settings = auth_client_settings;
     settings.network_request_handler = network;
 
-    return std::make_shared<VersionedLayerClient>(
+    return std::make_shared<write::VersionedLayerClient>(
         olp::client::HRN{CustomParameters::getArgument(kCatalog)}, settings);
   }
 
-  std::shared_ptr<VersionedLayerClient> client_;
+  std::shared_ptr<write::VersionedLayerClient> client_;
 };
 
 // Static network instance is necessary as it needs to outlive any created
@@ -93,8 +93,9 @@ std::shared_ptr<olp::http::Network>
 
 TEST_F(DataserviceWriteVersionedLayerClientTest, StartBatchInvalid) {
   auto versioned_client = CreateVersionedLayerClient();
-  auto response =
-      versioned_client->StartBatch(StartBatchRequest()).GetFuture().get();
+  auto response = versioned_client->StartBatch(model::StartBatchRequest())
+                      .GetFuture()
+                      .get();
 
   ASSERT_FALSE(response.IsSuccessful());
   ASSERT_FALSE(response.GetResult().GetId());
@@ -122,7 +123,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, StartBatchInvalid) {
 TEST_F(DataserviceWriteVersionedLayerClientTest, StartBatch) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response = versioned_client
-                      ->StartBatch(StartBatchRequest().WithLayers(
+                      ->StartBatch(model::StartBatchRequest().WithLayers(
                           {CustomParameters::getArgument(kVersionedLayer)}))
                       .GetFuture()
                       .get();
@@ -170,7 +171,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, StartBatch) {
 TEST_F(DataserviceWriteVersionedLayerClientTest, DeleteClient) {
   auto versioned_client = CreateVersionedLayerClient();
   auto fut = versioned_client
-                 ->StartBatch(StartBatchRequest().WithLayers(
+                 ->StartBatch(model::StartBatchRequest().WithLayers(
                      {CustomParameters::getArgument(kVersionedLayer)}))
                  .GetFuture();
   versioned_client = nullptr;
@@ -207,7 +208,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, GetBaseVersion) {
 TEST_F(DataserviceWriteVersionedLayerClientTest, CancelBatch) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response = versioned_client
-                      ->StartBatch(StartBatchRequest().WithLayers(
+                      ->StartBatch(model::StartBatchRequest().WithLayers(
                           {CustomParameters::getArgument(kVersionedLayer)}))
                       .GetFuture()
                       .get();
@@ -245,7 +246,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, CancelAllBatch) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response_future =
       versioned_client
-          ->StartBatch(StartBatchRequest().WithLayers(
+          ->StartBatch(model::StartBatchRequest().WithLayers(
               {CustomParameters::getArgument(kVersionedLayer)}))
           .GetFuture();
 
@@ -259,7 +260,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, CancelAllBatch) {
 TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatch) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response = versioned_client
-                      ->StartBatch(StartBatchRequest().WithLayers(
+                      ->StartBatch(model::StartBatchRequest().WithLayers(
                           {CustomParameters::getArgument(kVersionedLayer)}))
                       .GetFuture()
                       .get();
@@ -281,7 +282,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatch) {
       versioned_client
           ->PublishToBatch(
               response.GetResult(),
-              PublishPartitionDataRequest()
+              model::PublishPartitionDataRequest()
                   .WithData(
                       std::make_shared<std::vector<unsigned char>>(20, 0x30))
                   .WithLayerId(CustomParameters::getArgument(kVersionedLayer))
@@ -322,7 +323,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatch) {
 TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatchDeleteClient) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response = versioned_client
-                      ->StartBatch(StartBatchRequest().WithLayers(
+                      ->StartBatch(model::StartBatchRequest().WithLayers(
                           {CustomParameters::getArgument(kVersionedLayer)}))
                       .GetFuture()
                       .get();
@@ -344,7 +345,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatchDeleteClient) {
       versioned_client
           ->PublishToBatch(
               response.GetResult(),
-              PublishPartitionDataRequest()
+              model::PublishPartitionDataRequest()
                   .WithData(
                       std::make_shared<std::vector<unsigned char>>(20, 0x30))
                   .WithLayerId(CustomParameters::getArgument(kVersionedLayer))
@@ -355,7 +356,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatchDeleteClient) {
       versioned_client
           ->PublishToBatch(
               response.GetResult(),
-              PublishPartitionDataRequest()
+              model::PublishPartitionDataRequest()
                   .WithData(
                       std::make_shared<std::vector<unsigned char>>(20, 0x31))
                   .WithLayerId(CustomParameters::getArgument(kVersionedLayer))
@@ -404,7 +405,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatchDeleteClient) {
 TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatchMulti) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response = versioned_client
-                      ->StartBatch(StartBatchRequest().WithLayers(
+                      ->StartBatch(model::StartBatchRequest().WithLayers(
                           {CustomParameters::getArgument(kVersionedLayer)}))
                       .GetFuture()
                       .get();
@@ -426,7 +427,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatchMulti) {
       versioned_client
           ->PublishToBatch(
               response.GetResult(),
-              PublishPartitionDataRequest()
+              model::PublishPartitionDataRequest()
                   .WithData(
                       std::make_shared<std::vector<unsigned char>>(20, 0x30))
                   .WithLayerId(CustomParameters::getArgument(kVersionedLayer))
@@ -437,7 +438,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatchMulti) {
       versioned_client
           ->PublishToBatch(
               response.GetResult(),
-              PublishPartitionDataRequest()
+              model::PublishPartitionDataRequest()
                   .WithData(
                       std::make_shared<std::vector<unsigned char>>(20, 0x31))
                   .WithLayerId(CustomParameters::getArgument(kVersionedLayer))
@@ -482,7 +483,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatchMulti) {
 TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatchCancel) {
   auto versioned_client = CreateVersionedLayerClient();
   auto response = versioned_client
-                      ->StartBatch(StartBatchRequest().WithLayers(
+                      ->StartBatch(model::StartBatchRequest().WithLayers(
                           {CustomParameters::getArgument(kVersionedLayer)}))
                       .GetFuture()
                       .get();
@@ -504,7 +505,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, PublishToBatchCancel) {
       versioned_client
           ->PublishToBatch(
               response.GetResult(),
-              PublishPartitionDataRequest()
+              model::PublishPartitionDataRequest()
                   .WithData(
                       std::make_shared<std::vector<unsigned char>>(20, 0x30))
                   .WithLayerId(CustomParameters::getArgument(kVersionedLayer))
@@ -539,7 +540,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, CheckDataExists) {
   auto fut =
       versioned_client
           ->CheckDataExists(
-              CheckDataExistsRequest()
+              model::CheckDataExistsRequest()
                   .WithLayerId(CustomParameters::getArgument(kVersionedLayer))
                   .WithDataHandle("5d2082c3-9738-4de7-bde0-4a52527dab37"))
           .GetFuture();
@@ -548,7 +549,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, CheckDataExists) {
   auto response = fut.get();
 
   EXPECT_SUCCESS(response);
-  ASSERT_EQ(response.GetResult(), 200);
+  ASSERT_EQ(response.GetResult(), olp::http::HttpStatusCode::OK);
 }
 
 TEST_F(DataserviceWriteVersionedLayerClientTest, CheckDataNotExists) {
@@ -556,7 +557,7 @@ TEST_F(DataserviceWriteVersionedLayerClientTest, CheckDataNotExists) {
   auto fut =
       versioned_client
           ->CheckDataExists(
-              CheckDataExistsRequest()
+              model::CheckDataExistsRequest()
                   .WithLayerId(CustomParameters::getArgument(kVersionedLayer))
                   .WithDataHandle("5d2082c3-9738-4de7-bde0-4a52527dab34"))
           .GetFuture();


### PR DESCRIPTION
Use defines from HttpStatusCodes.h instead of hard-coded values
in functional tests.

Relates-To: OLPEDGE-686

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>