### PR TITLE
Add Protect/Release functionality

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
@@ -178,6 +178,30 @@ class CORE_API DefaultCache : public KeyValueCache {
    */
   bool Contains(const std::string& key) const override;
 
+  /**
+   * @brief Protects keys from eviction.
+   *
+   * You can use keys or prefixes to protect single keys or entire catalogs,
+   * layers, or version.
+   *
+   * @param keys The list of keys or prefixes.
+   *
+   * @return True if the keys are added to the protected list; false otherwise.
+   */
+  bool Protect(const KeyValueCache::KeyListType& keys) override;
+
+  /**
+   * @brief Removes a list of keys from protection.
+   *
+   * The provided keys can be full keys or prefixes only.
+   *
+   * @param keys The list of keys or prefixes.
+   *
+   * @return True if the keys are removed from the protected list; false
+   * otherwise.
+   */
+  bool Release(const KeyValueCache::KeyListType& keys) override;
+
  private:
   std::shared_ptr<DefaultCacheImpl> impl_;
 };

--- a/olp-cpp-sdk-core/include/olp/core/cache/KeyValueCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/KeyValueCache.h
@@ -139,6 +139,36 @@ class CORE_API KeyValueCache {
     CORE_UNUSED(key);
     return false;
   }
+
+  /**
+   * @brief Protects keys from eviction.
+   *
+   * You can use keys or prefixes to protect single keys or entire catalogs,
+   * layers, or version.
+   *
+   * @param keys The list of keys or prefixes.
+   *
+   * @return True if the keys are added to the protected list; false otherwise.
+   */
+  virtual bool Protect(const KeyListType& keys) {
+    CORE_UNUSED(keys);
+    return false;
+  }
+
+  /**
+   * @brief Removes a list of keys from protection.
+   *
+   * The provided keys can be full keys or prefixes only.
+   *
+   * @param keys The list of keys or prefixes.
+   *
+   * @return True if the keys are removed from the protected list; false
+   * otherwise.
+   */
+  virtual bool Release(const KeyListType& keys) {
+    CORE_UNUSED(keys);
+    return false;
+  }
 };
 
 }  // namespace cache

--- a/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
@@ -65,5 +65,13 @@ bool DefaultCache::Contains(const std::string& key) const {
   return impl_->Contains(key);
 }
 
+bool DefaultCache::Protect(const KeyValueCache::KeyListType& keys) {
+  return impl_->Protect(keys);
+}
+
+bool DefaultCache::Release(const KeyValueCache::KeyListType& keys) {
+  return impl_->Release(keys);
+}
+
 }  // namespace cache
 }  // namespace olp

