### PR TITLE
Change usage Index to QuadTreeIndex for GetData(TileRequest)

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -61,8 +61,8 @@ DataResponse DataRepository::GetVersionedTile(
     const TileRequest& request, int64_t version,
     client::CancellationContext context,
     const client::OlpClientSettings& settings) {
-  auto response = PartitionsRepository::GetAggregatedTile(
-      catalog, layer_id, context, request, version, settings);
+  auto response = PartitionsRepository::GetTile(catalog, layer_id, context,
+                                                request, version, settings);
 
   if (!response.IsSuccessful()) {
     OLP_SDK_LOG_WARNING_F(

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -61,8 +61,8 @@ DataResponse DataRepository::GetVersionedTile(
     const TileRequest& request, int64_t version,
     client::CancellationContext context,
     const client::OlpClientSettings& settings) {
-  auto response = PartitionsRepository::GetPartitionForVersionedTile(
-      catalog, layer_id, request, version, context, settings);
+  auto response = PartitionsRepository::GetAggregatedTile(
+      catalog, layer_id, context, request, version, settings);
 
   if (!response.IsSuccessful()) {
     OLP_SDK_LOG_WARNING_F(
@@ -74,7 +74,7 @@ DataResponse DataRepository::GetVersionedTile(
   }
 
   // Get the data using a data handle for requested tile
-  const auto& partition = response.GetResult().GetPartitions().front();
+  const auto& partition = response.GetResult();
   const auto data_request = DataRequest()
                                 .WithDataHandle(partition.GetDataHandle())
                                 .WithVersion(version)

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -445,27 +445,6 @@ PartitionResponse PartitionsRepository::GetAggregatedTile(
   }
   return FindPartition(tree, request, true);
 }
-
-model::Partitions PartitionsRepository::GetTileFromCache(
-    const client::HRN& catalog, const std::string& layer_id,
-    const TileRequest& request, int64_t version,
-    const client::OlpClientSettings& settings) {
-  if (request.GetFetchOption() != OnlineOnly) {
-    repository::PartitionsCacheRepository repository(
-        catalog, settings.cache, settings.default_cache_expiration);
-
-    auto partition_request = PartitionsRequest()
-                                 .WithBillingTag(request.GetBillingTag())
-                                 .WithVersion(version);
-
-    const std::vector<std::string> partitions{
-        request.GetTileKey().ToHereTile()};
-    return repository.Get(partition_request, partitions, layer_id);
-  }
-
-  return {};
-}
-
 PORTING_POP_WARNINGS()
 }  // namespace repository
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -43,6 +43,7 @@ class PartitionsCacheRepository;
 
 /// The partition metadata response type.
 using PartitionResponse = Response<model::Partition>;
+using QuadTreeIndexResponse = Response<QuadTreeIndex>;
 
 class PartitionsRepository {
  public:
@@ -77,11 +78,11 @@ class PartitionsRepository {
       const client::OlpClientSettings& settings);
 
  private:
-  static PartitionResponse GetTile(
+  static QuadTreeIndexResponse GetQuadTreeIndexForTile(
       const client::HRN& catalog, const std::string& layer,
       client::CancellationContext cancellation_context,
       const TileRequest& request, boost::optional<int64_t> version,
-      const client::OlpClientSettings& settings, bool aggregated);
+      const client::OlpClientSettings& settings);
 
   static PartitionsResponse GetPartitions(
       client::HRN catalog, std::string layer,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -61,8 +61,8 @@ class PartitionsRepository {
       client::CancellationContext cancellation_context,
       const DataRequest& data_request, client::OlpClientSettings settings);
 
-  static model::Partition PartitionFromSubQuad(
-      const model::SubQuad& sub_quad, const std::string& partition);
+  static model::Partition PartitionFromSubQuad(const model::SubQuad& sub_quad,
+                                               const std::string& partition);
 
   static PartitionResponse GetAggregatedTile(
       const client::HRN& catalog, const std::string& layer,
@@ -70,18 +70,7 @@ class PartitionsRepository {
       const TileRequest& request, boost::optional<int64_t> version,
       const client::OlpClientSettings& settings);
 
-  static PartitionsResponse GetPartitionForVersionedTile(
-      const client::HRN& catalog, const std::string& layer_id,
-      const TileRequest& request, int64_t version,
-      client::CancellationContext context,
-      const client::OlpClientSettings& settings);
-
  protected:
-  static PartitionsResponse QueryPartitionForVersionedTile(
-      const client::HRN& catalog, const std::string& layer_id,
-      const TileRequest& request, int64_t version,
-      client::CancellationContext context, client::OlpClientSettings settings);
-
   static model::Partitions GetTileFromCache(
       const client::HRN& catalog, const std::string& layer_id,
       const TileRequest& request, int64_t version,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -77,7 +77,7 @@ class PartitionsRepository {
       const client::OlpClientSettings& settings);
 
  private:
-  static PartitionResponse QueryQuadTreeIndexAndGetTile(
+  static PartitionResponse GetTile(
       const client::HRN& catalog, const std::string& layer,
       client::CancellationContext cancellation_context,
       const TileRequest& request, boost::optional<int64_t> version,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -70,12 +70,6 @@ class PartitionsRepository {
       const TileRequest& request, boost::optional<int64_t> version,
       const client::OlpClientSettings& settings);
 
- protected:
-  static model::Partitions GetTileFromCache(
-      const client::HRN& catalog, const std::string& layer_id,
-      const TileRequest& request, int64_t version,
-      const client::OlpClientSettings& settings);
-
  private:
   static PartitionsResponse GetPartitions(
       client::HRN catalog, std::string layer,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -70,7 +70,19 @@ class PartitionsRepository {
       const TileRequest& request, boost::optional<int64_t> version,
       const client::OlpClientSettings& settings);
 
+  static PartitionResponse GetTile(
+      const client::HRN& catalog, const std::string& layer,
+      client::CancellationContext cancellation_context,
+      const TileRequest& request, boost::optional<int64_t> version,
+      const client::OlpClientSettings& settings);
+
  private:
+  static PartitionResponse QueryQuadTreeIndexAndGetTile(
+      const client::HRN& catalog, const std::string& layer,
+      client::CancellationContext cancellation_context,
+      const TileRequest& request, boost::optional<int64_t> version,
+      const client::OlpClientSettings& settings, bool aggregated);
+
   static PartitionsResponse GetPartitions(
       client::HRN catalog, std::string layer,
       client::CancellationContext cancellation_context,

--- a/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
@@ -32,31 +32,31 @@
 #include <repositories/PartitionsCacheRepository.h>
 #include <repositories/PartitionsRepository.h>
 
-#define URL_LOOKUP \
-  R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data::olp-here-test:hereos-internal-test-v2/apis)"
+constexpr auto kUrlLookup =
+    R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data::olp-here-test:hereos-internal-test-v2/apis)";
 
-#define URL_BLOB_DATA_269 \
-  R"(https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/4eed6ed1-0d32-43b9-ae79-043cb4256432)"
+constexpr auto kUrlBlobData269 =
+    R"(https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/4eed6ed1-0d32-43b9-ae79-043cb4256432)";
 
-#define URL_BLOB_DATA_5904591 \
-  R"(https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1)"
+constexpr auto kUrlBlobData5904591 =
+    R"(https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1)";
 
-#define URL_BLOB_DATA_1476147 \
-  R"(https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/95c5c703-e00e-4c38-841e-e419367474f1)"
+constexpr auto kUrlBlobData1476147 =
+    R"(https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/95c5c703-e00e-4c38-841e-e419367474f1)";
 
-#define HTTP_RESPONSE_LOOKUP \
-  R"jsonString([{"api":"query","version":"v1","baseURL":"https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2","parameters":{}},{"api":"blob","version":"v1","baseURL":"https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2","parameters":{}}])jsonString"
+constexpr auto kUrlResponseLookup =
+    R"jsonString([{"api":"query","version":"v1","baseURL":"https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2","parameters":{}},{"api":"blob","version":"v1","baseURL":"https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2","parameters":{}}])jsonString";
 
-#define HTTP_RESPONSE_403 \
-  R"jsonString("Forbidden - A catalog with the specified HRN doesn't exist or access to this catalog is forbidden)jsonString"
+constexpr auto kUrlResponse403 =
+    R"jsonString("Forbidden - A catalog with the specified HRN doesn't exist or access to this catalog is forbidden)jsonString";
 
-#define BLOB_DATA_HANDLE R"(4eed6ed1-0d32-43b9-ae79-043cb4256432)"
+constexpr auto kUrlBlobDataHandle = R"(4eed6ed1-0d32-43b9-ae79-043cb4256432)";
 
-#define QUERY_TREE_INDEX \
-  R"(https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/testlayer/versions/4/quadkeys/23064/depths/4)"
+constexpr auto kUrlQueryTreeIndex =
+    R"(https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/testlayer/versions/4/quadkeys/23064/depths/4)";
 
-#define SUB_QUADS \
-  R"jsonString({"subQuads": [{"subQuadKey":"115","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"463","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString"
+constexpr auto kSubQuads =
+    R"jsonString({"subQuads": [{"subQuadKey":"115","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"463","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString";
 
 namespace {
 
@@ -96,14 +96,14 @@ std::string DataRepositoryTest::GetTestCatalog() {
 
 TEST_F(DataRepositoryTest, GetBlobData) {
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+              Send(common::IsGetRequest(kUrlLookup), _, _, _, _))
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     HTTP_RESPONSE_LOOKUP));
+                                     kUrlResponseLookup));
 
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
+              Send(common::IsGetRequest(kUrlBlobData269), _, _, _, _))
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
@@ -112,7 +112,7 @@ TEST_F(DataRepositoryTest, GetBlobData) {
   olp::client::CancellationContext context;
 
   olp::dataservice::read::DataRequest request;
-  request.WithDataHandle(BLOB_DATA_HANDLE);
+  request.WithDataHandle(kUrlBlobDataHandle);
 
   olp::client::HRN hrn(GetTestCatalog());
 
@@ -125,16 +125,16 @@ TEST_F(DataRepositoryTest, GetBlobData) {
 
 TEST_F(DataRepositoryTest, GetBlobDataApiLookupFailed403) {
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+              Send(common::IsGetRequest(kUrlLookup), _, _, _, _))
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::FORBIDDEN),
-                                     HTTP_RESPONSE_403));
+                                     kUrlResponse403));
 
   olp::client::CancellationContext context;
 
   olp::dataservice::read::DataRequest request;
-  request.WithDataHandle(BLOB_DATA_HANDLE);
+  request.WithDataHandle(kUrlBlobDataHandle);
 
   olp::client::HRN hrn(GetTestCatalog());
 
@@ -157,23 +157,23 @@ TEST_F(DataRepositoryTest, GetBlobDataNoDataHandle) {
 
 TEST_F(DataRepositoryTest, GetBlobDataFailedDataFetch403) {
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+              Send(common::IsGetRequest(kUrlLookup), _, _, _, _))
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     HTTP_RESPONSE_LOOKUP));
+                                     kUrlResponseLookup));
 
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
+              Send(common::IsGetRequest(kUrlBlobData269), _, _, _, _))
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::FORBIDDEN),
-                                     HTTP_RESPONSE_403));
+                                     kUrlResponse403));
 
   olp::client::CancellationContext context;
 
   olp::dataservice::read::DataRequest request;
