### PR TITLE
Add check if partition/tile cached

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -527,8 +527,10 @@ bool VersionedLayerClientImpl::IsCached(const std::string& partition_id) const {
 }
 
 bool VersionedLayerClientImpl::IsCached(const geo::TileKey& tile) const {
-  auto partition_id = tile.ToHereTile();
-  return IsCached(partition_id);
+  repository::PartitionsCacheRepository cache_repository(catalog_,
+                                                         settings_.cache);
+  return cache_repository.IsTileCached(catalog_version_.load(), tile,
+                                       layer_id_);
 }
 
 client::CancellationToken VersionedLayerClientImpl::GetAggregatedData(

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -519,6 +519,18 @@ bool VersionedLayerClientImpl::RemoveFromCache(const geo::TileKey& tile) {
   return RemoveFromCache(partition_id);
 }
 
+bool VersionedLayerClientImpl::IsCached(const std::string& partition_id) const {
+  repository::PartitionsCacheRepository cache_repository(catalog_,
+                                                         settings_.cache);
+  return cache_repository.IsPartitionCached(catalog_version_.load(),
+                                            partition_id, layer_id_);
+}
+
+bool VersionedLayerClientImpl::IsCached(const geo::TileKey& tile) const {
+  auto partition_id = tile.ToHereTile();
+  return IsCached(partition_id);
+}
+
 client::CancellationToken VersionedLayerClientImpl::GetAggregatedData(
     TileRequest request, AggregatedDataResponseCallback callback) {
   auto catalog = catalog_;

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -21,7 +21,6 @@
 
 #include <memory>
 
-#include <boost/optional.hpp>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
@@ -33,6 +32,7 @@
 #include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/TileRequest.h>
 #include <olp/dataservice/read/Types.h>
+#include <boost/optional.hpp>
 #include "repositories/ExecuteOrSchedule.inl"
 
 namespace olp {
@@ -84,6 +84,10 @@ class VersionedLayerClientImpl {
   virtual bool RemoveFromCache(const std::string& partition_id);
 
   virtual bool RemoveFromCache(const geo::TileKey& tile);
+
+  bool IsCached(const std::string& partition_id) const;
+
+  bool IsCached(const geo::TileKey& tile) const;
 
   virtual client::CancellationToken GetAggregatedData(
       TileRequest request, AggregatedDataResponseCallback callback);

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -21,6 +21,7 @@
 
 #include <memory>
 
+#include <boost/optional.hpp>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
@@ -32,7 +33,6 @@
 #include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/TileRequest.h>
 #include <olp/dataservice/read/Types.h>
-#include <boost/optional.hpp>
 #include "repositories/ExecuteOrSchedule.inl"
 
 namespace olp {

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
@@ -77,7 +77,7 @@ bool DataCacheRepository::IsCached(const std::string& layer_id,
                                    const std::string& data_handle) const {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto data_key = CreateKey(hrn, layer_id, data_handle);
-  OLP_SDK_LOG_INFO_F(kLogTag, "IsCached key -> '%s'", data_key.c_str());
+  OLP_SDK_LOG_DEBUG_F(kLogTag, "IsCached key -> '%s'", data_key.c_str());
   return cache_->Contains(data_key);
 }
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
@@ -73,6 +73,14 @@ boost::optional<model::Data> DataCacheRepository::Get(
   return cached_data;
 }
 
+bool DataCacheRepository::IsCached(const std::string& layer_id,
+                                   const std::string& data_handle) const {
+  std::string hrn(hrn_.ToCatalogHRNString());
+  auto data_key = CreateKey(hrn, layer_id, data_handle);
+  OLP_SDK_LOG_INFO_F(kLogTag, "IsCached key -> '%s'", data_key.c_str());
+  return cache_->Contains(data_key);
+}
+
 bool DataCacheRepository::Clear(const std::string& layer_id,
                                 const std::string& data_handle) {
   std::string hrn(hrn_.ToCatalogHRNString());

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.h
@@ -47,6 +47,8 @@ class DataCacheRepository final {
 
   boost::optional<model::Data> Get(const std::string& layer_id,
                                    const std::string& data_handle);
+  bool IsCached(const std::string& layer_id,
+                const std::string& data_handle) const;
 
   bool Clear(const std::string& layer_id, const std::string& data_handle);
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
@@ -231,13 +231,12 @@ bool PartitionsCacheRepository::Get(const std::string& layer,
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, layer, tile_key, depth, version);
   OLP_SDK_LOG_DEBUG_F(kLogTag, "Get -> '%s'", key.c_str());
-  if (cache_->Contains(key)) {
-    auto data = cache_->Get(key);
-    if (data) {
-      tree = QuadTreeIndex(data);
-      return true;
-    }
+  auto data = cache_->Get(key);
+  if (data) {
+    tree = QuadTreeIndex(data);
+    return true;
   }
+
   return false;
 }
 
@@ -293,20 +292,17 @@ bool PartitionsCacheRepository::GetPartitionHandle(
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, layer_id, partition_id, catalog_version);
   OLP_SDK_LOG_DEBUG_F(kLogTag, "IsPartitionCached -> '%s'", key.c_str());
-  if (cache_->Contains(key)) {
-    auto cached_partition =
-        cache_->Get(key, [](const std::string& serialized_object) {
-          return parser::parse<model::Partition>(serialized_object);
-        });
+  auto cached_partition =
+      cache_->Get(key, [](const std::string& serialized_object) {
+        return parser::parse<model::Partition>(serialized_object);
+      });
 
-    if (cached_partition.empty()) {
-      return false;
-    }
-    auto partition = boost::any_cast<model::Partition>(cached_partition);
-    data_handle = partition.GetDataHandle();
-    return true;
+  if (cached_partition.empty()) {
+    return false;
   }
-  return false;
+  auto partition = boost::any_cast<model::Partition>(cached_partition);
+  data_handle = partition.GetDataHandle();
+  return true;
 }
 PORTING_POP_WARNINGS()
 }  // namespace repository

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
@@ -78,6 +78,10 @@ class PartitionsCacheRepository final {
                               const std::string& layer_id,
                               boost::optional<model::Partition>& out_partition);
 
+  bool IsPartitionCached(const boost::optional<int64_t>& catalog_version,
+                         const std::string& partition_id,
+                         const std::string& layer_id);
+
  private:
   client::HRN hrn_;
   std::shared_ptr<cache::KeyValueCache> cache_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
@@ -82,6 +82,9 @@ class PartitionsCacheRepository final {
                          const std::string& partition_id,
                          const std::string& layer_id);
 
+  bool IsTileCached(const boost::optional<int64_t>& catalog_version,
+                    geo::TileKey key, const std::string& layer);
+
  private:
   client::HRN hrn_;
   std::shared_ptr<cache::KeyValueCache> cache_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
@@ -64,8 +64,8 @@ class PartitionsCacheRepository final {
            const QuadTreeIndex& quad_tree,
            const boost::optional<int64_t>& version);
 
-  QuadTreeIndex Get(const std::string& layer, geo::TileKey key, int32_t depth,
-                    const boost::optional<int64_t>& version);
+  bool Get(const std::string& layer, geo::TileKey key, int32_t depth,
+           const boost::optional<int64_t>& version, QuadTreeIndex& tree);
 
   void Clear(const std::string& layer_id);
 
@@ -78,12 +78,10 @@ class PartitionsCacheRepository final {
                               const std::string& layer_id,
                               boost::optional<model::Partition>& out_partition);
 
-  bool IsPartitionCached(const boost::optional<int64_t>& catalog_version,
-                         const std::string& partition_id,
-                         const std::string& layer_id);
-
-  bool IsTileCached(const boost::optional<int64_t>& catalog_version,
-                    geo::TileKey key, const std::string& layer);
+  bool GetPartitionHandle(const boost::optional<int64_t>& catalog_version,
+                          const std::string& partition_id,
+                          const std::string& layer_id,
+                          std::string& data_handle);
 
  private:
   client::HRN hrn_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -77,6 +77,13 @@ class PartitionsRepository {
       const TileRequest& request, boost::optional<int64_t> version,
       const client::OlpClientSettings& settings);
 
+  static bool FindQuadTree(const client::HRN& catalog,
+                           const client::OlpClientSettings& settings,
+                           const std::string& layer,
+                           boost::optional<int64_t> version,
+                           const olp::geo::TileKey& tile_key,
+                           read::QuadTreeIndex& tree);
+
  private:
   static QuadTreeIndexResponse GetQuadTreeIndexForTile(
       const client::HRN& catalog, const std::string& layer,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -207,8 +207,8 @@ SubQuadsResponse PrefetchTilesRepository::GetSubQuads(
   };
 
   // check if quad tree with requested tile and depth already in cache
-  auto cached_tree = repository.Get(layer_id, tile, depth, version);
-  if (!cached_tree.IsNull()) {
+  QuadTreeIndex cached_tree;
+  if (repository.Get(layer_id, tile, depth, version, cached_tree)) {
     OLP_SDK_LOG_DEBUG_F(kLogTag,
                         "GetSubQuads found in cache, tile='%s', "
                         "depth='%" PRId32 "'",

--- a/olp-cpp-sdk-dataservice-read/tests/DataCacheRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/DataCacheRepositoryTest.cpp
@@ -67,6 +67,14 @@ TEST(PartitionsCacheRepositoryTest, DefaultExpiry) {
 
     EXPECT_FALSE(result);
   }
+}
+
+TEST(PartitionsCacheRepositoryTest, IsCached) {
+  const auto hrn = client::HRN::FromString(kCatalog);
+  const auto layer = "layer";
+
+  const auto data = std::vector<unsigned char>{1, 2, 3};
+  const auto model_data = std::make_shared<std::vector<unsigned char>>(data);
 
   {
     SCOPED_TRACE("Is cached");

--- a/olp-cpp-sdk-dataservice-read/tests/DataCacheRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/DataCacheRepositoryTest.cpp
@@ -25,9 +25,10 @@
 #include <olp/core/client/OlpClientSettingsFactory.h>
 
 namespace {
-
-using namespace olp;
-using namespace olp::dataservice::read;
+namespace read = olp::dataservice::read;
+namespace repository = olp::dataservice::read::repository;
+namespace client = olp::client;
+namespace cache = olp::cache;
 
 constexpr auto kCatalog = "hrn:here:data::olp-here-test:catalog";
 constexpr auto kDataHandle = "4eed6ed1-0d32-43b9-ae79-043cb4256432";
@@ -63,6 +64,31 @@ TEST(PartitionsCacheRepositoryTest, DefaultExpiry) {
 
     repository.Put(model_data, layer, kDataHandle);
     const auto result = repository.Get(layer, kDataHandle);
+
+    EXPECT_FALSE(result);
+  }
+
+  {
+    SCOPED_TRACE("Is cached");
+
+    std::shared_ptr<cache::KeyValueCache> cache =
+        olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+    repository::DataCacheRepository repository(hrn, cache);
+
+    repository.Put(model_data, layer, kDataHandle);
+    const auto result = repository.IsCached(layer, kDataHandle);
+
+    EXPECT_TRUE(result);
+  }
+
+  {
+    SCOPED_TRACE("Is not cached");
+
+    std::shared_ptr<cache::KeyValueCache> cache =
+        olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+    repository::DataCacheRepository repository(hrn, cache);
+
+    const auto result = repository.IsCached(layer, kDataHandle);
 
     EXPECT_FALSE(result);
   }

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsCacheRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsCacheRepositoryTest.cpp
@@ -37,7 +37,8 @@ constexpr auto kCatalog = "hrn:here:data::olp-here-test:catalog";
 constexpr auto kPartitionId = "1111";
 constexpr auto kDataHandle = "7636348E50215979A39B5F3A429EDDB4.1111";
 constexpr auto kHereTile = "23618364";
-constexpr auto kTileDataHandle = "8C9B3E08E294ADB2CD07EBC8412062FE.236";
+constexpr auto kTileDataHandle = "BD53A6D60A34C20DC42ACAB2650FE361.48";
+constexpr auto kTileChildDataHandle = "7636348E50215979A39B5F3A429EDDB4.282";
 constexpr auto kQuadkeyResponse =
     R"jsonString({"subQuads": [{"subQuadKey": "4","version":282,"dataHandle":"7636348E50215979A39B5F3A429EDDB4.282","dataSize":277},{"subQuadKey":"5","version":282,"dataHandle":"8C9B3E08E294ADB2CD07EBC8412062FE.282","dataSize":271},{"subQuadKey": "6","version":282,"dataHandle":"9772F5E1822DFF25F48F150294B1ECF5.282","dataSize":289},{"subQuadKey":"7","version":282,"dataHandle":"BF84D8EC8124B96DBE5C4DB68B05918F.282","dataSize":283},{"subQuadKey":"1","version":48,"dataHandle":"BD53A6D60A34C20DC42ACAB2650FE361.48","dataSize":89}],"parentQuads":[{"partition":"23","version":282,"dataHandle":"F8F4C3CB09FBA61B927256CBCB8441D1.282","dataSize":52438},{"partition":"5","version":282,"dataHandle":"13E2C624E0136C3357D092EE7F231E87.282","dataSize":99151},{"partition":"95","version":253,"dataHandle":"B6F7614316BB8B81478ED7AE370B22A6.253","dataSize":6765}]})jsonString";
 
@@ -149,7 +150,7 @@ TEST(PartitionsCacheRepositoryTest, QuadTree) {
   const auto hrn = HRN::FromString(kCatalog);
   const auto layer = "layer";
   const auto version = 0;
-  const auto tile_key = olp::geo::TileKey::FromHereTile("23618364");
+  const auto tile_key = olp::geo::TileKey::FromHereTile(kHereTile);
   const auto depth = 2;
 
   {
@@ -189,20 +190,16 @@ TEST(PartitionsCacheRepositoryTest, QuadTree) {
   }
 }
 
-TEST(PartitionsCacheRepositoryTest, IsPartitionCached) {
+TEST(PartitionsCacheRepositoryTest, IsCached) {
   const auto hrn = HRN::FromString(kCatalog);
   const auto layer = "layer";
 
   model::Partition some_partition;
   some_partition.SetPartition(kPartitionId);
   some_partition.SetDataHandle(kDataHandle);
-  model::Partition some_tile_partition;
-  some_tile_partition.SetPartition(kHereTile);
-  some_tile_partition.SetDataHandle(kTileDataHandle);
   model::Partitions partitions;
   auto& partitions_vector = partitions.GetMutablePartitions();
   partitions_vector.push_back(some_partition);
-  partitions_vector.push_back(some_tile_partition);
 
   {
     SCOPED_TRACE("Put/Check partition");
@@ -212,7 +209,6 @@ TEST(PartitionsCacheRepositoryTest, IsPartitionCached) {
     repository::PartitionsCacheRepository repository(hrn, cache);
 
     repository.Put({}, partitions, layer, boost::none, true);
-
     EXPECT_FALSE(
         repository.IsPartitionCached(boost::none, kPartitionId, layer));
     repository::DataCacheRepository data_repository(hrn, cache);
@@ -237,19 +233,40 @@ TEST(PartitionsCacheRepositoryTest, IsPartitionCached) {
   {
     SCOPED_TRACE("Put/Check tile");
 
+    const auto version = 0;
+    const auto tile_key = olp::geo::TileKey::FromHereTile(kHereTile);
+    const auto depth = 4;
+    auto stream = std::stringstream(kQuadkeyResponse);
+    read::QuadTreeIndex quad_tree(tile_key, depth, stream);
+
     std::shared_ptr<KeyValueCache> cache =
         olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
     repository::PartitionsCacheRepository repository(hrn, cache);
+    repository.Put(layer, tile_key, depth, quad_tree, version);
+    const auto result = repository.Get(layer, tile_key, depth, version);
+    ASSERT_FALSE(result.IsNull());
+    ASSERT_EQ(*result.GetRawData(), *quad_tree.GetRawData());
+    EXPECT_FALSE(repository.IsTileCached(version, tile_key, layer));
 
-    repository.Put({}, partitions, layer, boost::none, true);
     repository::DataCacheRepository data_repository(hrn, cache);
     std::string some_data("abc");
     auto data = std::make_shared<std::vector<unsigned char>>(some_data.begin(),
                                                              some_data.end());
     data_repository.Put(data, layer, kTileDataHandle);
-    EXPECT_FALSE(
-        repository.IsPartitionCached(boost::none, kPartitionId, layer));
-    EXPECT_TRUE(repository.IsPartitionCached(boost::none, kHereTile, layer));
+    EXPECT_TRUE(repository.IsTileCached(version, tile_key, layer));
+    EXPECT_FALSE(repository.IsTileCached(version, tile_key.GetChild(0), layer));
+
+    data_repository.Put(data, layer, kTileChildDataHandle);
+    EXPECT_TRUE(repository.IsTileCached(version, tile_key.GetChild(0), layer));
+  }
+  {
+    SCOPED_TRACE("Check if tile not in cache");
+    const auto version = 0;
+    const auto tile_key = olp::geo::TileKey::FromHereTile(kHereTile);
+    std::shared_ptr<KeyValueCache> cache =
+        olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+    repository::PartitionsCacheRepository repository(hrn, cache);
+    EXPECT_FALSE(repository.IsTileCached(version, tile_key, layer));
   }
 }
 

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsCacheRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsCacheRepositoryTest.cpp
@@ -164,7 +164,6 @@ TEST(PartitionsCacheRepositoryTest, QuadTree) {
         .WillOnce(DoAll(SaveArg<0>(&key), Return(true)));
     repository.Put(layer, tile_key, depth, quad_tree, version);
 
-    EXPECT_CALL(*cache, Contains(key)).WillOnce(Return(true));
     EXPECT_CALL(*cache, Get(key)).WillOnce(Return(quad_tree.GetRawData()));
     read::QuadTreeIndex tree;
     const auto result = repository.Get(layer, tile_key, depth, version, tree);
@@ -181,7 +180,6 @@ TEST(PartitionsCacheRepositoryTest, QuadTree) {
     auto cache = std::make_shared<CacheMock>();
     repository::PartitionsCacheRepository repository(hrn, cache);
 
-    EXPECT_CALL(*cache, Contains(_)).WillOnce(Return(true));
     EXPECT_CALL(*cache, Get(_)).WillOnce(Return(KeyValueCache::ValueTypePtr()));
 
     repository.Put(layer, tile_key, depth, quad_tree, version);

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -930,10 +930,8 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
                                      kSubQuads));
-
     EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(boost::any()));
     EXPECT_CALL(*mock_cache, Put(_, _, _, _)).WillOnce(Return(true));
-    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
@@ -973,7 +971,6 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
                                      kSubQuadsWithParent));
     EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(boost::any()));
     EXPECT_CALL(*mock_cache, Put(_, _, _, _)).WillOnce(Return(true));
-    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
@@ -1005,7 +1002,6 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     auto ss = std::stringstream(kSubQuads);
     read::QuadTreeIndex quad_tree(tile_key.ChangedLevelBy(-depth), depth, ss);
 
-    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_)).WillOnce(Return(quad_tree.GetRawData()));
 
     auto response = PartitionsRepository::GetAggregatedTile(
@@ -1038,7 +1034,6 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
                                      kSubQuadsWithParent));
     EXPECT_CALL(*mock_cache, Get(_, _))
         .WillOnce(Return(boost::any(kUrlQueryApi)));
-    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
@@ -1076,7 +1071,6 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
                                      kSubQuads));
     EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(boost::any()));
     EXPECT_CALL(*mock_cache, Put(_, _, _, _)).WillOnce(Return(true));
-    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
@@ -1105,7 +1099,6 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     settings.cache = mock_cache;
     settings.network_request_handler = mock_network;
 
-    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
@@ -1138,7 +1131,6 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
                                    olp::http::HttpStatusCode::BAD_REQUEST),
                                kErrorServiceUnavailable));
     EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(boost::any()));
-    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
@@ -1179,7 +1171,6 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
                                kErrorServiceUnavailable));
     EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(boost::any()));
     EXPECT_CALL(*mock_cache, Put(_, _, _, _)).WillOnce(Return(true));
