### PR TITLE
Implement Prefetch caching with QuadTreeIndex

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -20,8 +20,8 @@
 #pragma once
 
 #include <memory>
-#include <vector>
 #include <string>
+#include <vector>
 
 #include <boost/optional.hpp>
 #include <olp/core/client/ApiError.h>
@@ -318,6 +318,8 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * @note This method does not guarantee that all tiles are available offline
    * as the cache might overflow, and data might be evicted at any point.
+   * Use GetData(TileRequest) or GetAggregatedData(TileRequest) to retrieve
+   * tiles loaded by PrefetchTiles.
    *
    * @param request The `PrefetchTilesRequest` instance that contains
    * a complete set of request parameters.
@@ -342,6 +344,8 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * @note This method does not guarantee that all tiles are available offline
    * as the cache might overflow, and data might be evicted at any point.
+   * Use GetData(TileRequest) or GetAggregatedData(TileRequest) to retrieve
+   * tiles loaded by PrefetchTiles.
    *
    * @param request The `PrefetchTilesRequest` instance that contains
    * a complete set of request parameters.

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.cpp
@@ -99,41 +99,6 @@ QueryApi::PartitionsResponse QueryApi::GetPartitionsbyId(
   return olp::parser::parse<model::Partitions>(response.response);
 }
 
-QueryApi::QuadTreeIndexResponse QueryApi::QuadTreeIndex(
-    const client::OlpClient& client, const std::string& layer_id,
-    int64_t version, const std::string& quad_key, int32_t depth,
-    boost::optional<std::vector<std::string>> additional_fields,
-    boost::optional<std::string> billing_tag,
-    client::CancellationContext context) {
-  std::multimap<std::string, std::string> header_params;
-  header_params.insert(std::make_pair("Accept", "application/json"));
-
-  std::multimap<std::string, std::string> query_params;
-  if (additional_fields) {
-    query_params.insert(std::make_pair(
-        "additionalFields", ConcatStringArray(*additional_fields, ",")));
-  }
-  if (billing_tag) {
-    query_params.insert(std::make_pair("billingTag", *billing_tag));
-  }
-
-  std::string metadata_uri = "/layers/" + layer_id + "/versions/" +
-                             std::to_string(version) + "/quadkeys/" + quad_key +
-                             "/depths/" + std::to_string(depth);
-
-  client::HttpResponse response = client.CallApi(
-      metadata_uri, "GET", std::move(query_params), std::move(header_params),
-      {}, nullptr, std::string{}, std::move(context));
-
-  OLP_SDK_LOG_DEBUG_F(kLogTag, "QuadTreeIndex, uri=%s, status=%d",
-                      metadata_uri.c_str(), response.status);
-  if (response.status != olp::http::HttpStatusCode::OK) {
-    return client::ApiError(response.status, response.response.str());
-  }
-
-  return olp::parser::parse<model::Index>(response.response);
-}
-
 olp::client::HttpResponse QueryApi::QuadTreeIndex(
     const client::OlpClient& client, const std::string& layer_id,
     const std::string& quad_key, boost::optional<int64_t> version,

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.h
@@ -86,10 +86,10 @@ class QueryApi {
    * Content of this parameter must refer to a valid layer already configured
    * in the catalog configuration. Exactly one layer ID must be
    * provided.
-   * @param version The version of the catalog against
-   * which to run the query. Must be a valid catalog version.
    * @param quad_key The geometric area specified by an index in the request,
    * represented as a HERE tile
+   * @param version The version of the catalog against
+   * which to run the query. Must be a valid catalog version.
    * @param depth The recursion depth
    * of the response. If set to 0, the response includes only data for the
    * quad_key specified in the request. In this way, depth describes the maximum
@@ -107,13 +107,6 @@ class QueryApi {
    * @param The result of this operation as a client::ApiResponse object with \c
    * model::Index as a result
    **/
-  static QuadTreeIndexResponse QuadTreeIndex(
-      const client::OlpClient& client, const std::string& layer_id,
-      int64_t version, const std::string& quad_key, int32_t depth,
-      boost::optional<std::vector<std::string>> additional_fields,
-      boost::optional<std::string> billing_tag,
-      client::CancellationContext context);
-
   static olp::client::HttpResponse QuadTreeIndex(
       const client::OlpClient& client, const std::string& layer_id,
       const std::string& quad_key, boost::optional<int64_t> version,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -437,7 +437,7 @@ QuadTreeIndexResponse PartitionsRepository::GetQuadTreeIndexForTile(
         "root='%s', version='%" PRId64 "', depth='%" PRId32 "'",
         catalog.ToString().c_str(), layer.c_str(), root_tile_here.c_str(),
         version.get_value_or(-1), kAggregateQuadTreeDepth);
-    return {{client::ErrorCode::Unknown, "Failed to parse QuadTreeIndex json"}};
+    return {{client::ErrorCode::Unknown, "Failed to parse quad tree response"}};
   }
 
   if (fetch_option != OnlineOnly) {

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -21,6 +21,7 @@
 
 #include <inttypes.h>
 #include <algorithm>
+#include <iterator>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -70,7 +71,7 @@ void PrefetchTilesRepository::SplitSubtree(
 
     for (std::uint64_t key = beginTileKey; key < endTileKey; ++key) {
       auto child = geo::TileKey::FromQuadKey64(key);
-      // skip child, if it not parent, or a child of prefetched tile
+      // skip child, if it is not a parent, or a child of prefetched tile
       if (!tile_key.IsParentOf(child) && !child.IsParentOf(tile_key) &&
           child != tile_key) {
         continue;
@@ -255,7 +256,7 @@ SubQuadsResponse PrefetchTilesRepository::GetSubQuads(
   // add to cache
   repository.Put(layer_id, tile, depth, tree, version);
   return get_sub_quads(tree);
-}  // namespace repository
+}
 
 SubQuadsResponse PrefetchTilesRepository::GetVolatileSubQuads(
     const client::HRN& catalog, const std::string& layer_id,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -85,7 +85,7 @@ class PrefetchTilesRepository {
 
   static void SplitSubtree(RootTilesForRequest& root_tiles_depth,
                            RootTilesForRequest::iterator subtree_to_split,
-                           geo::TileKey tile_key);
+                           const geo::TileKey& tile_key, unsigned int min);
 };
 
 }  // namespace repository

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -57,8 +57,8 @@ class PrefetchTilesRepository {
    * @param maxLevel Maximum level of the resultant tile keys.
    */
   static RootTilesForRequest GetSlicedTiles(
-      const std::vector<geo::TileKey>& tile_keys, unsigned int min,
-      unsigned int max);
+      const std::vector<geo::TileKey>& tile_keys, std::uint32_t min,
+      std::uint32_t max);
 
   static SubTilesResponse GetSubTiles(
       const client::HRN& catalog, const std::string& layer_id,
@@ -85,7 +85,7 @@ class PrefetchTilesRepository {
 
   static void SplitSubtree(RootTilesForRequest& root_tiles_depth,
                            RootTilesForRequest::iterator subtree_to_split,
-                           const geo::TileKey& tile_key, unsigned int min);
+                           const geo::TileKey& tile_key, std::uint32_t min);
 };
 
 }  // namespace repository

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -84,7 +84,8 @@ class PrefetchTilesRepository {
       client::CancellationContext context);
 
   static void SplitSubtree(RootTilesForRequest& root_tiles_depth,
-                           RootTilesForRequest::iterator subtree_to_split);
+                           RootTilesForRequest::iterator subtree_to_split,
+                           geo::TileKey tile_key);
 };
 
 }  // namespace repository