-  request.WithDataHandle(BLOB_DATA_HANDLE);
+  request.WithDataHandle(kUrlBlobDataHandle);
 
   olp::client::HRN hrn(GetTestCatalog());
 
@@ -186,14 +186,14 @@ TEST_F(DataRepositoryTest, GetBlobDataFailedDataFetch403) {
 
 TEST_F(DataRepositoryTest, GetBlobDataCache) {
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+              Send(common::IsGetRequest(kUrlLookup), _, _, _, _))
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     HTTP_RESPONSE_LOOKUP));
+                                     kUrlResponseLookup));
 
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
+              Send(common::IsGetRequest(kUrlBlobData269), _, _, _, _))
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
@@ -202,7 +202,7 @@ TEST_F(DataRepositoryTest, GetBlobDataCache) {
   olp::client::CancellationContext context;
 
   olp::dataservice::read::DataRequest request;
-  request.WithDataHandle(BLOB_DATA_HANDLE);
+  request.WithDataHandle(kUrlBlobDataHandle);
 
   olp::client::HRN hrn(GetTestCatalog());
 
@@ -222,14 +222,14 @@ TEST_F(DataRepositoryTest, GetBlobDataCache) {
 }
 
 TEST_F(DataRepositoryTest, GetBlobDataImmediateCancel) {
-  ON_CALL(*network_mock_, Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+  ON_CALL(*network_mock_, Send(common::IsGetRequest(kUrlLookup), _, _, _, _))
       .WillByDefault(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     HTTP_RESPONSE_LOOKUP));
+                                     kUrlResponseLookup));
 
   ON_CALL(*network_mock_,
-          Send(common::IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
+          Send(common::IsGetRequest(kUrlBlobData269), _, _, _, _))
       .WillByDefault(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
@@ -238,7 +238,7 @@ TEST_F(DataRepositoryTest, GetBlobDataImmediateCancel) {
   olp::client::CancellationContext context;
 
   olp::dataservice::read::DataRequest request;
-  request.WithDataHandle(BLOB_DATA_HANDLE);
+  request.WithDataHandle(kUrlBlobDataHandle);
 
   olp::client::HRN hrn(GetTestCatalog());
 
@@ -254,16 +254,16 @@ TEST_F(DataRepositoryTest, GetBlobDataImmediateCancel) {
 
 TEST_F(DataRepositoryTest, GetBlobDataInProgressCancel) {
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+              Send(common::IsGetRequest(kUrlLookup), _, _, _, _))
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     HTTP_RESPONSE_LOOKUP));
+                                     kUrlResponseLookup));
 
   olp::client::CancellationContext context;
 
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
+              Send(common::IsGetRequest(kUrlBlobData269), _, _, _, _))
       .WillOnce(
           [&](olp::http::NetworkRequest, olp::http::Network::Payload,
               olp::http::Network::Callback, olp::http::Network::HeaderCallback,
@@ -275,7 +275,7 @@ TEST_F(DataRepositoryTest, GetBlobDataInProgressCancel) {
   EXPECT_CALL(*network_mock_, Cancel(_)).WillOnce(testing::Return());
 
   olp::dataservice::read::DataRequest request;
-  request.WithDataHandle(BLOB_DATA_HANDLE);
+  request.WithDataHandle(kUrlBlobDataHandle);
 
   olp::client::HRN hrn(GetTestCatalog());
 
@@ -288,21 +288,21 @@ TEST_F(DataRepositoryTest, GetBlobDataInProgressCancel) {
 
 TEST_F(DataRepositoryTest, GetVersionedDataTile) {
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+              Send(common::IsGetRequest(kUrlLookup), _, _, _, _))
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     HTTP_RESPONSE_LOOKUP));
+                                     kUrlResponseLookup));
 
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(QUERY_TREE_INDEX), _, _, _, _))
+              Send(common::IsGetRequest(kUrlQueryTreeIndex), _, _, _, _))
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     SUB_QUADS));
+                                     kSubQuads));
 
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(URL_BLOB_DATA_5904591), _, _, _, _))
+              Send(common::IsGetRequest(kUrlBlobData5904591), _, _, _, _))
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
@@ -325,14 +325,14 @@ TEST_F(DataRepositoryTest, GetVersionedDataTile) {
   // second request for another tile key, data handle should be found in cache,
   // no need to query online
   {
-    ON_CALL(*network_mock_, Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+    ON_CALL(*network_mock_, Send(common::IsGetRequest(kUrlLookup), _, _, _, _))
         .WillByDefault(
             common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                            olp::http::HttpStatusCode::OK),
-                                       HTTP_RESPONSE_LOOKUP));
+                                       kUrlResponseLookup));
 
     EXPECT_CALL(*network_mock_,
-                Send(common::IsGetRequest(URL_BLOB_DATA_1476147), _, _, _, _))
+                Send(common::IsGetRequest(kUrlBlobData1476147), _, _, _, _))
         .WillOnce(
             common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                            olp::http::HttpStatusCode::OK),
