### PR TITLE
Add QuadTreeIndex GetIndexData

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.cpp
@@ -322,6 +322,31 @@ boost::optional<QuadTreeIndex::IndexData> QuadTreeIndex::FindNearestParent(
   return boost::none;
 }
 
+std::vector<QuadTreeIndex::IndexData> QuadTreeIndex::GetIndexData() const {
+  std::vector<QuadTreeIndex::IndexData> result;
+  if (IsNull()) {
+    return result;
+  }
+  for (auto it = ParentEntryEnd(); it-- != ParentEntryBegin();) {
+    QuadTreeIndex::IndexData data;
+    data.tile_key = geo::TileKey::FromQuadKey64(it->key);
+    if (ReadIndexData(data, it->tag_offset)) {
+      result.emplace_back(std::move(data));
+    }
+  }
+  for (auto it = SubEntryEnd(); it-- != SubEntryBegin();) {
+    QuadTreeIndex::IndexData data;
+    const olp::geo::TileKey& root_tile_key =
+        olp::geo::TileKey::FromQuadKey64(data_->root_tilekey);
+    auto subtile = root_tile_key.AddedSubkey64(std::uint64_t(it->sub_quadkey));
+    data.tile_key = subtile;
+    if (ReadIndexData(data, it->tag_offset)) {
+      result.emplace_back(std::move(data));
+    }
+  }
+  return result;
+}
+
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.cpp
@@ -322,12 +322,12 @@ boost::optional<QuadTreeIndex::IndexData> QuadTreeIndex::FindNearestParent(
   return boost::none;
 }
 
