### PR TITLE
Request apis in one request for write lib.

### DIFF
--- a/olp-cpp-sdk-dataservice-write/src/ApiClientLookup.h
+++ b/olp-cpp-sdk-dataservice-write/src/ApiClientLookup.h
@@ -56,6 +56,11 @@ class ApiClientLookup {
       const client::HRN& catalog,
       client::CancellationContext cancellation_context, std::string service,
       std::string service_version, client::OlpClientSettings settings);
+
+  static ApiClientResponse LookupApisClient(
+      const client::HRN& catalog,
+      client::CancellationContext cancellation_context, std::string service,
+      std::string service_version, client::OlpClientSettings settings);
 };
 
 }  // namespace write

--- a/olp-cpp-sdk-dataservice-write/src/generated/PlatformApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/PlatformApi.cpp
@@ -83,6 +83,25 @@ PlatformApi::ApisResponse PlatformApi::GetApis(
   return ApisResponse(parser::parse<model::Apis>(http_response.response));
 }
 
+PlatformApi::ApisResponse PlatformApi::GetApis(
+    const client::OlpClient& client, client::CancellationContext context) {
+  std::multimap<std::string, std::string> header_params;
+  header_params.insert(std::make_pair("Accept", "application/json"));
+  std::multimap<std::string, std::string> query_params;
+  std::multimap<std::string, std::string> form_params;
+
+  std::string platform_url = "/platform/apis";
+
+  auto http_response = client.CallApi(
+      std::move(platform_url), "GET", std::move(query_params),
+      std::move(header_params), std::move(form_params), nullptr, "", context);
+  if (http_response.status != olp::http::HttpStatusCode::OK) {
+    return {{http_response.status, http_response.response.str()}};
+  }
+
+  return parser::parse<model::Apis>(http_response.response);
+}
+
 }  // namespace write
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/PlatformApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/PlatformApi.h
@@ -63,6 +63,12 @@ class PlatformApi {
                               const std::string& service,
                               const std::string& service_version,
                               client::CancellationContext context);
+
+  /**
+   * @brief Synchronous version of \c GetApis method but for all apis.
+   */
+  static ApisResponse GetApis(const client::OlpClient& client,
+                              client::CancellationContext context);
 };
 
 }  // namespace write

--- a/olp-cpp-sdk-dataservice-write/src/generated/ResourcesApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/ResourcesApi.cpp
@@ -82,6 +82,26 @@ ResourcesApi::ApisResponse ResourcesApi::GetApis(
   return ApisResponse(parser::parse<model::Apis>(http_response.response));
 }
 
+ResourcesApi::ApisResponse ResourcesApi::GetApis(
+    const client::OlpClient& client, const std::string& hrn,
+    olp::client::CancellationContext cancel_context) {
+  std::multimap<std::string, std::string> header_params;
+  header_params.insert(std::make_pair("Accept", "application/json"));
+  std::multimap<std::string, std::string> query_params;
+  std::multimap<std::string, std::string> form_params;
+
+  // scan apis at resource endpoint
+  std::string resource_url = "/resources/" + hrn + "/apis";
+  auto http_response =
+      client.CallApi(std::move(resource_url), "GET", std::move(query_params),
+                     std::move(header_params), std::move(form_params), nullptr,
+                     "", cancel_context);
+  if (http_response.status != olp::http::HttpStatusCode::OK) {
+    return {{http_response.status, http_response.response.str()}};
+  }
+  return parser::parse<model::Apis>(http_response.response);
+}
+
 }  // namespace write
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/ResourcesApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/ResourcesApi.h
@@ -66,6 +66,13 @@ class ResourcesApi {
                               const std::string& service,
                               const std::string& service_version,
                               olp::client::CancellationContext cancel_context);
+
+  /**
+   * @brief Similar to synchronous GetApis method but requesting all apis.
+   */
+  static ApisResponse GetApis(const client::OlpClient& client,
+                              const std::string& hrn,
+                              olp::client::CancellationContext cancel_context);
 };
 
 }  // namespace write


### PR DESCRIPTION
Currently, write::ApiClientLookup::LookupApiClient loads only one api
per request. We can lower number of requests by requesting all apis
instead and cache them using new LookupApisClient. Its similar to
read::ApiClientLookup.

Resolves: OLPEDGE-1409

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>