@@ -350,26 +350,26 @@ TEST_F(DataRepositoryTest, GetVersionedDataTile) {
 
 TEST_F(DataRepositoryTest, GetVersionedDataTileOnlineOnly) {
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+              Send(common::IsGetRequest(kUrlLookup), _, _, _, _))
       .Times(2)
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     HTTP_RESPONSE_LOOKUP))
+                                     kUrlResponseLookup))
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     HTTP_RESPONSE_LOOKUP));
+                                     kUrlResponseLookup));
 
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(QUERY_TREE_INDEX), _, _, _, _))
+              Send(common::IsGetRequest(kUrlQueryTreeIndex), _, _, _, _))
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     SUB_QUADS));
+                                     kSubQuads));
 
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(URL_BLOB_DATA_5904591), _, _, _, _))
+              Send(common::IsGetRequest(kUrlBlobData5904591), _, _, _, _))
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
@@ -413,16 +413,16 @@ TEST_F(DataRepositoryTest, GetVersionedDataTileImmediateCancel) {
 
 TEST_F(DataRepositoryTest, GetVersionedDataTileInProgressCancel) {
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+              Send(common::IsGetRequest(kUrlLookup), _, _, _, _))
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     HTTP_RESPONSE_LOOKUP));
+                                     kUrlResponseLookup));
 
   olp::client::CancellationContext context;
 
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(QUERY_TREE_INDEX), _, _, _, _))
+              Send(common::IsGetRequest(kUrlQueryTreeIndex), _, _, _, _))
       .WillOnce(
           [&](olp::http::NetworkRequest, olp::http::Network::Payload,
               olp::http::Network::Callback, olp::http::Network::HeaderCallback,
@@ -450,14 +450,14 @@ TEST_F(DataRepositoryTest, GetVersionedDataTileInProgressCancel) {
 
 TEST_F(DataRepositoryTest, GetVersionedDataTileReturnEmpty) {
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+              Send(common::IsGetRequest(kUrlLookup), _, _, _, _))
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     HTTP_RESPONSE_LOOKUP));
+                                     kUrlResponseLookup));
 
   EXPECT_CALL(*network_mock_,
-              Send(common::IsGetRequest(QUERY_TREE_INDEX), _, _, _, _))
+              Send(common::IsGetRequest(kUrlQueryTreeIndex), _, _, _, _))
       .WillOnce(
           common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),