--- a/tests/integration/olp-cpp-sdk-core/DefaultCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-core/DefaultCacheTest.cpp
@@ -23,19 +23,19 @@
 #include <olp/core/cache/DefaultCache.h>
 
 namespace {
-using namespace olp::cache;
+namespace cache = olp::cache;
 
 TEST(DefaultCacheTest, DataExpiration) {
   const std::string content_key = "test_key";
-  CacheSettings settings;
+  cache::CacheSettings settings;
   settings.max_memory_cache_size = 5;  // bytes
   settings.disk_path_mutable = "./cache";
   const auto expire_time = 1;
 
   {
     SCOPED_TRACE("Create a disk cache, write data.");
-    DefaultCache cache(settings);
-    EXPECT_EQ(cache.Open(), DefaultCache::StorageOpenResult::Success);
+    cache::DefaultCache cache(settings);
+    EXPECT_EQ(cache.Open(), cache::DefaultCache::StorageOpenResult::Success);
 
     const std::string content = "12345";
     auto buffer = std::make_shared<std::vector<unsigned char>>(
@@ -51,12 +51,286 @@ TEST(DefaultCacheTest, DataExpiration) {
 
   {
     SCOPED_TRACE("Check that data is expired after timeout.");
-    DefaultCache cache(settings);
-    EXPECT_EQ(cache.Open(), DefaultCache::StorageOpenResult::Success);
+    cache::DefaultCache cache(settings);
+    EXPECT_EQ(cache.Open(), cache::DefaultCache::StorageOpenResult::Success);
 
     auto buffer = cache.Get(content_key);
     ASSERT_EQ(buffer, nullptr);
 
+    cache.Close();
+  }
+}
+
+TEST(DefaultCacheTest, ProtectExpiration) {
+  const std::string prefix = "test::";
+  const std::string content_key = prefix + "test_key";
+  cache::CacheSettings settings;
+  settings.max_memory_cache_size = 5;  // bytes
+  settings.disk_path_mutable = "./cache";
+  const auto expire_time = 1;
+  const std::string content = "12345";
+  auto buffer = std::make_shared<std::vector<unsigned char>>(
+      std::begin(content), std::end(content));
+
+  {
+    SCOPED_TRACE("Protected data do not expire after timeout.");
+    cache::DefaultCache cache(settings);
+    EXPECT_EQ(cache.Open(), cache::DefaultCache::StorageOpenResult::Success);
+    EXPECT_TRUE(cache.Put(content_key, buffer, expire_time));
+    // protect key wait timeout and check if it exist
+    EXPECT_TRUE(cache.Protect({content_key}));
+    std::this_thread::sleep_for(std::chrono::seconds(expire_time + 1));
+    ASSERT_NE(cache.Get(content_key), nullptr);
+    cache.Clear();
+    cache.Close();
+  }
+  {
+    SCOPED_TRACE("Protected data do not expire after release.");
+    cache::DefaultCache cache(settings);
+    EXPECT_EQ(cache.Open(), cache::DefaultCache::StorageOpenResult::Success);
+    EXPECT_TRUE(cache.Put(content_key, buffer, expire_time));
+    // protect key wait timeout and check if it exist
+    EXPECT_TRUE(cache.Protect({content_key}));
+    std::this_thread::sleep_for(std::chrono::seconds(expire_time + 1));
+    EXPECT_TRUE(cache.Contains(content_key));
+    ASSERT_NE(cache.Get(content_key), nullptr);
+    // release key and check if it expires
+    EXPECT_TRUE(cache.Release({content_key}));
+    EXPECT_FALSE(cache.Contains(content_key));
+    ASSERT_EQ(cache.Get(content_key), nullptr);
+    cache.Clear();
+    cache.Close();
+  }
+  {
+    SCOPED_TRACE("Protected data before put");
+    cache::DefaultCache cache(settings);
+    EXPECT_EQ(cache.Open(), cache::DefaultCache::StorageOpenResult::Success);
+    EXPECT_FALSE(cache.Contains(content_key));
+    // protect key wait timeout and check if it exist
+    EXPECT_TRUE(cache.Protect({content_key}));
+    EXPECT_TRUE(cache.Put(content_key, buffer, expire_time));
+    std::this_thread::sleep_for(std::chrono::seconds(expire_time + 1));
+    EXPECT_TRUE(cache.Contains(content_key));
+    ASSERT_NE(cache.Get(content_key), nullptr);
+    // release key and check if it expires
+    EXPECT_TRUE(cache.Release({content_key}));
+    EXPECT_FALSE(cache.Contains(content_key));
+    ASSERT_EQ(cache.Get(content_key), nullptr);
+    cache.Clear();
+    cache.Close();
+  }
+  {
+    SCOPED_TRACE("Protect and release key by prefix");
+    cache::DefaultCache cache(settings);
+    EXPECT_EQ(cache.Open(), cache::DefaultCache::StorageOpenResult::Success);
+    EXPECT_TRUE(cache.Put(content_key, buffer, expire_time));
+    // protect key wait timeout and check if it exist
+    EXPECT_TRUE(cache.Protect({prefix}));
+    std::this_thread::sleep_for(std::chrono::seconds(expire_time + 1));
+    EXPECT_TRUE(cache.Contains(content_key));
+    ASSERT_NE(cache.Get(content_key), nullptr);
+    // release key and check if it expires
+    EXPECT_TRUE(cache.Release({prefix}));
+    EXPECT_FALSE(cache.Contains(content_key));
+    ASSERT_EQ(cache.Get(content_key), nullptr);
+    cache.Clear();
+    cache.Close();
+  }
+  {
+    SCOPED_TRACE("Protect and release key, put multiple keys");
+    cache::DefaultCache cache(settings);
+    EXPECT_EQ(cache.Open(), cache::DefaultCache::StorageOpenResult::Success);
+    EXPECT_TRUE(cache.Put(content_key, buffer, expire_time));
+    for (auto i = 0; i < 10; i++) {
+      EXPECT_TRUE(
+          cache.Put(content_key + std::to_string(i), buffer, expire_time));
+    }
+    // protect key wait timeout and check if protected key exist, other expires
+    EXPECT_TRUE(cache.Protect({content_key}));
+    std::this_thread::sleep_for(std::chrono::seconds(expire_time + 1));
+    EXPECT_TRUE(cache.Contains(content_key));
+    for (auto i = 0; i < 10; i++) {
+      EXPECT_FALSE(cache.Contains(content_key + std::to_string(i)));
+    }
+    ASSERT_NE(cache.Get(content_key), nullptr);
+    // release key and check if it expires
+    EXPECT_TRUE(cache.Release({content_key}));
+    EXPECT_FALSE(cache.Contains(content_key));
+    ASSERT_EQ(cache.Get(content_key), nullptr);
+    cache.Clear();
+    cache.Close();
+  }
+  {
+    SCOPED_TRACE("Protect multiple keys in multiple calls");
+    cache::DefaultCache cache(settings);
+    EXPECT_EQ(cache.Open(), cache::DefaultCache::StorageOpenResult::Success);
+    for (auto i = 0; i < 10; i++) {
+      EXPECT_TRUE(
+          cache.Put(content_key + std::to_string(i), buffer, expire_time));
+    }
+    // protect some keys wait timeout and check if protected key exist, other
+    // expires
+    for (auto i = 0; i < 5; i++) {
+      EXPECT_TRUE(cache.Protect({content_key + std::to_string(i)}));
+    }
+    std::this_thread::sleep_for(std::chrono::seconds(expire_time + 1));
+    for (auto i = 0; i < 5; i++) {
+      EXPECT_TRUE(cache.Contains(content_key + std::to_string(i)));
+    }
+    for (auto i = 5; i < 10; i++) {
+      EXPECT_FALSE(cache.Contains(content_key + std::to_string(i)));
+    }
+    cache.Clear();
+    cache.Close();
+  }
+  {
+    SCOPED_TRACE("Protect and release multiple keys in one call");
+    cache::DefaultCache cache(settings);
+    EXPECT_EQ(cache.Open(), cache::DefaultCache::StorageOpenResult::Success);
+    for (auto i = 0; i < 10; i++) {
+      EXPECT_TRUE(
+          cache.Put(content_key + std::to_string(i), buffer, expire_time));
+    }
+    // protect some keys wait timeout and check if protected key exist, other
+    // expires
+    cache::DefaultCache::KeyListType list_to_protect;
+    list_to_protect.reserve(5);
+    for (auto i = 0; i < 5; i++) {
+      list_to_protect.push_back(content_key + std::to_string(i));
+    }
+    EXPECT_TRUE(cache.Protect(list_to_protect));
+    std::this_thread::sleep_for(std::chrono::seconds(expire_time + 1));
+    for (auto i = 0; i < 5; i++) {
+      EXPECT_TRUE(cache.Contains(content_key + std::to_string(i)));
+    }
+    for (auto i = 5; i < 10; i++) {
+      EXPECT_FALSE(cache.Contains(content_key + std::to_string(i)));
+    }
+    // release keys
+    EXPECT_TRUE(cache.Release(list_to_protect));
+    for (auto i = 0; i < 5; i++) {
+      EXPECT_FALSE(cache.Contains(content_key + std::to_string(i)));
+    }
+    cache.Clear();
+    cache.Close();
+  }
+  {
+    SCOPED_TRACE("Protect and release multiple keys by prefix");
+    cache::DefaultCache cache(settings);
+    EXPECT_EQ(cache.Open(), cache::DefaultCache::StorageOpenResult::Success);
+    for (auto i = 0; i < 10; i++) {
+      EXPECT_TRUE(
+          cache.Put(content_key + std::to_string(i), buffer, expire_time));
+    }
+    // protect some keys wait timeout and check if protected key exist
+    EXPECT_TRUE(cache.Protect({prefix}));
+    std::this_thread::sleep_for(std::chrono::seconds(expire_time + 1));
+    for (auto i = 0; i < 10; i++) {
+      EXPECT_TRUE(cache.Contains(content_key + std::to_string(i)));
+    }
+    // release keys
+    EXPECT_TRUE(cache.Release({prefix}));
+    for (auto i = 0; i < 10; i++) {
+      EXPECT_FALSE(cache.Contains(content_key + std::to_string(i)));
+    }
+    cache.Clear();
+    cache.Close();
+  }
+  {
+    SCOPED_TRACE("Protect and release multiple keys by prefix");
+    cache::DefaultCache cache(settings);
+    EXPECT_EQ(cache.Open(), cache::DefaultCache::StorageOpenResult::Success);
+    for (auto i = 0; i < 10; i++) {
+      EXPECT_TRUE(
+          cache.Put(content_key + std::to_string(i), buffer, expire_time));
+    }
+    // protect keys with prefix and key with the same prefix
+    EXPECT_TRUE(cache.Protect({prefix, content_key}));
+    std::this_thread::sleep_for(std::chrono::seconds(expire_time + 1));
+    for (auto i = 0; i < 10; i++) {
+      EXPECT_TRUE(cache.Contains(content_key + std::to_string(i)));
+    }
+    // try to release key, which protected by prefix
+    EXPECT_FALSE(cache.Release({content_key}));
+
+    cache.Clear();
+    cache.Close();
+  }
+}
+TEST(DefaultCacheTest, ProtectedLruEviction) {
+  {
+    SCOPED_TRACE("Protect and release keys, which suppose to be evicted");
+
+    const auto prefix{"somekey"};
+    const auto data_size = 1024u;
+    std::vector<unsigned char> binary_data(data_size);
+    auto data = std::make_shared<std::vector<unsigned char>>(binary_data);
+    cache::CacheSettings settings;
+    settings.disk_path_mutable = "./cache";
+    settings.eviction_policy = cache::EvictionPolicy::kLeastRecentlyUsed;
+    settings.max_disk_storage = 2u * 1024u * 1024u;
+    cache::DefaultCache cache(settings);
+
+    cache.Open();
+    cache.Clear();
+    // protect all keys, than close cache
+    cache.Protect({prefix});
+    cache.Close();
+    cache.Open();
+
+    const auto protected_key = prefix + std::to_string(0);
+    const auto evicted_key = prefix + std::to_string(1);
+    cache.Put(protected_key, data, (std::numeric_limits<time_t>::max)());
+
+    // overflow the mutable cache
+    auto count = 0u;
+    std::string key;
+    const auto max_count = settings.max_disk_storage / data_size;
+    for (; count < max_count; ++count) {
+      key = prefix + std::to_string(count);
+      const auto result =
+          cache.Put(key, data, (std::numeric_limits<time_t>::max)());
+
+      ASSERT_TRUE(result);
+
+      EXPECT_TRUE(cache.Contains(key));
+    }
+
+    // maximum is reached. Check if no keys was evicted
+    ASSERT_TRUE(count == max_count);
+    for (auto i = 0u; i < count; i++) {
+      EXPECT_TRUE(cache.Contains(prefix + std::to_string(i)));
+    }
+    // now release keys by prefix and protect single key
+    cache.Release({prefix});
+    cache.Protect({protected_key});
+    // put some keys to trigger eviction, even keys was promoted, we will not
+    // evict protected_key
+    for (auto i = 1u; i < count; i++) {
+      auto some_key = prefix + std::to_string(i);
+      const auto result =
+          cache.Put(some_key, data, (std::numeric_limits<time_t>::max)());
+
+      ASSERT_TRUE(result);
+      EXPECT_TRUE(cache.Contains(some_key));
+    }
+
+    // key was evicted, but protected still in cache
+    EXPECT_FALSE(cache.Contains(evicted_key));
+    EXPECT_TRUE(cache.Contains(protected_key));
+    // now release protected key and put some other keys again
+    cache.Release({protected_key});
+
+    for (auto i = 1u; i < count; i++) {
+      auto some_key = prefix + std::to_string(i);
+      const auto result =
+          cache.Put(some_key, data, (std::numeric_limits<time_t>::max)());
+
+      ASSERT_TRUE(result);
+      EXPECT_TRUE(cache.Contains(some_key));
+    }
+    EXPECT_FALSE(cache.Contains(protected_key));
+    cache.Clear();
     cache.Close();
   }
 }


### PR DESCRIPTION
Add interface functions Protect/Release.
Protect used mark keys as  non-evictable that they should stay in cache,
till their state will be changed back after calling Release with that keys.

Calling Protect function with some keys and prefixes
adds them to protected list, which guarantee that keys
will never be evicted or expired, even if LRU eviction is used,
and expiration is set. Keys could be protected before,
or after they were added to cache. If key was protected before,
and expiration is set, it will be written to cache with expiration, but 
never removed from cache after time elapsed. If key was protected
after, and still in cache, after expiration it will be returned to user, without
considering expiration. In both cases protected keys are not added to lru, 
so they will never be evicted.

With Release function protected keys will be removed from 
protected list, which means they could be evicted by lru,
and will expire after, if expiration set.

Add integration tests to check if protected keys
are not expire and are not evictable.

Relates-To: OLPEDGE-2124

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>