### PR TITLE
Default lookup api provider.

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -58,6 +58,7 @@ set(OLP_SDK_CACHE_HEADERS
 
 set(OLP_SDK_CLIENT_HEADERS
     ./include/olp/core/client/ApiError.h
+    ./include/olp/core/client/ApiLookupClient.h
     ./include/olp/core/client/ApiNoResult.h
     ./include/olp/core/client/ApiResponse.h
     ./include/olp/core/client/BackdownStrategy.h

--- a/olp-cpp-sdk-core/include/olp/core/client/ApiLookupClient.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiLookupClient.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+
+#include <olp/core/CoreApi.h>
+
+namespace olp {
+
+namespace client {
+/**
+ * @brief Default implementation of the lookup API endpoint provider.
+ *
+ * This is returning the default lookup API endpoint URLs based on the HRN
+ * partition.
+ */
+struct CORE_API DefaultLookupEndpointProvider {
+ public:
+  std::string operator()(const std::string& partition) {
+    constexpr struct {
+      const char* partition;
+      const char* url;
+    } kDatastoreServerUrl[4] = {
+        {"here", "https://api-lookup.data.api.platform.here.com/lookup/v1"},
+        {"here-dev",
+         "https://api-lookup.data.api.platform.in.here.com/lookup/v1"},
+        {"here-cn",
+         "https://api-lookup.data.api.platform.hereolp.cn/lookup/v1"},
+        {"here-cn-dev",
+         "https://api-lookup.data.api.platform.in.hereolp.cn/lookup/v1"}};
+
+    for (const auto& it : kDatastoreServerUrl) {
+      if (partition == it.partition)
+        return it.url;
+    }
+
+    return std::string();
+  }
+};
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(OLP_CPP_SDK_CORE_TESTS_SOURCES
 
     ./client/CancellationContextTest.cpp
     ./client/ConditionTest.cpp
+    ./client/DefaultLookupEndpointProviderTest.cpp
     ./client/HRNTest.cpp
     ./client/OlpClientTest.cpp
     ./client/TaskContextTest.cpp

--- a/olp-cpp-sdk-core/tests/client/DefaultLookupEndpointProviderTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/DefaultLookupEndpointProviderTest.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock.h>
+#include <olp/core/client/ApiLookupClient.h>
+
+namespace {
+namespace client = olp::client;
+
+TEST(DefaultLookupEndpointProviderTest, ParenthesisOperator) {
+  const struct {
+    const std::string partition;
+    const std::string url;
+  } valid_apis[] = {
+      {"here", "https://api-lookup.data.api.platform.here.com/lookup/v1"},
+      {"here-dev",
+       "https://api-lookup.data.api.platform.in.here.com/lookup/v1"},
+      {"here-cn", "https://api-lookup.data.api.platform.hereolp.cn/lookup/v1"},
+      {"here-cn-dev",
+       "https://api-lookup.data.api.platform.in.hereolp.cn/lookup/v1"}};
+
+  auto provider = client::DefaultLookupEndpointProvider();
+
+  {
+    SCOPED_TRACE("Valid usage");
+    for (const auto& api : valid_apis) {
+      ASSERT_EQ(api.url, provider(api.partition));
+    }
+  }
+
+  {
+    SCOPED_TRACE("Not found partition");
+    const std::string unknown_partition = "unknown";
+    ASSERT_TRUE(provider(unknown_partition).empty());
+  }
+
+  {
+    SCOPED_TRACE("Empty partition");
+    ASSERT_TRUE(provider({}).empty());
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
DefaultLookupEndpointProvider used if user didn't provide any custom
lookup_endpoint_provider. This is preparation before adding
ApiLookupClient.

Resolves: OLPEDGE-1695

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>