--- a/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
@@ -442,6 +442,6 @@ TEST_F(DataRepositoryTest, GetVersionedDataTileReturnEmpty) {
   ASSERT_EQ(response.GetError().GetErrorCode(),
             olp::client::ErrorCode::Unknown);
   ASSERT_EQ(response.GetError().GetMessage(),
-            "Failed to parse QuadTreeIndex json");
+            "Failed to parse quad tree response");
 }
 }  // namespace

--- a/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
@@ -36,7 +36,7 @@ TEST(PrefetchRepositoryTest, SplitTreeLevel5) {
   auto tile = olp::geo::TileKey::FromHereTile("5904591");
   auto it = root_tiles_depth.emplace(tile, 5);
 
-  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile);
+  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile, 0);
   ASSERT_EQ(it.first->second, 0);
   ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 1));
 }
@@ -46,7 +46,7 @@ TEST(PrefetchRepositoryTest, SplitTreeLevel8) {
   auto tile = olp::geo::TileKey::FromHereTile("5904591");
   auto it = root_tiles_depth.emplace(tile, 8);
 
-  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile);
+  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile, 0);
   ASSERT_EQ(it.first->second, 3);
   ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 4));
 }
@@ -56,7 +56,7 @@ TEST(PrefetchRepositoryTest, SplitTreeLevel9) {
   auto tile = olp::geo::TileKey::FromHereTile("5904591");
   auto it = root_tiles_depth.emplace(tile, 9);
 
-  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile);
+  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile, 0);
   ASSERT_EQ(it.first->second, 4);
   ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 5));
 }
@@ -66,9 +66,21 @@ TEST(PrefetchRepositoryTest, SplitTreeLevel10) {
   auto tile = olp::geo::TileKey::FromHereTile("5904591");
   auto it = root_tiles_depth.emplace(tile, 10);
 
-  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile);
+  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile, 0);
   ASSERT_EQ(it.first->second, 0);
   ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 1) + pow(4, 6));
+}
+
+TEST(PrefetchRepositoryTest, SplitTreeLevelMinLevelSet) {
+  repository::RootTilesForRequest root_tiles_depth;
+  auto tile = olp::geo::TileKey::FromHereTile("5904591");
+  auto it = root_tiles_depth.emplace(tile, 10);
+
+  // want to slice up starting from level 13
+  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile,
+                                           13);
+  ASSERT_EQ(root_tiles_depth.find(tile), root_tiles_depth.end());
+  ASSERT_EQ(root_tiles_depth.size(), pow(4, 1) + pow(4, 6));
 }
 
 TEST(PrefetchRepositoryTest, GetSlicedTiles) {
@@ -94,9 +106,22 @@ TEST(PrefetchRepositoryTest, GetSlicedTilesWithLevelsSpecified2) {
   auto tile = olp::geo::TileKey::FromHereTile("5904591");  // level 11
   auto root_tiles_depth =
       PrefetchRepositoryTestable::GetSlicedTiles({tile}, 1, 13);
-  auto parent = tile.ChangedLevelBy(-10);
+  auto parent = tile.ChangedLevelTo(1);
+  // sliced levels should be 1, 6, 11
   ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
-  ASSERT_EQ(root_tiles_depth.size(), 13 / 4);  // on each slice is 1 tile
+  // 1 tile on each level
+  ASSERT_EQ(root_tiles_depth.size(), 3);
+}
+
+TEST(PrefetchRepositoryTest, GetSlicedTilesWithLevelsSpecified3) {
+  auto tile = olp::geo::TileKey::FromHereTile("5904591");  // level 11
+  auto root_tiles_depth =
+      PrefetchRepositoryTestable::GetSlicedTiles({tile}, 14, 16);
+  // sliced levels should be 12
+  auto parent = tile.ChangedLevelTo(12);
+  ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
+  //  and 4^(12-11) tiles on level 12
+  ASSERT_EQ(root_tiles_depth.size(), 4);
 }
 
 TEST(PrefetchRepositoryTest, GetSlicedTilesDifferentLevelsButLevelsSpecified) {
@@ -105,9 +130,38 @@ TEST(PrefetchRepositoryTest, GetSlicedTilesDifferentLevelsButLevelsSpecified) {
       "23618365");  // level 12, this tile will be in the same subtree
   auto root_tiles_depth =
       PrefetchRepositoryTestable::GetSlicedTiles({tile1, tile2}, 1, 13);
-  auto parent = tile1.ChangedLevelBy(-10);
+  // sliced levels should be 1, 6, 11
+  auto parent = tile1.ChangedLevelTo(1);
   ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
-  ASSERT_EQ(root_tiles_depth.size(), 13 / 4);  // on each slice is 1 tile
+  ASSERT_EQ(root_tiles_depth.size(), 3);
+}
+
+TEST(PrefetchRepositoryTest, GetSlicedTilesDifferentLevelsButLevelsSpecified2) {
+  auto tile1 = olp::geo::TileKey::FromHereTile("5904591");  // level 11
+  auto tile2 = olp::geo::TileKey::FromHereTile(
+      "23618365");  // level 12, this tile will be in the same subtree
+  auto root_tiles_depth =
+      PrefetchRepositoryTestable::GetSlicedTiles({tile1, tile2}, 12, 13);
+  // sliced levels is 9
+  auto parent = tile1.ChangedLevelTo(13 - 4);
+  ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
+  // no duplicates for sliced tiles, as tile1 is parent tile2
+  ASSERT_EQ(root_tiles_depth.size(), 1);
+}
+
+TEST(PrefetchRepositoryTest, GetSlicedTilesDifferentLevelsButLevelsSpecified3) {
+  auto tile1 = olp::geo::TileKey::FromHereTile("5904591");  // level 11
+  auto tile2 = olp::geo::TileKey::FromHereTile(
+      "23618365");  // level 12, this tile will be in the same subtree
+  auto root_tiles_depth =
+      PrefetchRepositoryTestable::GetSlicedTiles({tile1, tile2}, 15, 16);
+  // sliced levels is 7 and 12, as tile1 on level 11, this means we need to get
+  // 4 tiles on level 12, and so on, so on level 15 it is and 4^(15-11) tiles
+  // the best way to query for each of 4 tiles on level 12
+  auto parent = tile1.ChangedLevelTo(16 - 4);
+  ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
+  // no duplicates for sliced tiles, as tile1 is parent tile2
+  ASSERT_EQ(root_tiles_depth.size(), 4);
 }
 
 TEST(PrefetchRepositoryTest, GetSlicedTilesSibilings) {

--- a/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
@@ -33,40 +33,40 @@ class PrefetchRepositoryTestable
 
 TEST(PrefetchRepositoryTest, SplitTreeLevel5) {
   repository::RootTilesForRequest root_tiles_depth;
-  auto it =
-      root_tiles_depth.emplace(olp::geo::TileKey::FromHereTile("5904591"), 5);
+  auto tile = olp::geo::TileKey::FromHereTile("5904591");
+  auto it = root_tiles_depth.emplace(tile, 5);
 
-  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first);
+  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile);
   ASSERT_EQ(it.first->second, 0);
   ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 1));
 }
 
 TEST(PrefetchRepositoryTest, SplitTreeLevel8) {
   repository::RootTilesForRequest root_tiles_depth;
-  auto it =
-      root_tiles_depth.emplace(olp::geo::TileKey::FromHereTile("5904591"), 8);
+  auto tile = olp::geo::TileKey::FromHereTile("5904591");
+  auto it = root_tiles_depth.emplace(tile, 8);
 
-  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first);
+  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile);
   ASSERT_EQ(it.first->second, 3);
   ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 4));
 }
 
 TEST(PrefetchRepositoryTest, SplitTreeLevel9) {
   repository::RootTilesForRequest root_tiles_depth;
-  auto it =
-      root_tiles_depth.emplace(olp::geo::TileKey::FromHereTile("5904591"), 9);
+  auto tile = olp::geo::TileKey::FromHereTile("5904591");
+  auto it = root_tiles_depth.emplace(tile, 9);
 
-  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first);
+  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile);
   ASSERT_EQ(it.first->second, 4);
   ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 5));
 }
 
 TEST(PrefetchRepositoryTest, SplitTreeLevel10) {
   repository::RootTilesForRequest root_tiles_depth;
-  auto it =
-      root_tiles_depth.emplace(olp::geo::TileKey::FromHereTile("5904591"), 10);
+  auto tile = olp::geo::TileKey::FromHereTile("5904591");
+  auto it = root_tiles_depth.emplace(tile, 10);
 
-  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first);
+  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile);
   ASSERT_EQ(it.first->second, 0);
   ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 1) + pow(4, 6));
 }
