### PR TITLE
RemoveFromCache with TileKey and QuadTree

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
@@ -264,6 +264,15 @@ void PartitionsCacheRepository::ClearPartitions(
   }
 }
 
+bool PartitionsCacheRepository::ClearQuadTree(
+    const std::string& layer, geo::TileKey tile_key, int32_t depth,
+    const boost::optional<int64_t>& version) {
+  std::string hrn(hrn_.ToCatalogHRNString());
+  const auto key = CreateKey(hrn, layer, tile_key, depth, version);
+  OLP_SDK_LOG_INFO_F(kLogTag, "ClearQuadTree -> '%s'", key.c_str());
+  return cache_->RemoveKeysWithPrefix(key);
+}
+
 bool PartitionsCacheRepository::ClearPartitionMetadata(
     const boost::optional<int64_t>& catalog_version,
     const std::string& partition_id, const std::string& layer_id,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
@@ -73,6 +73,9 @@ class PartitionsCacheRepository final {
                        const std::vector<std::string>& partitionIds,
                        const std::string& layer_id);
 
+  bool ClearQuadTree(const std::string& layer, geo::TileKey key, int32_t depth,
+                     const boost::optional<int64_t>& version);
+
   bool ClearPartitionMetadata(const boost::optional<int64_t>& catalog_version,
                               const std::string& partition_id,
                               const std::string& layer_id,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.h
@@ -71,6 +71,11 @@ class QuadTreeIndex {
 
   std::vector<QuadTreeIndex::IndexData> GetIndexData() const;
 
+  olp::geo::TileKey GetRootTile() const {
+    return data_ ? olp::geo::TileKey::FromQuadKey64(data_->root_tilekey)
+                 : olp::geo::TileKey();
+  }
+
  private:
   struct SubEntry {
     std::uint16_t sub_quadkey;

--- a/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientTest.cpp
@@ -181,6 +181,8 @@ TEST(VersionedLayerClientTest, RemoveFromCacheTileKey) {
     EXPECT_CALL(*cache_mock, Get(_)).WillOnce(found_cache_response);
     EXPECT_CALL(*cache_mock, RemoveKeysWithPrefix(_))
         .WillOnce(data_cache_remove);
+    EXPECT_CALL(*cache_mock, Contains(_))
+        .WillRepeatedly([&](const std::string&) { return true; });
     ASSERT_TRUE(client.RemoveFromCache(tile_key));
   }
   {
@@ -213,6 +215,26 @@ TEST(VersionedLayerClientTest, RemoveFromCacheTileKey) {
     EXPECT_CALL(*cache_mock, Get(_)).WillOnce(found_cache_response);
     EXPECT_CALL(*cache_mock, RemoveKeysWithPrefix(_))
         .WillOnce([](const std::string&) { return false; });
+    ASSERT_FALSE(client.RemoveFromCache(tile_key));
+  }
+  {
+    SCOPED_TRACE("Successfull remove tile and quad tree from cache");
+    EXPECT_CALL(*cache_mock, Get(_)).WillOnce(found_cache_response);
+    EXPECT_CALL(*cache_mock, RemoveKeysWithPrefix(_))
+        .WillOnce(data_cache_remove)
+        .WillOnce([&](const std::string&) { return true; });
+    EXPECT_CALL(*cache_mock, Contains(_))
+        .WillRepeatedly([&](const std::string&) { return false; });
+    ASSERT_TRUE(client.RemoveFromCache(tile_key));
+  }
+  {
+    SCOPED_TRACE("Successfull remove tile but removing quad tree fails");
+    EXPECT_CALL(*cache_mock, Get(_)).WillOnce(found_cache_response);
+    EXPECT_CALL(*cache_mock, RemoveKeysWithPrefix(_))
+        .WillOnce(data_cache_remove)
+        .WillOnce([&](const std::string&) { return false; });
+    EXPECT_CALL(*cache_mock, Contains(_))
+        .WillRepeatedly([&](const std::string&) { return false; });
     ASSERT_FALSE(client.RemoveFromCache(tile_key));
   }
 }

--- a/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientTest.cpp
@@ -25,6 +25,7 @@
 #include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
 #include <olp/dataservice/read/VersionedLayerClient.h>
+#include "repositories/QuadTreeIndex.h"
 
 namespace {
 namespace read = olp::dataservice::read;
@@ -38,8 +39,11 @@ const auto kHrn = olp::client::HRN::FromString(kCatalog);
 const auto kPartitionId = "269";
 const auto kCatalogVersion = 108;
 const auto kTimeout = std::chrono::seconds(5);
-
 constexpr auto kBlobDataHandle = R"(4eed6ed1-0d32-43b9-ae79-043cb4256432)";
+constexpr auto kHereTile = "23618364";
+constexpr auto kHereTileDataHandle = "BD53A6D60A34C20DC42ACAB2650FE361.48";
+constexpr auto kQuadkeyResponse =
+    R"jsonString({"subQuads": [{"subQuadKey": "4","version":282,"dataHandle":"7636348E50215979A39B5F3A429EDDB4.282","dataSize":277},{"subQuadKey":"5","version":282,"dataHandle":"8C9B3E08E294ADB2CD07EBC8412062FE.282","dataSize":271},{"subQuadKey": "6","version":282,"dataHandle":"9772F5E1822DFF25F48F150294B1ECF5.282","dataSize":289},{"subQuadKey":"7","version":282,"dataHandle":"BF84D8EC8124B96DBE5C4DB68B05918F.282","dataSize":283},{"subQuadKey":"1","version":48,"dataHandle":"BD53A6D60A34C20DC42ACAB2650FE361.48","dataSize":89}],"parentQuads":[{"partition":"23","version":282,"dataHandle":"F8F4C3CB09FBA61B927256CBCB8441D1.282","dataSize":52438},{"partition":"5","version":282,"dataHandle":"13E2C624E0136C3357D092EE7F231E87.282","dataSize":99151},{"partition":"95","version":253,"dataHandle":"B6F7614316BB8B81478ED7AE370B22A6.253","dataSize":6765}]})jsonString";
 
 TEST(VersionedLayerClientTest, CanBeMoved) {
   read::VersionedLayerClient client_a(olp::client::HRN(), "", boost::none, {});
@@ -143,59 +147,71 @@ TEST(VersionedLayerClientTest, RemoveFromCacheTileKey) {
   std::shared_ptr<CacheMock> cache_mock = std::make_shared<CacheMock>();
   settings.cache = cache_mock;
 
-  // successfull mock cache calls
-  auto found_cache_response = [](const std::string& /*key*/,
-                                 const olp::cache::Decoder& /*encoder*/) {
-    auto partition = model::Partition();
-    partition.SetPartition(kPartitionId);
-    partition.SetDataHandle(kBlobDataHandle);
-    return partition;
+  auto depth = 4;
+  auto tile_key = olp::geo::TileKey::FromHereTile(kHereTile);
+  auto stream = std::stringstream(kQuadkeyResponse);
+  read::QuadTreeIndex quad_tree(tile_key, depth, stream);
+  auto buffer = quad_tree.GetRawData();
+
+  auto root = tile_key.ChangedLevelBy(-depth);
+
+  auto quad_cache_key = [&depth](const olp::geo::TileKey& key) {
+    return kHrn.ToCatalogHRNString() + "::" + kLayerId +
+           "::" + key.ToHereTile() + "::" + std::to_string(kCatalogVersion) +
+           "::" + std::to_string(depth) + "::quadtree";
   };
-  auto partition_cache_remove = [&](const std::string& prefix) {
-    std::string expected_prefix =
-        kHrn.ToCatalogHRNString() + "::" + kLayerId + "::" + kPartitionId +
-        "::" + std::to_string(kCatalogVersion) + "::partition";
-    EXPECT_EQ(prefix, expected_prefix);
-    return true;
+
+  // successfull mock cache calls
+  auto found_cache_response = [&buffer, &root,
+                               &quad_cache_key](const std::string& key) {
+    EXPECT_EQ(key, quad_cache_key(root));
+    return buffer;
   };
   auto data_cache_remove = [&](const std::string& prefix) {
     std::string expected_prefix = kHrn.ToCatalogHRNString() + "::" + kLayerId +
-                                  "::" + kBlobDataHandle + "::Data";
+                                  "::" + kHereTileDataHandle + "::Data";
     EXPECT_EQ(prefix, expected_prefix);
     return true;
   };
 
-  auto tile_key = olp::geo::TileKey::FromHereTile(kPartitionId);
   read::VersionedLayerClient client(kHrn, kLayerId, kCatalogVersion, settings);
   {
     SCOPED_TRACE("Successfull remove tile from cache");
 
-    EXPECT_CALL(*cache_mock, Get(_, _)).WillOnce(found_cache_response);
+    EXPECT_CALL(*cache_mock, Get(_)).WillOnce(found_cache_response);
     EXPECT_CALL(*cache_mock, RemoveKeysWithPrefix(_))
-        .WillOnce(partition_cache_remove)
         .WillOnce(data_cache_remove);
     ASSERT_TRUE(client.RemoveFromCache(tile_key));
   }
   {
     SCOPED_TRACE("Remove not existing tile from cache");
-    EXPECT_CALL(*cache_mock, Get(_, _))
-        .WillOnce([](const std::string&, const olp::cache::Decoder&) {
-          return boost::any();
+    EXPECT_CALL(*cache_mock, Get(_))
+        .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-4)));
+          return nullptr;
+        })
+        .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-3)));
+          return nullptr;
+        })
+        .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-2)));
+          return nullptr;
+        })
+        .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-1)));
+          return nullptr;
+        })
+        .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
+          EXPECT_EQ(key, quad_cache_key(tile_key));
+          return nullptr;
         });
     ASSERT_TRUE(client.RemoveFromCache(tile_key));
   }
   {
-    SCOPED_TRACE("Partition cache failure");
-    EXPECT_CALL(*cache_mock, Get(_, _)).WillOnce(found_cache_response);
-    EXPECT_CALL(*cache_mock, RemoveKeysWithPrefix(_))
-        .WillOnce([](const std::string&) { return false; });
-    ASSERT_FALSE(client.RemoveFromCache(tile_key));
-  }
-  {
     SCOPED_TRACE("Data cache failure");
-    EXPECT_CALL(*cache_mock, Get(_, _)).WillOnce(found_cache_response);
+    EXPECT_CALL(*cache_mock, Get(_)).WillOnce(found_cache_response);
     EXPECT_CALL(*cache_mock, RemoveKeysWithPrefix(_))
-        .WillOnce(partition_cache_remove)
         .WillOnce([](const std::string&) { return false; });
     ASSERT_FALSE(client.RemoveFromCache(tile_key));
   }

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -2684,7 +2684,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, RemoveFromCacheTileKey) {
       .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
                                    HTTP_RESPONSE_LOOKUP))
       .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