--- a/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
@@ -61,7 +61,7 @@
 namespace {
 
 using testing::_;
-using namespace olp::tests::common;
+namespace common = olp::tests::common;
 
 const std::string kLayerId = "testlayer";
 const std::string kService = "blob";
@@ -74,11 +74,11 @@ class DataRepositoryTest : public ::testing::Test {
   std::string GetTestCatalog();
 
   std::shared_ptr<olp::client::OlpClientSettings> settings_;
-  std::shared_ptr<NetworkMock> network_mock_;
+  std::shared_ptr<common::NetworkMock> network_mock_;
 };
 
 void DataRepositoryTest::SetUp() {
-  network_mock_ = std::make_shared<NetworkMock>();
+  network_mock_ = std::make_shared<common::NetworkMock>();
   settings_ = std::make_shared<olp::client::OlpClientSettings>();
   settings_->cache =
       olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
@@ -95,15 +95,19 @@ std::string DataRepositoryTest::GetTestCatalog() {
 }
 
 TEST_F(DataRepositoryTest, GetBlobData) {
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   HTTP_RESPONSE_LOOKUP));
+  EXPECT_CALL(*network_mock_,
+              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     HTTP_RESPONSE_LOOKUP));
 
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   "someData"));
+  EXPECT_CALL(*network_mock_,
+              Send(common::IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     "someData"));
 
   olp::client::CancellationContext context;
 