@@ -85,8 +85,9 @@ TEST(PrefetchRepositoryTest, GetSlicedTilesWithLevelsSpecified) {
   auto tile = olp::geo::TileKey::FromHereTile("5904591");
   auto root_tiles_depth =
       PrefetchRepositoryTestable::GetSlicedTiles({tile}, 11, 13);
-  ASSERT_EQ(root_tiles_depth.begin()->first, tile);
-  ASSERT_EQ(root_tiles_depth.begin()->second, 2);
+  auto parent = tile.ChangedLevelTo(13 - 4);  // max_level -4
+  ASSERT_EQ(root_tiles_depth.begin()->first, parent);
+  ASSERT_EQ(root_tiles_depth.begin()->second, 4);
 }
 
 TEST(PrefetchRepositoryTest, GetSlicedTilesWithLevelsSpecified2) {
@@ -94,8 +95,8 @@ TEST(PrefetchRepositoryTest, GetSlicedTilesWithLevelsSpecified2) {
   auto root_tiles_depth =
       PrefetchRepositoryTestable::GetSlicedTiles({tile}, 1, 13);
   auto parent = tile.ChangedLevelBy(-10);
-  ASSERT_EQ(root_tiles_depth.find(parent)->second, 2);
-  ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 3) + pow(4, 8));
+  ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
+  ASSERT_EQ(root_tiles_depth.size(), 13 / 4);  // on each slice is 1 tile
 }
 
 TEST(PrefetchRepositoryTest, GetSlicedTilesDifferentLevelsButLevelsSpecified) {
@@ -105,8 +106,8 @@ TEST(PrefetchRepositoryTest, GetSlicedTilesDifferentLevelsButLevelsSpecified) {
   auto root_tiles_depth =
       PrefetchRepositoryTestable::GetSlicedTiles({tile1, tile2}, 1, 13);
   auto parent = tile1.ChangedLevelBy(-10);
-  ASSERT_EQ(root_tiles_depth.find(parent)->second, 2);
-  ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 3) + pow(4, 8));
+  ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
+  ASSERT_EQ(root_tiles_depth.size(), 13 / 4);  // on each slice is 1 tile
 }
 
 TEST(PrefetchRepositoryTest, GetSlicedTilesSibilings) {
@@ -128,10 +129,10 @@ TEST(PrefetchRepositoryTest, GetSlicedTilesSibilingsWithLevelsSpecified) {
   auto root_tiles_depth =
       PrefetchRepositoryTestable::GetSlicedTiles({tile1, tile2}, 11, 12);
   ASSERT_EQ(root_tiles_depth.size(), 1);
-  auto parent1 = tile1.ChangedLevelBy(-1);
-  auto parent2 = tile1.ChangedLevelBy(-1);
+  auto parent1 = tile1.ChangedLevelTo(12 - 4);
+  auto parent2 = tile1.ChangedLevelTo(12 - 4);
   ASSERT_EQ(parent1, parent2);
   ASSERT_EQ(root_tiles_depth.begin()->first, parent1);
-  ASSERT_EQ(root_tiles_depth.begin()->second, 1);
+  ASSERT_EQ(root_tiles_depth.begin()->second, 4);
 }
 }  // namespace

--- a/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
@@ -31,46 +31,52 @@ class PrefetchRepositoryTestable
   using repository::PrefetchTilesRepository::SplitSubtree;
 };
 