-    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
@@ -1219,7 +1210,6 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
                                      kInvalidJson));
     EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(boost::any()));
     EXPECT_CALL(*mock_cache, Put(_, _, _, _)).WillOnce(Return(true));
-    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -930,8 +930,10 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
                                      kSubQuads));
+
     EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(boost::any()));
     EXPECT_CALL(*mock_cache, Put(_, _, _, _)).WillOnce(Return(true));
+    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
@@ -971,6 +973,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
                                      kSubQuadsWithParent));
     EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(boost::any()));
     EXPECT_CALL(*mock_cache, Put(_, _, _, _)).WillOnce(Return(true));
+    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
@@ -1002,6 +1005,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     auto ss = std::stringstream(kSubQuads);
     read::QuadTreeIndex quad_tree(tile_key.ChangedLevelBy(-depth), depth, ss);
 
+    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_)).WillOnce(Return(quad_tree.GetRawData()));
 
     auto response = PartitionsRepository::GetAggregatedTile(
@@ -1034,6 +1038,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
                                      kSubQuadsWithParent));
     EXPECT_CALL(*mock_cache, Get(_, _))
         .WillOnce(Return(boost::any(kUrlQueryApi)));
+    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
@@ -1071,6 +1076,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
                                      kSubQuads));
     EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(boost::any()));
     EXPECT_CALL(*mock_cache, Put(_, _, _, _)).WillOnce(Return(true));
+    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
@@ -1099,6 +1105,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     settings.cache = mock_cache;
     settings.network_request_handler = mock_network;
 
+    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
@@ -1131,6 +1138,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
                                    olp::http::HttpStatusCode::BAD_REQUEST),
                                kErrorServiceUnavailable));
     EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(boost::any()));
+    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
@@ -1171,6 +1179,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
                                kErrorServiceUnavailable));
     EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(boost::any()));
     EXPECT_CALL(*mock_cache, Put(_, _, _, _)).WillOnce(Return(true));
+    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
@@ -1210,6 +1219,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
                                      kInvalidJson));
     EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(boost::any()));
     EXPECT_CALL(*mock_cache, Put(_, _, _, _)).WillOnce(Return(true));
+    EXPECT_CALL(*mock_cache, Contains(_)).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 


### PR DESCRIPTION
Add implementation to VersionLayerClientImpl
if partition/tile cached. Added check to
DataCacheRepository if data handle cached.
Add tests for PartitionCacheRepository to check
if partition is cached.

Relates-To: OLPEDGE-2111

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>