@@ -120,10 +124,12 @@ TEST_F(DataRepositoryTest, GetBlobData) {
 }
 
 TEST_F(DataRepositoryTest, GetBlobDataApiLookupFailed403) {
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::FORBIDDEN),
-                                   HTTP_RESPONSE_403));
+  EXPECT_CALL(*network_mock_,
+              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::FORBIDDEN),
+                                     HTTP_RESPONSE_403));
 
   olp::client::CancellationContext context;
 
@@ -150,15 +156,19 @@ TEST_F(DataRepositoryTest, GetBlobDataNoDataHandle) {
 }
 
 TEST_F(DataRepositoryTest, GetBlobDataFailedDataFetch403) {
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   HTTP_RESPONSE_LOOKUP));
+  EXPECT_CALL(*network_mock_,
+              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     HTTP_RESPONSE_LOOKUP));
 
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::FORBIDDEN),
-                                   HTTP_RESPONSE_403));
+  EXPECT_CALL(*network_mock_,
+              Send(common::IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::FORBIDDEN),
+                                     HTTP_RESPONSE_403));
 
   olp::client::CancellationContext context;
 
@@ -175,15 +185,19 @@ TEST_F(DataRepositoryTest, GetBlobDataFailedDataFetch403) {
 }
 
 TEST_F(DataRepositoryTest, GetBlobDataCache) {
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   HTTP_RESPONSE_LOOKUP));
+  EXPECT_CALL(*network_mock_,
+              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     HTTP_RESPONSE_LOOKUP));
 
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   "someData"));
+  EXPECT_CALL(*network_mock_,
+              Send(common::IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     "someData"));
 
   olp::client::CancellationContext context;
 