-TEST(PrefetchRepositoryTest, SplitTreeLevel5) {
-  repository::RootTilesForRequest root_tiles_depth;
-  auto tile = olp::geo::TileKey::FromHereTile("5904591");
-  auto it = root_tiles_depth.emplace(tile, 5);
+TEST(PrefetchRepositoryTest, SplitTreeLevels) {
+  {
+    SCOPED_TRACE("Split with depth 5");
+    repository::RootTilesForRequest root_tiles_depth;
+    auto tile = olp::geo::TileKey::FromHereTile("5904591");
+    auto it = root_tiles_depth.emplace(tile, 5);
 
-  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile, 0);
-  ASSERT_EQ(it.first->second, 0);
-  ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 1));
+    PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile,
+                                             0);
+    ASSERT_EQ(it.first->second, 0);
+    ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 1));
+  }
+  {
+    SCOPED_TRACE("Split with depth 8");
+    repository::RootTilesForRequest root_tiles_depth;
+    auto tile = olp::geo::TileKey::FromHereTile("5904591");
+    auto it = root_tiles_depth.emplace(tile, 8);
+
+    PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile,
+                                             0);
+    ASSERT_EQ(it.first->second, 3);
+    ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 4));
+  }
+  {
+    SCOPED_TRACE("Split with depth 9");
+    repository::RootTilesForRequest root_tiles_depth;
+    auto tile = olp::geo::TileKey::FromHereTile("5904591");
+    auto it = root_tiles_depth.emplace(tile, 9);
+
+    PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile,
+                                             0);
+    ASSERT_EQ(it.first->second, 4);
+    ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 5));
+  }
+  {
+    SCOPED_TRACE("Split with depth 10");
+    repository::RootTilesForRequest root_tiles_depth;
+    auto tile = olp::geo::TileKey::FromHereTile("5904591");
+    auto it = root_tiles_depth.emplace(tile, 10);
+
+    PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile,
+                                             0);
+    ASSERT_EQ(it.first->second, 0);
+    ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 1) + pow(4, 6));
+  }
 }
