### PR TITLE
Missing <numeric> include.

### DIFF
--- a/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -30,6 +30,7 @@
 #include <olp/core/porting/make_unique.h>
 #include <olp/dataservice/read/FetchOptions.h>
 #include <olp/dataservice/read/VersionedLayerClient.h>
+#include <numeric>
 #include <string>
 #include <testutils/CustomParameters.hpp>
 // clang-format off


### PR DESCRIPTION
std::iota used to generate QuadTreeIndex response. Its require <numeric>
include for build.

Resolves: OLPEDGE-2120

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>