@@ -208,15 +222,18 @@ TEST_F(DataRepositoryTest, GetBlobDataCache) {
 }
 
 TEST_F(DataRepositoryTest, GetBlobDataImmediateCancel) {
-  ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP), _, _, _, _))
-      .WillByDefault(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                            olp::http::HttpStatusCode::OK),
-                                        HTTP_RESPONSE_LOOKUP));
+  ON_CALL(*network_mock_, Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+      .WillByDefault(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     HTTP_RESPONSE_LOOKUP));
 
-  ON_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
-      .WillByDefault(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                            olp::http::HttpStatusCode::OK),
-                                        "someData"));
+  ON_CALL(*network_mock_,
+          Send(common::IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
+      .WillByDefault(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     "someData"));
 
   olp::client::CancellationContext context;
 
@@ -236,14 +253,17 @@ TEST_F(DataRepositoryTest, GetBlobDataImmediateCancel) {
 }
 
 TEST_F(DataRepositoryTest, GetBlobDataInProgressCancel) {
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   HTTP_RESPONSE_LOOKUP));
+  EXPECT_CALL(*network_mock_,
+              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     HTTP_RESPONSE_LOOKUP));
 
   olp::client::CancellationContext context;
 
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
+  EXPECT_CALL(*network_mock_,
+              Send(common::IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
       .WillOnce(
           [&](olp::http::NetworkRequest, olp::http::Network::Payload,
               olp::http::Network::Callback, olp::http::Network::HeaderCallback,
@@ -267,21 +287,26 @@ TEST_F(DataRepositoryTest, GetBlobDataInProgressCancel) {
 }
 
 TEST_F(DataRepositoryTest, GetVersionedDataTile) {
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   HTTP_RESPONSE_LOOKUP));
-
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(QUERY_TREE_INDEX), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   SUB_QUADS));
+  EXPECT_CALL(*network_mock_,
+              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     HTTP_RESPONSE_LOOKUP));
 
   EXPECT_CALL(*network_mock_,
-              Send(IsGetRequest(URL_BLOB_DATA_5904591), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   "someData"));
+              Send(common::IsGetRequest(QUERY_TREE_INDEX), _, _, _, _))
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     SUB_QUADS));
+
+  EXPECT_CALL(*network_mock_,
+              Send(common::IsGetRequest(URL_BLOB_DATA_5904591), _, _, _, _))
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     "someData"));
 
   olp::client::HRN hrn(GetTestCatalog());
   int64_t version = 4;