-
-TEST(PrefetchRepositoryTest, SplitTreeLevel8) {
-  repository::RootTilesForRequest root_tiles_depth;
-  auto tile = olp::geo::TileKey::FromHereTile("5904591");
-  auto it = root_tiles_depth.emplace(tile, 8);
-
-  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile, 0);
-  ASSERT_EQ(it.first->second, 3);
-  ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 4));
-}
-
-TEST(PrefetchRepositoryTest, SplitTreeLevel9) {
-  repository::RootTilesForRequest root_tiles_depth;
-  auto tile = olp::geo::TileKey::FromHereTile("5904591");
-  auto it = root_tiles_depth.emplace(tile, 9);
-
-  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile, 0);
-  ASSERT_EQ(it.first->second, 4);
-  ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 5));
-}
-
-TEST(PrefetchRepositoryTest, SplitTreeLevel10) {
-  repository::RootTilesForRequest root_tiles_depth;
-  auto tile = olp::geo::TileKey::FromHereTile("5904591");
-  auto it = root_tiles_depth.emplace(tile, 10);
-
-  PrefetchRepositoryTestable::SplitSubtree(root_tiles_depth, it.first, tile, 0);
-  ASSERT_EQ(it.first->second, 0);
-  ASSERT_EQ(root_tiles_depth.size(), 1 + pow(4, 1) + pow(4, 6));
-}
-
 TEST(PrefetchRepositoryTest, SplitTreeLevelMinLevelSet) {
   repository::RootTilesForRequest root_tiles_depth;
   auto tile = olp::geo::TileKey::FromHereTile("5904591");
@@ -83,88 +89,100 @@ TEST(PrefetchRepositoryTest, SplitTreeLevelMinLevelSet) {
   ASSERT_EQ(root_tiles_depth.size(), pow(4, 1) + pow(4, 6));
 }
 
-TEST(PrefetchRepositoryTest, GetSlicedTiles) {
+TEST(PrefetchRepositoryTest, GetSlicedTilesNoLevels) {
   auto tile = olp::geo::TileKey::FromHereTile("5904591");
   auto root_tiles_depth =
       PrefetchRepositoryTestable::GetSlicedTiles({tile}, 0, 0);
   ASSERT_EQ(root_tiles_depth.size(), 1);
   auto parent = tile.ChangedLevelBy(-4);
+  ASSERT_EQ(root_tiles_depth.size(), 1);
   ASSERT_EQ(root_tiles_depth.begin()->first, parent);
   ASSERT_EQ(root_tiles_depth.begin()->second, 4);
 }
 
 TEST(PrefetchRepositoryTest, GetSlicedTilesWithLevelsSpecified) {
-  auto tile = olp::geo::TileKey::FromHereTile("5904591");
-  auto root_tiles_depth =
-      PrefetchRepositoryTestable::GetSlicedTiles({tile}, 11, 13);
-  auto parent = tile.ChangedLevelTo(13 - 4);  // max_level -4
-  ASSERT_EQ(root_tiles_depth.begin()->first, parent);
-  ASSERT_EQ(root_tiles_depth.begin()->second, 4);
-}
-
-TEST(PrefetchRepositoryTest, GetSlicedTilesWithLevelsSpecified2) {
   auto tile = olp::geo::TileKey::FromHereTile("5904591");  // level 11
-  auto root_tiles_depth =
-      PrefetchRepositoryTestable::GetSlicedTiles({tile}, 1, 13);
-  auto parent = tile.ChangedLevelTo(1);
-  // sliced levels should be 1, 6, 11
-  ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
-  // 1 tile on each level
-  ASSERT_EQ(root_tiles_depth.size(), 3);
+  {
+    SCOPED_TRACE(
+        "Get sliced tiles with min level equal requested root tile level");
+    auto root_tiles_depth =
+        PrefetchRepositoryTestable::GetSlicedTiles({tile}, 11, 13);
+    auto parent = tile.ChangedLevelTo(13 - 4);  // max_level -4
+    ASSERT_EQ(root_tiles_depth.size(), 1);
+    ASSERT_EQ(root_tiles_depth.begin()->first, parent);
+    ASSERT_EQ(root_tiles_depth.begin()->second, 4);
+  }
+  {
+    SCOPED_TRACE(
+        "Get sliced tiles with min level smaller than requested root tile "
+        "level");
+    auto root_tiles_depth =
+        PrefetchRepositoryTestable::GetSlicedTiles({tile}, 1, 13);
+    auto parent = tile.ChangedLevelTo(1);
+    // sliced levels should be 1, 6, 11
+    ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
+    // 1 tile on each level
+    ASSERT_EQ(root_tiles_depth.size(), 3);
+  }
+  {
+    SCOPED_TRACE(
+        "Get sliced tiles with min level greater than requested root tile "
+        "level");
+    auto root_tiles_depth =
+        PrefetchRepositoryTestable::GetSlicedTiles({tile}, 14, 16);
+    // sliced levels should be 12
+    auto parent = tile.ChangedLevelTo(12);
+    ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
+    //  and 4^(12-11) tiles on level 12
+    ASSERT_EQ(root_tiles_depth.size(), 4);
+  }
 }
 
-TEST(PrefetchRepositoryTest, GetSlicedTilesWithLevelsSpecified3) {
-  auto tile = olp::geo::TileKey::FromHereTile("5904591");  // level 11
-  auto root_tiles_depth =
-      PrefetchRepositoryTestable::GetSlicedTiles({tile}, 14, 16);
-  // sliced levels should be 12
-  auto parent = tile.ChangedLevelTo(12);
-  ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
-  //  and 4^(12-11) tiles on level 12
-  ASSERT_EQ(root_tiles_depth.size(), 4);
-}
-
-TEST(PrefetchRepositoryTest, GetSlicedTilesDifferentLevelsButLevelsSpecified) {
+TEST(PrefetchRepositoryTest, GetSlicedTilesMultipleRootTiles) {
   auto tile1 = olp::geo::TileKey::FromHereTile("5904591");  // level 11
   auto tile2 = olp::geo::TileKey::FromHereTile(
       "23618365");  // level 12, this tile will be in the same subtree
-  auto root_tiles_depth =
-      PrefetchRepositoryTestable::GetSlicedTiles({tile1, tile2}, 1, 13);
-  // sliced levels should be 1, 6, 11
-  auto parent = tile1.ChangedLevelTo(1);
-  ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
-  ASSERT_EQ(root_tiles_depth.size(), 3);
+  {
+    SCOPED_TRACE(
+        "Get sliced tiles with min level smaller than both requested root tile "
+        "levels");
+    auto root_tiles_depth =
+        PrefetchRepositoryTestable::GetSlicedTiles({tile1, tile2}, 1, 13);
+    // sliced levels should be 1, 6, 11
+    auto parent = tile1.ChangedLevelTo(1);
+    ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
+    ASSERT_EQ(root_tiles_depth.size(), 3);
+  }
+  {
+    SCOPED_TRACE(
+        "Get sliced tiles with min level greter than first root tile level, "
+        "but equal second");
+
+    auto root_tiles_depth =
+        PrefetchRepositoryTestable::GetSlicedTiles({tile1, tile2}, 12, 13);
+    // sliced levels is 9
+    auto parent = tile1.ChangedLevelTo(13 - 4);
+    ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
+    // no duplicates for sliced tiles, as tile1 is parent tile2
+    ASSERT_EQ(root_tiles_depth.size(), 1);
+  }
+  {
+    SCOPED_TRACE(
+        "Get sliced tiles with min level greter than both requested root tiles "
+        "levels");
+    auto root_tiles_depth =
+        PrefetchRepositoryTestable::GetSlicedTiles({tile1, tile2}, 15, 16);
+    // sliced levels is 7 and 12, as tile1 on level 11, this means we need to
+    // get 4 tiles on level 12, and so on, so on level 15 it is and 4^(15-11)
+    // tiles the best way to query for each of 4 tiles on level 12
+    auto parent = tile1.ChangedLevelTo(16 - 4);
+    ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
+    // no duplicates for sliced tiles, as tile1 is parent tile2
+    ASSERT_EQ(root_tiles_depth.size(), 4);
+  }
 }
 
-TEST(PrefetchRepositoryTest, GetSlicedTilesDifferentLevelsButLevelsSpecified2) {
-  auto tile1 = olp::geo::TileKey::FromHereTile("5904591");  // level 11
-  auto tile2 = olp::geo::TileKey::FromHereTile(
-      "23618365");  // level 12, this tile will be in the same subtree
-  auto root_tiles_depth =
-      PrefetchRepositoryTestable::GetSlicedTiles({tile1, tile2}, 12, 13);
-  // sliced levels is 9
-  auto parent = tile1.ChangedLevelTo(13 - 4);
-  ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
-  // no duplicates for sliced tiles, as tile1 is parent tile2
-  ASSERT_EQ(root_tiles_depth.size(), 1);
-}
-
-TEST(PrefetchRepositoryTest, GetSlicedTilesDifferentLevelsButLevelsSpecified3) {
-  auto tile1 = olp::geo::TileKey::FromHereTile("5904591");  // level 11
-  auto tile2 = olp::geo::TileKey::FromHereTile(
-      "23618365");  // level 12, this tile will be in the same subtree
-  auto root_tiles_depth =
-      PrefetchRepositoryTestable::GetSlicedTiles({tile1, tile2}, 15, 16);
-  // sliced levels is 7 and 12, as tile1 on level 11, this means we need to get
-  // 4 tiles on level 12, and so on, so on level 15 it is and 4^(15-11) tiles
-  // the best way to query for each of 4 tiles on level 12
-  auto parent = tile1.ChangedLevelTo(16 - 4);
-  ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
-  // no duplicates for sliced tiles, as tile1 is parent tile2
-  ASSERT_EQ(root_tiles_depth.size(), 4);
-}
-
-TEST(PrefetchRepositoryTest, GetSlicedTilesSibilings) {
+TEST(PrefetchRepositoryTest, GetSlicedTilesSiblingsNoLevels) {
   auto tile1 = olp::geo::TileKey::FromHereTile("23618366");
   auto tile2 = olp::geo::TileKey::FromHereTile("23618365");
   auto root_tiles_depth =
@@ -177,7 +195,7 @@ TEST(PrefetchRepositoryTest, GetSlicedTilesSibilings) {
   ASSERT_EQ(root_tiles_depth.begin()->second, 4);
 }
 
-TEST(PrefetchRepositoryTest, GetSlicedTilesSibilingsWithLevelsSpecified) {
+TEST(PrefetchRepositoryTest, GetSlicedTilesSiblings) {
   auto tile1 = olp::geo::TileKey::FromHereTile("23618366");
   auto tile2 = olp::geo::TileKey::FromHereTile("23618365");
   auto root_tiles_depth =

--- a/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
@@ -44,7 +44,7 @@ constexpr auto kUrlQueryPartition269 =
     R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/testlayer/partitions?partition=269)";
 
 constexpr auto kUrlQuadTreeIndexVolatile =
-    R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/testlayer/quadkeys/5904591/depths/1)";
+    R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/testlayer/quadkeys/92259/depths/4)";
 
 constexpr auto kUrlQuadTreeIndexVolatile2 =
     R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/testlayer/quadkeys/23064/depths/4)";
@@ -504,7 +504,7 @@ TEST(VolatileLayerClientImplTest, PrefetchTiles) {
 
     auto request = read::PrefetchTilesRequest()
                        .WithTileKeys(tile_keys)
-                       .WithMinLevel(11)
+                       .WithMinLevel(8)
                        .WithMaxLevel(12);
 
     auto promise =
@@ -688,7 +688,7 @@ TEST(VolatileLayerClientImplTest, PrefetchTilesCancellableFuture) {
 
     auto request = read::PrefetchTilesRequest()
                        .WithTileKeys(tile_keys)
-                       .WithMinLevel(11)
+                       .WithMinLevel(8)
                        .WithMaxLevel(12);
 
     auto cancellable = client.PrefetchTiles(request);

--- a/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
@@ -329,14 +329,13 @@ TEST_F(ApiTest, QuadTreeIndex) {
 
   auto start_time = std::chrono::high_resolution_clock::now();
   auto index_response = olp::dataservice::read::QueryApi::QuadTreeIndex(
-      query_client, layer_id, version, quad_key, depth, boost::none,
+      query_client, layer_id, quad_key, version, depth, boost::none,
       boost::none, olp::client::CancellationContext{});
   auto end = std::chrono::high_resolution_clock::now();
 
   std::chrono::duration<double> time = end - start_time;
   std::cout << "duration: " << time.count() * 1000000 << " us" << std::endl;
-  ASSERT_TRUE(index_response.IsSuccessful())
-      << ApiErrorToString(index_response.GetError());
+  ASSERT_EQ(index_response.status, olp::http::HttpStatusCode::OK);
 }
 
 }  // namespace

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -199,8 +199,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, Prefetch) {
                        .WithMaxLevel(12);
 
     std::promise<dataservice_read::PrefetchTilesResponse> promise;
-    std::future<dataservice_read::PrefetchTilesResponse> future =
-        promise.get_future();
+    auto future = promise.get_future();
     auto token = client->PrefetchTiles(
         request, [&promise](dataservice_read::PrefetchTilesResponse response) {
           promise.set_value(std::move(response));
@@ -294,8 +293,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWideRange) {
                        .WithMaxLevel(12);
 
     std::promise<dataservice_read::PrefetchTilesResponse> promise;
-    std::future<dataservice_read::PrefetchTilesResponse> future =
-        promise.get_future();
+    auto future = promise.get_future();
     auto token = client->PrefetchTiles(
         request, [&promise](dataservice_read::PrefetchTilesResponse response) {
           promise.set_value(std::move(response));
@@ -355,8 +353,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWrongLevels) {
                          .WithMaxLevel(0);
 
       std::promise<dataservice_read::PrefetchTilesResponse> promise;
-      std::future<dataservice_read::PrefetchTilesResponse> future =
-          promise.get_future();
+      auto future = promise.get_future();
       auto token = client->PrefetchTiles(
           request,
           [&promise](dataservice_read::PrefetchTilesResponse response) {
@@ -384,8 +381,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWrongLevels) {
                          .WithMaxLevel(0);
 
       std::promise<dataservice_read::PrefetchTilesResponse> promise;
-      std::future<dataservice_read::PrefetchTilesResponse> future =
-          promise.get_future();
+      auto future = promise.get_future();
       auto token = client->PrefetchTiles(
           request,
           [&promise](dataservice_read::PrefetchTilesResponse response) {
@@ -412,8 +408,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWrongLevels) {
                          .WithMaxLevel(-1);
 
       std::promise<dataservice_read::PrefetchTilesResponse> promise;
-      std::future<dataservice_read::PrefetchTilesResponse> future =
-          promise.get_future();
+      auto future = promise.get_future();
       auto token = client->PrefetchTiles(
           request,
           [&promise](dataservice_read::PrefetchTilesResponse response) {
@@ -440,8 +435,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWrongLevels) {
                          .WithMaxLevel(3);
 
       std::promise<dataservice_read::PrefetchTilesResponse> promise;
-      std::future<dataservice_read::PrefetchTilesResponse> future =
-          promise.get_future();
+      auto future = promise.get_future();
       auto token = client->PrefetchTiles(
           request,
           [&promise](dataservice_read::PrefetchTilesResponse response) {

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -290,7 +290,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWideRange) {
 
     auto request = olp::dataservice::read::PrefetchTilesRequest()
                        .WithTileKeys(tile_keys)
-                       .WithMinLevel(10)
+                       .WithMinLevel(6)
                        .WithMaxLevel(12);
 
     std::promise<dataservice_read::PrefetchTilesResponse> promise;

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTestBase.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTestBase.cpp
@@ -174,9 +174,9 @@ void CatalogClientTestBase::SetUpCommonNetworkMockCalls() {
       .WillByDefault(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
                                         HTTP_RESPONSE_QUADKEYS_1476147));
 
-  ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_5904591), _, _, _, _))
+  ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_92259), _, _, _, _))
       .WillByDefault(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
-                                        HTTP_RESPONSE_QUADKEYS_5904591));
+                                        HTTP_RESPONSE_QUADKEYS_92259));
 
   ON_CALL(*network_mock_, Send(IsGetRequest(URL_QUADKEYS_369036), _, _, _, _))
       .WillByDefault(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),

--- a/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
@@ -104,8 +104,9 @@
 #define URL_LOOKUP_CONFIG \
   R"(https://api-lookup.data.api.platform.here.com/lookup/v1/platform/apis)"
 
-#define URL_LOOKUP_API \
-  R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/)"+GetTestCatalog()+R"(/apis)"
+#define URL_LOOKUP_API                                                      \
+  R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/)" + \
+      GetTestCatalog() + R"(/apis)"
 
 #define URL_SEEK_STREAM \
   R"(https://some.stream.url/stream/v2/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/testlayer/seek?mode=serial&subscriptionId=subscribe_id_12345)"
@@ -183,20 +184,21 @@
   R"jsonString({ "nodeBaseURL": "https://some.stream.url/stream/v2/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2", "subscriptionId": "subscribe_id_12345" })jsonString"
 
 // <PREFETCH URLs and RESPONSEs>
-#define URL_CONFIG_V2 \
-  R"(https://config.data.api.platform.here.com/config/v1/catalogs/)"+GetTestCatalog()
+#define URL_CONFIG_V2                                                  \
+  R"(https://config.data.api.platform.here.com/config/v1/catalogs/)" + \
+      GetTestCatalog()
 
 #define URL_QUADKEYS_23618364 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/23618364/depths/0)"
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/23618364/depths/4)"
 
 #define URL_QUADKEYS_1476147 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/1476147/depths/2)"
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/1476147/depths/4)"
 
 #define URL_QUADKEYS_5904591 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/5904591/depths/1)"
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/5904591/depths/4)"
 
 #define URL_QUADKEYS_369036 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/369036/depths/0)"
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/369036/depths/4)"
 
 #define URL_QUADKEYS_92259 \
   R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/92259/depths/4)"