-std::vector<QuadTreeIndex::IndexData> QuadTreeIndex::ConvertToIndexData()
-    const {
+std::vector<QuadTreeIndex::IndexData> QuadTreeIndex::GetIndexData() const {
   std::vector<QuadTreeIndex::IndexData> result;
   if (IsNull()) {
     return result;
   }
+  result.reserve(data_->parent_count + data_->subkey_count);
   for (auto it = ParentEntryEnd(); it-- != ParentEntryBegin();) {
     QuadTreeIndex::IndexData data;
     data.tile_key = geo::TileKey::FromQuadKey64(it->key);

--- a/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.cpp
@@ -322,7 +322,8 @@ boost::optional<QuadTreeIndex::IndexData> QuadTreeIndex::FindNearestParent(
   return boost::none;
 }
 
-std::vector<QuadTreeIndex::IndexData> QuadTreeIndex::GetIndexData() const {
+std::vector<QuadTreeIndex::IndexData> QuadTreeIndex::ConvertToIndexData()
+    const {
   std::vector<QuadTreeIndex::IndexData> result;
   if (IsNull()) {
     return result;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.h
@@ -69,7 +69,7 @@ class QuadTreeIndex {
     return raw_data_;
   }
 
-  std::vector<QuadTreeIndex::IndexData> GetIndexData() const;
+  std::vector<QuadTreeIndex::IndexData> ConvertToIndexData() const;
 
  private:
   struct SubEntry {

--- a/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.h
@@ -69,6 +69,8 @@ class QuadTreeIndex {
     return raw_data_;
   }
 
+  std::vector<QuadTreeIndex::IndexData> GetIndexData() const;
+
  private:
   struct SubEntry {
     std::uint16_t sub_quadkey;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.h
@@ -69,7 +69,7 @@ class QuadTreeIndex {
     return raw_data_;
   }
 
-  std::vector<QuadTreeIndex::IndexData> ConvertToIndexData() const;
+  std::vector<QuadTreeIndex::IndexData> GetIndexData() const;
 
  private:
   struct SubEntry {

--- a/olp-cpp-sdk-dataservice-read/tests/QuadTreeIndexTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/QuadTreeIndexTest.cpp
@@ -101,8 +101,9 @@ TEST(QuadTreeIndexTest, ParseBlob) {
   }
 
   {
-    SCOPED_TRACE("Quad tree ConvertToIndexData test");
-    for (const auto& data : index.ConvertToIndexData()) {
+    SCOPED_TRACE("Quad tree GetIndexData test");
+
+    for (const auto& data : index.GetIndexData()) {
       if (data.tile_key == olp::geo::TileKey::FromHereTile("23")) {
         EXPECT_EQ(data.data_handle, "F8F4C3CB09FBA61B927256CBCB8441D1.282");
       }
@@ -113,7 +114,7 @@ TEST(QuadTreeIndexTest, ParseBlob) {
   }
 
   {
-    SCOPED_TRACE("Mailformed JSon response");
+    SCOPED_TRACE("Malformed JSon response");
 
     auto tile_key = olp::geo::TileKey::FromHereTile("381");
     auto stream = std::stringstream(HTTP_RESPONSE_MAILFORMED);
@@ -123,15 +124,12 @@ TEST(QuadTreeIndexTest, ParseBlob) {
   }
 
   {
-    SCOPED_TRACE("Mailformed QuadTreeIndex try to ConvertToIndexData ");
+    SCOPED_TRACE("Malformed QuadTreeIndex try to GetIndexData ");
 
     auto tile_key = olp::geo::TileKey::FromHereTile("381");
     auto stream = std::stringstream(HTTP_RESPONSE_MAILFORMED);
     read::QuadTreeIndex index(tile_key, 1, stream);
-    for (const auto& data : index.ConvertToIndexData()) {
-      (void)data;
-      EXPECT_EQ(true, false);
-    }
+    EXPECT_EQ(index.GetIndexData().size(), 0);
   }
 
   {

--- a/olp-cpp-sdk-dataservice-read/tests/QuadTreeIndexTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/QuadTreeIndexTest.cpp
@@ -101,6 +101,18 @@ TEST(QuadTreeIndexTest, ParseBlob) {
   }
 
   {
+    SCOPED_TRACE("Quad tree ConvertToIndexData test");
+    for (const auto& data : index.GetIndexData()) {
+      if (data.tile_key == olp::geo::TileKey::FromHereTile("23")) {
+        EXPECT_EQ(data.data_handle, "F8F4C3CB09FBA61B927256CBCB8441D1.282");
+      }
+      if (data.tile_key == olp::geo::TileKey::FromHereTile("1524")) {
+        EXPECT_EQ(data.data_handle, "7636348E50215979A39B5F3A429EDDB4.282");
+      }
+    }
+  }
+
+  {
     SCOPED_TRACE("Mailformed JSon response");
 
     auto tile_key = olp::geo::TileKey::FromHereTile("381");
@@ -108,6 +120,18 @@ TEST(QuadTreeIndexTest, ParseBlob) {
     read::QuadTreeIndex index(tile_key, 1, stream);
     auto data = index.Find(tile_key, false);
     EXPECT_TRUE(data == boost::none);
+  }
+
+  {
+    SCOPED_TRACE("Mailformed QuadTreeIndex try to ConvertToIndexData ");
+
+    auto tile_key = olp::geo::TileKey::FromHereTile("381");
+    auto stream = std::stringstream(HTTP_RESPONSE_MAILFORMED);
+    read::QuadTreeIndex index(tile_key, 1, stream);
+    for (const auto& data : index.GetIndexData()) {
+      (void)data;
+      EXPECT_EQ(true, false);
+    }
   }
 
   {

--- a/olp-cpp-sdk-dataservice-read/tests/QuadTreeIndexTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/QuadTreeIndexTest.cpp
@@ -102,7 +102,7 @@ TEST(QuadTreeIndexTest, ParseBlob) {
 
   {
     SCOPED_TRACE("Quad tree ConvertToIndexData test");
-    for (const auto& data : index.GetIndexData()) {
+    for (const auto& data : index.ConvertToIndexData()) {
       if (data.tile_key == olp::geo::TileKey::FromHereTile("23")) {
         EXPECT_EQ(data.data_handle, "F8F4C3CB09FBA61B927256CBCB8441D1.282");
       }
@@ -128,7 +128,7 @@ TEST(QuadTreeIndexTest, ParseBlob) {
     auto tile_key = olp::geo::TileKey::FromHereTile("381");
     auto stream = std::stringstream(HTTP_RESPONSE_MAILFORMED);
     read::QuadTreeIndex index(tile_key, 1, stream);
-    for (const auto& data : index.GetIndexData()) {
+    for (const auto& data : index.ConvertToIndexData()) {
       (void)data;
       EXPECT_EQ(true, false);
     }


### PR DESCRIPTION
Add converting QuadTreeIndex to IndexData.
Needed for bypass QuadTreeIndex.
Add unit tests.

Relates-To: OLPEDGE-2084

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>