@@ -300,17 +325,18 @@ TEST_F(DataRepositoryTest, GetVersionedDataTile) {
   // second request for another tile key, data handle should be found in cache,
   // no need to query online
   {
-    ON_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP), _, _, _, _))
+    ON_CALL(*network_mock_, Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
         .WillByDefault(
-            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                   olp::http::HttpStatusCode::OK),
-                               HTTP_RESPONSE_LOOKUP));
+            common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                           olp::http::HttpStatusCode::OK),
+                                       HTTP_RESPONSE_LOOKUP));
 
     EXPECT_CALL(*network_mock_,
-                Send(IsGetRequest(URL_BLOB_DATA_1476147), _, _, _, _))
-        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                         olp::http::HttpStatusCode::OK),
-                                     "someData"));
+                Send(common::IsGetRequest(URL_BLOB_DATA_1476147), _, _, _, _))
+        .WillOnce(
+            common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                           olp::http::HttpStatusCode::OK),
+                                       "someData"));
 
     auto request = olp::dataservice::read::TileRequest().WithTileKey(
         olp::geo::TileKey::FromHereTile("1476147"));
@@ -323,26 +349,31 @@ TEST_F(DataRepositoryTest, GetVersionedDataTile) {
 }
 
 TEST_F(DataRepositoryTest, GetVersionedDataTileOnlineOnly) {
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP), _, _, _, _))
+  EXPECT_CALL(*network_mock_,
+              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
       .Times(2)
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   HTTP_RESPONSE_LOOKUP))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   HTTP_RESPONSE_LOOKUP));
-
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(QUERY_TREE_INDEX), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   SUB_QUADS));
-
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     HTTP_RESPONSE_LOOKUP))
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     HTTP_RESPONSE_LOOKUP));
 
   EXPECT_CALL(*network_mock_,
-              Send(IsGetRequest(URL_BLOB_DATA_5904591), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   "someData"));
+              Send(common::IsGetRequest(QUERY_TREE_INDEX), _, _, _, _))
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     SUB_QUADS));
+
+  EXPECT_CALL(*network_mock_,
+              Send(common::IsGetRequest(URL_BLOB_DATA_5904591), _, _, _, _))
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     "someData"));
 
   olp::client::HRN hrn(GetTestCatalog());
   int64_t version = 4;
@@ -381,14 +412,17 @@ TEST_F(DataRepositoryTest, GetVersionedDataTileImmediateCancel) {
 }
 
 TEST_F(DataRepositoryTest, GetVersionedDataTileInProgressCancel) {
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   HTTP_RESPONSE_LOOKUP));
+  EXPECT_CALL(*network_mock_,
+              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     HTTP_RESPONSE_LOOKUP));
 
   olp::client::CancellationContext context;
 
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(QUERY_TREE_INDEX), _, _, _, _))
+  EXPECT_CALL(*network_mock_,
+              Send(common::IsGetRequest(QUERY_TREE_INDEX), _, _, _, _))
       .WillOnce(
           [&](olp::http::NetworkRequest, olp::http::Network::Payload,
               olp::http::Network::Callback, olp::http::Network::HeaderCallback,
@@ -415,15 +449,19 @@ TEST_F(DataRepositoryTest, GetVersionedDataTileInProgressCancel) {
 }
 
 TEST_F(DataRepositoryTest, GetVersionedDataTileReturnEmpty) {
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   HTTP_RESPONSE_LOOKUP));
+  EXPECT_CALL(*network_mock_,
+              Send(common::IsGetRequest(URL_LOOKUP), _, _, _, _))
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     HTTP_RESPONSE_LOOKUP));
 
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(QUERY_TREE_INDEX), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   "no_data_handle_in_responce"));
+  EXPECT_CALL(*network_mock_,
+              Send(common::IsGetRequest(QUERY_TREE_INDEX), _, _, _, _))
+      .WillOnce(
+          common::ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     "no_data_handle_in_responce"));
 
   olp::client::HRN hrn(GetTestCatalog());
   int64_t version = 4;