@@ -205,25 +207,29 @@
   R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/testlayer/versions/108/quadkeys/92259/depths/4)"
 
 #define URL_QUADKEYS_VOLATILE_23618364 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/quadkeys/23618364/depths/0)"
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/quadkeys/23618364/depths/4)"
 
 #define URL_QUADKEYS_VOLATILE_1476147 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/quadkeys/1476147/depths/2)"
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/quadkeys/1476147/depths/4)"
 
 #define URL_QUADKEYS_VOLATILE_5904591 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/quadkeys/5904591/depths/1)"
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/quadkeys/5904591/depths/4)"
 
 #define URL_QUADKEYS_VOLATILE_369036 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/quadkeys/369036/depths/0)"
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/quadkeys/369036/depths/4)"
 
 #define URL_QUADKEYS_VOLATILE_92259 \
   R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/quadkeys/92259/depths/4)"
 
-#define URL_QUERY_PARTITION_23618365 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/)"+GetTestCatalog()+R"(/layers/hype-test-prefetch/partitions?partition=23618365&version=4)"
+#define URL_QUERY_PARTITION_23618365                                 \
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/)" + \
+      GetTestCatalog() +                                             \
+      R"(/layers/hype-test-prefetch/partitions?partition=23618365&version=4)"
 
-#define URL_QUERY_PARTITION_1476147 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/)"+GetTestCatalog()+R"(/layers/hype-test-prefetch/partitions?partition=1476147&version=4)"
+#define URL_QUERY_PARTITION_1476147                                  \
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/)" + \
+      GetTestCatalog() +                                             \
+      R"(/layers/hype-test-prefetch/partitions?partition=1476147&version=4)"
 
 #define URL_QUERY_VOLATILE_PARTITION_269 \
   R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/testlayer_volatile/partitions?partition=269)"
