### PR TITLE
Mark SignInGoogle as deprecated.

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
@@ -395,7 +395,11 @@ class AUTHENTICATION_API AuthenticationClient {
    *
    * @return The `CancellationToken` instance that can be used to cancel
    * the request.
+   *
+   * @deprecated Will be removed by 12.2020.
    */
+  OLP_SDK_DEPRECATED(
+      "Sign in with Google token is deprecated and will be removed by 12.2020")
   client::CancellationToken SignInGoogle(
       const AuthenticationCredentials& credentials,
       const FederatedProperties& properties,

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -757,38 +757,6 @@ TEST_F(AuthenticationClientTest, SignInFacebookData) {
   ::testing::Mock::VerifyAndClearExpectations(network_.get());
 }
 
-TEST_F(AuthenticationClientTest, SignInGoogleData) {
-  EXPECT_CALL(*network_, Send(_, _, _, _, _))
-      .WillOnce(ReturnHttpResponse(
-          GetResponse(olp::http::HttpStatusCode::OK).WithError(kErrorOk),
-          kGoogleSigninResponse));
-
-  auth::AuthenticationClient::FederatedProperties properties;
-  std::time_t now = std::time(nullptr);
-  std::promise<auth::AuthenticationClient::SignInUserResponse> request;
-
-  client_->SignInGoogle(
-      auth::AuthenticationCredentials(key_, secret_), properties,
-      [&](const auth::AuthenticationClient::SignInUserResponse& response) {
-        request.set_value(response);
-      });
-
-  auto request_future = request.get_future();
-  auto response = request_future.get();
-
-  EXPECT_TRUE(response.IsSuccessful());
-  EXPECT_EQ(olp::http::HttpStatusCode::OK, response.GetResult().GetStatus());
-  EXPECT_EQ(kErrorOk, response.GetResult().GetErrorResponse().message);
-  EXPECT_EQ("google_grant_token", response.GetResult().GetAccessToken());
-  EXPECT_GE(now + kMaxExpiryTime, response.GetResult().GetExpiryTime());
-  EXPECT_LT(now + kMinExpiryTime, response.GetResult().GetExpiryTime());
-  EXPECT_EQ("bearer", response.GetResult().GetTokenType());
-  EXPECT_FALSE(response.GetResult().GetRefreshToken().empty());
-  EXPECT_FALSE(response.GetResult().GetUserIdentifier().empty());
-
-  ::testing::Mock::VerifyAndClearExpectations(network_.get());
-}
-
 TEST_F(AuthenticationClientTest, SignInArcGisData) {
   EXPECT_CALL(*network_, Send(_, _, _, _, _))
       .WillOnce(ReturnHttpResponse(

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationMockedResponses.h
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationMockedResponses.h
@@ -90,9 +90,6 @@ const std::string kUserSigninResponse = R"JSON(
 const std::string kFacebookSigninResponse = R"JSON(
     {"accessToken":"facebook_grant_token","tokenType":"bearer","expiresIn":3599,"refreshToken":"5j687leur4njgb4osomifn55p0","userId":"HERE-5fa10eda-39ff-4cbc-9b0c-5acba4685649"}
     )JSON";
-const std::string kGoogleSigninResponse = R"JSON(
-    {"accessToken":"google_grant_token","tokenType":"bearer","expiresIn":3599,"refreshToken":"5j687leur4njgb4osomifn55p0","userId":"HERE-5fa10eda-39ff-4cbc-9b0c-5acba4685649"}
-    )JSON";
 const std::string kArcgisSigninResponse = R"JSON(
     {"accessToken":"arcgis_grant_token","tokenType":"bearer","expiresIn":3599,"refreshToken":"5j687leur4njgb4osomifn55p0","userId":"HERE-5fa10eda-39ff-4cbc-9b0c-5acba4685649"}
     )JSON";


### PR DESCRIPTION
Sign with Google token is not supported anymore and so marked as
deprecated.

Resolves: OLPEDGE-2087

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>