@@ -438,6 +476,8 @@ TEST_F(DataRepositoryTest, GetVersionedDataTileReturnEmpty) {
 
   ASSERT_FALSE(response.IsSuccessful());
   ASSERT_EQ(response.GetError().GetErrorCode(),
-            olp::client::ErrorCode::NotFound);
+            olp::client::ErrorCode::Unknown);
+  ASSERT_EQ(response.GetError().GetMessage(),
+            "Failed to parse QuadTreeIndex json");
 }
 }  // namespace

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -878,25 +878,27 @@ TEST_F(PartitionsRepositoryTest, CheckCashedPartitions) {
     auto request = olp::dataservice::read::TileRequest().WithTileKey(
         olp::geo::TileKey::FromHereTile("5904591"));
     olp::client::CancellationContext context;
-    auto response = QueryPartitionForVersionedTile(hrn, layer, request, version,
-                                                   context, settings);
+    auto response =
+        GetAggregatedTile(hrn, layer, context, request, version, settings);
 
     ASSERT_TRUE(response.IsSuccessful());
-    ASSERT_EQ(response.GetResult().GetPartitions().front().GetDataHandle(),
+    ASSERT_EQ(response.GetResult().GetDataHandle(),
               "e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1");
   }
 
   {
     SCOPED_TRACE(
         "Check if all partitions stored in cache, request another tile");
-    auto request = olp::dataservice::read::TileRequest().WithTileKey(
-        olp::geo::TileKey::FromHereTile("1476147"));
-    auto partitions = GetTileFromCache(hrn, layer, request, version, settings);
+    olp::client::CancellationContext context;
+    auto request = olp::dataservice::read::TileRequest()
+                       .WithTileKey(olp::geo::TileKey::FromHereTile("1476147"))
+                       .WithFetchOption(read::CacheOnly);
+    auto response =
+        GetAggregatedTile(hrn, layer, context, request, version, settings);
 
     // check if partition was stored to cache
-    ASSERT_FALSE(partitions.GetPartitions().size() == 0);
-    ASSERT_EQ(partitions.GetPartitions().front().GetDataHandle(),
-              kBlobDataHandle1476147);
+    ASSERT_TRUE(response.IsSuccessful());
+    ASSERT_EQ(response.GetResult().GetDataHandle(), kBlobDataHandle1476147);
   }
 }
 

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -878,8 +878,7 @@ TEST_F(PartitionsRepositoryTest, CheckCashedPartitions) {
     auto request = olp::dataservice::read::TileRequest().WithTileKey(
         olp::geo::TileKey::FromHereTile("5904591"));
     olp::client::CancellationContext context;
-    auto response =
-        GetAggregatedTile(hrn, layer, context, request, version, settings);
+    auto response = GetTile(hrn, layer, context, request, version, settings);
 
     ASSERT_TRUE(response.IsSuccessful());
     ASSERT_EQ(response.GetResult().GetDataHandle(),
@@ -893,8 +892,7 @@ TEST_F(PartitionsRepositoryTest, CheckCashedPartitions) {
     auto request = olp::dataservice::read::TileRequest()
                        .WithTileKey(olp::geo::TileKey::FromHereTile("1476147"))
                        .WithFetchOption(read::CacheOnly);
-    auto response =
-        GetAggregatedTile(hrn, layer, context, request, version, settings);
+    auto response = GetTile(hrn, layer, context, request, version, settings);
 
     // check if partition was stored to cache
     ASSERT_TRUE(response.IsSuccessful());


### PR DESCRIPTION
Use GetAggregatedTile functionality to query and cache quad tree.
Remove unnecessary tests

Relates-To: OLPEDGE-2083

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>