@@ -289,13 +295,13 @@
   R"jsonString({"subQuads": [{"version":4,"subQuadKey":"1","dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"}],"parentQuads": [{"version":4,"partition":"1476147","dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"}]})jsonString"
 
 #define HTTP_RESPONSE_QUADKEYS_5904591 \
-  R"jsonString({"subQuads": [{"version":4,"subQuadKey":"4","dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"},{"version":4,"subQuadKey":"5","dataHandle":"e119d20e-c7c6-4563-ae88-8aa5c6ca75c3"},{"version":4,"subQuadKey":"6","dataHandle":"a7a1afdf-db7e-4833-9627-d38bee6e2f81"},{"version":4,"subQuadKey":"7","dataHandle":"9d515348-afce-44e8-bc6f-3693cfbed104"},{"version":4,"subQuadKey":"1","dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": [{"version":4,"partition":"1476147","dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"}]})jsonString"
+  R"jsonString({"subQuads": [{"subQuadKey":"19","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"311","version":4,"dataHandle":"2d696e1f-4145-4bc9-b2b0-7420d1bc78c2"},{"subQuadKey":"316","version":4,"dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"},{"subQuadKey":"317","version":4,"dataHandle":"e119d20e-c7c6-4563-ae88-8aa5c6ca75c3"},{"subQuadKey":"318","version":4,"dataHandle":"a7a1afdf-db7e-4833-9627-d38bee6e2f81"},{"subQuadKey":"319","version":4,"dataHandle":"9d515348-afce-44e8-bc6f-3693cfbed104"},{"subQuadKey":"79","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString"
 
 #define HTTP_RESPONSE_QUADKEYS_369036 \
   R"jsonString({"subQuads": [{"version":4,"subQuadKey":"1","dataHandle":"data:Embedded Data for 369036"}],"parentQuads": []})jsonString"
 
 #define HTTP_RESPONSE_QUADKEYS_92259 \
-R"jsonString({"subQuads": [{"subQuadKey":"19","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"311","version":4,"dataHandle":"2d696e1f-4145-4bc9-b2b0-7420d1bc78c2"},{"subQuadKey":"316","version":4,"dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"},{"subQuadKey":"317","version":4,"dataHandle":"e119d20e-c7c6-4563-ae88-8aa5c6ca75c3"},{"subQuadKey":"318","version":4,"dataHandle":"a7a1afdf-db7e-4833-9627-d38bee6e2f81"},{"subQuadKey":"319","version":4,"dataHandle":"9d515348-afce-44e8-bc6f-3693cfbed104"},{"subQuadKey":"79","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString"
+  R"jsonString({"subQuads": [{"subQuadKey":"19","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"316","version":4,"dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"},{"subQuadKey":"317","version":4,"dataHandle":"e119d20e-c7c6-4563-ae88-8aa5c6ca75c3"},{"subQuadKey":"318","version":4,"dataHandle":"a7a1afdf-db7e-4833-9627-d38bee6e2f81"},{"subQuadKey":"319","version":4,"dataHandle":"9d515348-afce-44e8-bc6f-3693cfbed104"},{"subQuadKey":"79","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString"
 
 #define HTTP_RESPONSE_QUADKEYS_92259_ROOT_ONLY \
   R"jsonString({"subQuads": [{"subQuadKey":"1","version":4,"dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"}],"parentQuads": []})jsonString"

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -227,6 +227,10 @@ class DataserviceReadVersionedLayerClientTest : public ::testing::Test {
             Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_6), _, _, _, _))
         .WillByDefault(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
                                           HTTP_RESPONSE_BLOB_DATA_PREFETCH_6));
+    ON_CALL(*network_mock_,
+            Send(IsGetRequest(URL_BLOB_DATA_PREFETCH_7), _, _, _, _))
+        .WillByDefault(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
+                                          HTTP_RESPONSE_BLOB_DATA_PREFETCH_7));
 
     ON_CALL(*network_mock_, Send(IsGetRequest(URL_BLOB_DATA_269), _, _, _, _))
         .WillByDefault(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
@@ -1546,7 +1550,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesCancelOnLookup) {
       geo::TileKey::FromHereTile(kParitionId)};
   auto request = read::PrefetchTilesRequest()
                      .WithTileKeys(tile_keys)
