### PR TITLE
Adding model::Api and FetchOptions to core.

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -67,6 +67,7 @@ set(OLP_SDK_CLIENT_HEADERS
     ./include/olp/core/client/CancellationToken.h
     ./include/olp/core/client/Condition.h
     ./include/olp/core/client/ErrorCode.h
+    ./include/olp/core/client/FetchOptions.h
     ./include/olp/core/client/HRN.h
     ./include/olp/core/client/HttpResponse.h
     ./include/olp/core/client/OlpClient.h
@@ -94,6 +95,10 @@ set(OLP_SDK_HTTP_HEADERS
     ./include/olp/core/http/NetworkSettings.h
     ./include/olp/core/http/NetworkTypes.h
     ./include/olp/core/http/NetworkUtils.h
+)
+
+set(OLP_SDK_MODEL_HEADERS
+    ./include/olp/core/client/model/Api.h
 )
 
 set(OLP_SDK_PLATFORM_HEADERS
@@ -227,6 +232,11 @@ set(OLP_SDK_CLIENT_SOURCES
     ./src/client/Tokenizer.h
 )
 
+set(OLP_SDK_PARSER_SOURCES
+    ./src/client/parser/ApiParser.cpp
+    ./src/client/parser/ApiParser.h
+)
+
 set(OLP_SDK_HTTP_SOURCES
     ./src/http/DefaultNetwork.cpp
     ./src/http/DefaultNetwork.h
@@ -307,6 +317,7 @@ set(OLP_SDK_CORE_HEADERS
     ${OLP_SDK_CLIENT_HEADERS}
     ${OLP_SDK_GENERATED_HEADERS}
     ${OLP_SDK_HTTP_HEADERS}
+    ${OLP_SDK_MODEL_HEADERS}
     ${OLP_SDK_PLATFORM_HEADERS}
     ${OLP_SDK_PORTING_HEADERS}
     ${OLP_SDK_UTILS_HEADERS}
@@ -325,6 +336,7 @@ set(OLP_SDK_CORE_SOURCES
     ${OLP_SDK_CLIENT_SOURCES}
     ${OLP_SDK_HTTP_SOURCES}
     ${OLP_SDK_PLATFORM_SOURCES}
+    ${OLP_SDK_PARSER_SOURCES}
     ${OLP_SDK_UTILS_SOURCES}
     ${OLP_SDK_LOGGING_SOURCES}
     ${OLP_SDK_THREAD_SOURCES}
@@ -438,6 +450,7 @@ endif()
 
 # install component
 install (FILES ${OLP_SDK_HTTP_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/http)
+install (FILES ${OLP_SDK_MODEL_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/model)
 install (FILES ${OLP_SDK_PLATFORM_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/platform)
 install (FILES ${OLP_SDK_PORTING_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/porting)
 install (FILES ${OLP_SDK_UTILS_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/utils)

--- a/olp-cpp-sdk-core/include/olp/core/client/FetchOptions.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/FetchOptions.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+namespace olp {
+namespace client {
+
+enum FetchOptions {
+  /**
+   * A default option. Queries the network if the requested resource is not
+   * found in the cache.
+   */
+  OnlineIfNotFound,
+
+  /**
+   * Skips cache lookups and queries the network right away.
+   */
+  OnlineOnly,
+
+  /**
+   * Returns immediately if a cache lookup fails.
+   */
+  CacheOnly,
+
+  /**
+   * Returns the requested cached resource if it is found and updates the cache
+   * in the background.
+   * @note Do not use for versioned layer client requests.
+   */
+  CacheWithUpdate
+};
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-core/include/olp/core/client/model/Api.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/model/Api.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace olp {
+namespace client {
+/**
+ * @brief The API Services provided by the HERE platform.
+ */
+class Api {
+ public:
+  Api() = default;
+  virtual ~Api() = default;
+
+  /**
+   * @brief Gets an API name.
+   *
+   * @return The API name.
+   */
+  const std::string& GetApi() const { return api_; }
+  /**
+   * @brief Gets a mutable reference to the API name.
+   *
+   * @return The mutable reference to the API name.
+   */
+  std::string& GetMutableApi() { return api_; }
+  /**
+   * @brief Sets the API name.
+   *
+   * @param value The API name.
+   */
+  void SetApi(const std::string& value) { this->api_ = value; }
+  /**
+   * @brief Gets a version of the API.
+   *
+   * @return The version of the API.
+   */
+  const std::string& GetVersion() const { return version_; }
+  /**
+   * @brief Gets a mutable reference to the API version.
+   *
+   * @return The mutable reference to the API version.
+   */
+  std::string& GetMutableVersion() { return version_; }
+  /**
+   * @brief Sets the API version.
+   *
+   * @param value The API version.
+   */
+  void SetVersion(const std::string& value) { this->version_ = value; }
+  /**
+   * @brief Gets an URL of the API.
+   *
+   * @return The URL of the API.
+   */
+  const std::string& GetBaseUrl() const { return baseUrl_; }
+  /**
+   * @brief Gets a mutable reference to the URL of the API.
+   *
+   * @return The mutable reference to the URL of the API.
+   */
+  std::string& GetMutableBaseUrl() { return baseUrl_; }
+  /**
+   * @brief Sets the URL of the API.
+   *
+   * @param value The URL of the API.
+   */
+  void SetBaseUrl(const std::string& value) { this->baseUrl_ = value; }
+  /**
+   * @brief Gets a map of parameters.
+   *
+   * @return The API parameters.
+   */
+  const std::map<std::string, std::string>& GetParameters() const {
+    return parameters_;
+  }
+  /**
+   * @brief Gets a mutable reference to the API parameters.
+   *
+   * @return The mutable reference to the API parameters.
+   */
+  std::map<std::string, std::string>& GetMutableParameters() {
+    return parameters_;
+  }
+  /**
+   * @brief Sets the API parameters.
+   *
+   * @param value The parameters map.
+   */
+  void SetParameters(const std::map<std::string, std::string>& value) {
+    this->parameters_ = value;
+  }
+
+ private:
+  std::string api_;
+  std::string version_;
+  std::string baseUrl_;
+  std::map<std::string, std::string> parameters_;
+};
+
+using Apis = std::vector<Api>;
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/client/parser/ApiParser.cpp
+++ b/olp-cpp-sdk-core/src/client/parser/ApiParser.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "ApiParser.h"
+
+#include <olp/core/generated/parser/ParserWrapper.h>
+
+namespace olp {
+namespace parser {
+void from_json(const rapidjson::Value& value, olp::client::Api& x) {
+  x.SetApi(parse<std::string>(value, "api"));
+  x.SetVersion(parse<std::string>(value, "version"));
+  x.SetBaseUrl(parse<std::string>(value, "baseURL"));
+  x.SetParameters(
+      parse<std::map<std::string, std::string> >(value, "parameters"));
+}
+
+}  // namespace parser
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/client/parser/ApiParser.h
+++ b/olp-cpp-sdk-core/src/client/parser/ApiParser.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <olp/core/client/model/Api.h>
+#include <rapidjson/document.h>
+
+namespace olp {
+namespace parser {
+void from_json(const rapidjson::Value& value, olp::client::Api& x);
+
+}  // namespace parser
+}  // namespace olp


### PR DESCRIPTION
This is preparation for ApiLookupClient update. Classes taken from
dataservice::read. They are required for lookup request and parsing its
result.

Resolves: OLPEDGE-1697

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>