-                                   kHttpResponsePartition_269))
+                                   HTTP_RESPONSE_QUADKEYS_92259))
       .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
                                    kHttpResponseBlobData_269));
 
@@ -2694,8 +2694,8 @@ TEST_F(DataserviceReadVersionedLayerClientTest, RemoveFromCacheTileKey) {
   // load and cache some data
   auto promise = std::make_shared<std::promise<DataResponse>>();
   auto future = promise->get_future();
-
-  auto data_request = read::DataRequest().WithPartitionId(kTestPartition);
+  auto tile_key = geo::TileKey::FromHereTile("23618364");
+  auto data_request = read::TileRequest().WithTileKey(tile_key);
   auto token = client->GetData(data_request, [promise](DataResponse response) {
     promise->set_value(response);
   });
@@ -2708,7 +2708,6 @@ TEST_F(DataserviceReadVersionedLayerClientTest, RemoveFromCacheTileKey) {
   ASSERT_NE(response.GetResult()->size(), 0u);
 
   // remove the data from cache
-  auto tile_key = geo::TileKey::FromHereTile(kTestPartition);
   ASSERT_TRUE(client->RemoveFromCache(tile_key));
 
   // check the data is not available in cache


### PR DESCRIPTION
Search for tile in quadtree. If data handle was found,
remove data. Check if at least one data for tile exist,
if not remove quad tree. Fix tests to work with quadtree.
    
Relates-To: OLPEDGE-2124
    
Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>