-                     .WithMinLevel(11)
+                     .WithMinLevel(10)
                      .WithMaxLevel(12);
 
   auto token = client->PrefetchTiles(
@@ -1572,7 +1576,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
 
   auto request = read::PrefetchTilesRequest()
                      .WithTileKeys(tile_keys)
-                     .WithMinLevel(11)
+                     .WithMinLevel(10)
                      .WithMaxLevel(12);
 
   auto client = std::make_shared<read::VersionedLayerClient>(kCatalog, kLayerId,

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -1326,7 +1326,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesWithCache) {
                        .WithMaxLevel(12);
 
     auto promise = std::make_shared<std::promise<PrefetchTilesResponse>>();
-    std::future<PrefetchTilesResponse> future = promise->get_future();
+    auto future = promise->get_future();
     auto token = client->PrefetchTiles(
         request, [promise](PrefetchTilesResponse response) {
           promise->set_value(std::move(response));
@@ -1423,7 +1423,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
                        .WithMaxLevel(0);
 
     auto promise = std::make_shared<std::promise<PrefetchTilesResponse>>();
-    std::future<PrefetchTilesResponse> future = promise->get_future();
+    auto future = promise->get_future();
     auto token = client->PrefetchTiles(
         request, [promise](PrefetchTilesResponse response) {
           promise->set_value(std::move(response));
@@ -1490,7 +1490,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
       .WillOnce(testing::Invoke(std::move(cancel_mock)));
 
   std::promise<PrefetchTilesResponse> promise;
-  std::future<PrefetchTilesResponse> future = promise.get_future();
+  auto future = promise.get_future();
 
   constexpr auto kLayerId = "prefetch-catalog";
   constexpr auto kParitionId = "prefetch-partition";
@@ -1538,7 +1538,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesCancelOnLookup) {
       .WillOnce(testing::Invoke(std::move(cancel_mock)));
 
   std::promise<PrefetchTilesResponse> promise;
-  std::future<PrefetchTilesResponse> future = promise.get_future();
+  auto future = promise.get_future();
 
   constexpr auto kLayerId = "prefetch-catalog";
   constexpr auto kParitionId = "prefetch-partition";
@@ -1657,7 +1657,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesInvalidResponse) {
                                      "some invalid json"));
   }
   auto promise = std::make_shared<std::promise<PrefetchTilesResponse>>();
-  std::future<PrefetchTilesResponse> future = promise->get_future();
+  auto future = promise->get_future();
   auto token =
       client.PrefetchTiles(request, [promise](PrefetchTilesResponse response) {
         promise->set_value(std::move(response));
@@ -1668,7 +1668,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesInvalidResponse) {
   ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
   ASSERT_TRUE(response.GetResult().empty());
   ASSERT_EQ(client::ErrorCode::Unknown, response.GetError().GetErrorCode());
-  ASSERT_EQ("Failed to parse QuadTreeIndex json",
+  ASSERT_EQ("Failed to parse quad tree response",
             response.GetError().GetMessage());
 }
 
@@ -1690,7 +1690,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchSameTiles) {
                                      HTTP_RESPONSE_QUADKEYS_92259));
 
     auto promise = std::make_shared<std::promise<PrefetchTilesResponse>>();
-    std::future<PrefetchTilesResponse> future = promise->get_future();
+    auto future = promise->get_future();
     auto token = client.PrefetchTiles(
         request, [promise](PrefetchTilesResponse response) {
           promise->set_value(std::move(response));
@@ -1715,7 +1715,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchSameTiles) {
         .Times(0);
 
     auto promise = std::make_shared<std::promise<PrefetchTilesResponse>>();
-    std::future<PrefetchTilesResponse> future = promise->get_future();
+    auto future = promise->get_future();
     auto token = client.PrefetchTiles(
         request, [promise](PrefetchTilesResponse response) {
           promise->set_value(std::move(response));
@@ -3521,7 +3521,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesAndGetAggregated) {
                        .WithMaxLevel(12);
 
     auto promise = std::make_shared<std::promise<PrefetchTilesResponse>>();
-    std::future<PrefetchTilesResponse> future = promise->get_future();
+    auto future = promise->get_future();
     auto token = client.PrefetchTiles(
         request, [promise](PrefetchTilesResponse response) {
           promise->set_value(std::move(response));

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
@@ -171,6 +171,11 @@ void DataserviceReadVolatileLayerClientTest::SetUpCommonNetworkMockCalls() {
       .WillByDefault(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                             olp::http::HttpStatusCode::OK),
                                         HTTP_RESPONSE_BLOB_DATA_PREFETCH_6));
+  ON_CALL(*network_mock_,
+          Send(IsGetRequest(URL_BLOB_DATA_VOLATILE_PREFETCH_7), _, _, _, _))
+      .WillByDefault(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                            olp::http::HttpStatusCode::OK),
+                                        HTTP_RESPONSE_BLOB_DATA_PREFETCH_7));
 
   // Catch any non-interesting network calls that don't need to be verified
   EXPECT_CALL(*network_mock_, Send(_, _, _, _, _)).Times(testing::AtLeast(0));
@@ -958,7 +963,7 @@ TEST_F(DataserviceReadVolatileLayerClientTest, PrefetchTilesWithCache) {
         olp::geo::TileKey::FromHereTile("5904591")};
     auto request = read::PrefetchTilesRequest()
                        .WithTileKeys(tile_keys)
-                       .WithMinLevel(11)
+                       .WithMinLevel(8)
                        .WithMaxLevel(12);
     auto promise =
         std::make_shared<std::promise<read::PrefetchTilesResponse>>();
@@ -1208,7 +1213,7 @@ TEST_F(DataserviceReadVolatileLayerClientTest,
       olp::geo::TileKey::FromHereTile("5904591")};
   auto request = read::PrefetchTilesRequest()
                      .WithTileKeys(tile_keys)
-                     .WithMinLevel(11)
+                     .WithMinLevel(10)
                      .WithMaxLevel(12);
   auto cancel_future = client.PrefetchTiles(request);
   auto raw_future = cancel_future.GetFuture();
@@ -1251,7 +1256,7 @@ TEST_F(DataserviceReadVolatileLayerClientTest,
       olp::geo::TileKey::FromHereTile("5904591")};
   auto request = read::PrefetchTilesRequest()
                      .WithTileKeys(tile_keys)
-                     .WithMinLevel(11)
+                     .WithMinLevel(10)
                      .WithMaxLevel(12);
   auto cancel_future = client.PrefetchTiles(request);
 

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
@@ -137,10 +137,10 @@ void DataserviceReadVolatileLayerClientTest::SetUpCommonNetworkMockCalls() {
                                         HTTP_RESPONSE_QUADKEYS_1476147));
 
   ON_CALL(*network_mock_,
-          Send(IsGetRequest(URL_QUADKEYS_VOLATILE_5904591), _, _, _, _))
+          Send(IsGetRequest(URL_QUADKEYS_VOLATILE_92259), _, _, _, _))
       .WillByDefault(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                             olp::http::HttpStatusCode::OK),
-                                        HTTP_RESPONSE_QUADKEYS_5904591));
+                                        HTTP_RESPONSE_QUADKEYS_92259));
 
   ON_CALL(*network_mock_,
           Send(IsGetRequest(URL_BLOB_DATA_VOLATILE_PREFETCH_1), _, _, _, _))
@@ -1208,7 +1208,7 @@ TEST_F(DataserviceReadVolatileLayerClientTest,
       olp::geo::TileKey::FromHereTile("5904591")};
   auto request = read::PrefetchTilesRequest()
                      .WithTileKeys(tile_keys)
-                     .WithMinLevel(10)
+                     .WithMinLevel(11)
                      .WithMaxLevel(12);
   auto cancel_future = client.PrefetchTiles(request);
   auto raw_future = cancel_future.GetFuture();
@@ -1251,7 +1251,7 @@ TEST_F(DataserviceReadVolatileLayerClientTest,
       olp::geo::TileKey::FromHereTile("5904591")};
   auto request = read::PrefetchTilesRequest()
                      .WithTileKeys(tile_keys)
-                     .WithMinLevel(10)
+                     .WithMinLevel(11)
                      .WithMaxLevel(12);
   auto cancel_future = client.PrefetchTiles(request);
 


### PR DESCRIPTION
Change caching to QuadTreeIndex.
Always query depth 4. Update tests.

Relates-To: OLPEDGE-2084

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>