### PR TITLE
Support classes for ApiLookupClient

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -222,6 +222,14 @@ set(OLP_SDK_CACHE_SOURCES
 )
 
 set(OLP_SDK_CLIENT_SOURCES
+    ./src/client/api/PlatformApi.cpp
+    ./src/client/api/PlatformApi.h
+    ./src/client/api/ResourcesApi.cpp
+    ./src/client/api/ResourcesApi.h
+    ./src/client/parser/ApiParser.cpp
+    ./src/client/parser/ApiParser.h
+    ./src/client/repository/ApiCacheRepository.cpp
+    ./src/client/repository/ApiCacheRepository.h
     ./src/client/CancellationToken.cpp
     ./src/client/HRN.cpp
     ./src/client/OlpClient.cpp
@@ -230,11 +238,6 @@ set(OLP_SDK_CLIENT_SOURCES
     ./src/client/OlpClientSettingsFactory.cpp
     ./src/client/PendingRequests.cpp
     ./src/client/Tokenizer.h
-)
-
-set(OLP_SDK_PARSER_SOURCES
-    ./src/client/parser/ApiParser.cpp
-    ./src/client/parser/ApiParser.h
 )
 
 set(OLP_SDK_HTTP_SOURCES
@@ -336,7 +339,6 @@ set(OLP_SDK_CORE_SOURCES
     ${OLP_SDK_CLIENT_SOURCES}
     ${OLP_SDK_HTTP_SOURCES}
     ${OLP_SDK_PLATFORM_SOURCES}
-    ${OLP_SDK_PARSER_SOURCES}
     ${OLP_SDK_UTILS_SOURCES}
     ${OLP_SDK_LOGGING_SOURCES}
     ${OLP_SDK_THREAD_SOURCES}

--- a/olp-cpp-sdk-core/src/client/api/PlatformApi.cpp
+++ b/olp-cpp-sdk-core/src/client/api/PlatformApi.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "PlatformApi.h"
+
+#include <map>
+#include <memory>
+#include <sstream>
+#include <utility>
+
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/HttpResponse.h>
+#include <olp/core/client/OlpClient.h>
+#include <olp/core/http/NetworkUtils.h>
+// clang-format off
+#include "client/parser/ApiParser.h"
+#include <olp/core/generated/parser/JsonParser.h>
+// clang-format on
+
+namespace {
+using NetworkUtils = olp::http::NetworkUtils;
+const std::string kExpiryHeader = "cache-control";
+
+boost::optional<time_t> GetExpiry(const olp::http::Headers& headers) {
+  auto it = std::find_if(headers.begin(), headers.end(),
+                         [](const olp::http::Header& header) {
+                           return NetworkUtils::CaseInsensitiveCompare(
+                               header.first, kExpiryHeader);
+                         });
+  if (it == headers.end()) {
+    return boost::none;
+  }
+
+  const auto& expiry_str = it->second;
+  std::size_t index = NetworkUtils::CaseInsensitiveFind(expiry_str, "max-age=");
+  if (index == std::string::npos) {
+    return boost::none;
+  }
+
+  auto expiry = std::stoi(expiry_str.substr(index + 8));
+  return expiry;
+}
+
+}  // namespace
+
+namespace olp {
+namespace client {
+
+PlatformApi::ApisResponse PlatformApi::GetApis(
+    const OlpClient& client, const CancellationContext& context) {
+  std::multimap<std::string, std::string> header_params;
+  header_params.insert(std::make_pair("Accept", "application/json"));
+
+  const auto platform_url = "/platform/apis";
+
+  auto response = client.CallApi(platform_url, "GET", {}, header_params, {},
+                                 nullptr, "", context);
+  if (response.status != http::HttpStatusCode::OK) {
+    return {{response.status, response.response.str()}};
+  }
+
+  return {
+      {parser::parse<Apis>(response.response), GetExpiry(response.headers)}};
+}
+
+CancellationToken PlatformApi::GetApis(const OlpClient& client,
+                                       const ApisCallback& callback) {
+  std::multimap<std::string, std::string> header_params;
+  header_params.insert(std::make_pair("Accept", "application/json"));
+
+  const auto platform_url = "/platform/apis";
+
+  auto network_callback = [callback](client::HttpResponse response) {
+    if (response.status != olp::http::HttpStatusCode::OK) {
+      callback({{response.status, response.response.str()}});
+    } else {
+      callback({{parser::parse<Apis>(response.response),
+                 GetExpiry(response.headers)}});
+    }
+  };
+
+  return client.CallApi(platform_url, "GET", {}, header_params, {}, nullptr, "",
+                        network_callback);
+}
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/client/api/PlatformApi.h
+++ b/olp-cpp-sdk-core/src/client/api/PlatformApi.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/model/Api.h>
+#include <boost/optional.hpp>
+
+namespace olp {
+namespace client {
+class OlpClient;
+class CancellationContext;
+
+/**
+ * @brief Api to lookup platform base urls.
+ */
+class PlatformApi {
+ public:
+  using ApisResult = std::pair<Apis, boost::optional<time_t>>;
+  using ApisResponse = ApiResponse<ApisResult, client::ApiError>;
+  using ApisCallback = std::function<void(ApisResponse)>;
+
+  /**
+   * @brief Call to lookup platform base urls.
+   * @param client Instance of OlpClient used to make REST request.
+   * @param context A CancellationContext, which can be used to cancel any
+   * pending request.
+   *
+   * @return The Apis response.
+   */
+  static ApisResponse GetApis(const OlpClient& client,
+                              const CancellationContext& context);
+
+  /**
+   * @brief Asynchronous version of \c GetApis method.
+   */
+  static CancellationToken GetApis(const OlpClient& client,
+                                   const ApisCallback& callback);
+};
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/client/api/ResourcesApi.cpp
+++ b/olp-cpp-sdk-core/src/client/api/ResourcesApi.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "ResourcesApi.h"
+
+#include <map>
+#include <memory>
+#include <sstream>
+
+#include <olp/core/client/HttpResponse.h>
+#include <olp/core/client/OlpClient.h>
+#include <olp/core/http/NetworkUtils.h>
+// clang-format off
+#include "client/parser/ApiParser.h"
+#include <olp/core/generated/parser/JsonParser.h>
+// clang-format on
+
+namespace {
+using NetworkUtils = olp::http::NetworkUtils;
+const std::string kExpiryHeader = "cache-control";
+
+boost::optional<time_t> GetExpiry(const olp::http::Headers& headers) {
+  auto it = std::find_if(headers.begin(), headers.end(),
+                         [](const olp::http::Header& header) {
+                           return NetworkUtils::CaseInsensitiveCompare(
+                               header.first, kExpiryHeader);
+                         });
+  if (it == headers.end()) {
+    return boost::none;
+  }
+
+  const auto& expiry_str = it->second;
+  std::size_t index = NetworkUtils::CaseInsensitiveFind(expiry_str, "max-age=");
+  if (index == std::string::npos) {
+    return boost::none;
+  }
+
+  auto expiry = std::stoi(expiry_str.substr(index + 8));
+  return expiry;
+}
+
+}  // namespace
+
+namespace olp {
+namespace client {
+
+ResourcesApi::ApisResponse ResourcesApi::GetApis(
+    const OlpClient& client, const std::string& hrn,
+    const CancellationContext& context) {
+  std::multimap<std::string, std::string> header_params;
+  header_params.emplace("Accept", "application/json");
+
+  // scan apis at resource endpoint
+  const auto resource_url = "/resources/" + hrn + "/apis";
+  auto response = client.CallApi(resource_url, "GET", {}, header_params, {},
+                                 nullptr, "", context);
+
+  if (response.status != http::HttpStatusCode::OK) {
+    return {{response.status, response.response.str()}};
+  }
+
+  return {
+      {parser::parse<Apis>(response.response), GetExpiry(response.headers)}};
+}
+
+CancellationToken ResourcesApi::GetApis(const OlpClient& client,
+                                        const std::string& hrn,
+                                        const ApisCallback& callback) {
+  std::multimap<std::string, std::string> header_params;
+  header_params.insert(std::make_pair("Accept", "application/json"));
+
+  // scan apis at resource endpoint
+  const auto resource_url = "/resources/" + hrn + "/apis";
+
+  auto network_callback = [callback](client::HttpResponse response) {
+    if (response.status != olp::http::HttpStatusCode::OK) {
+      callback({{response.status, response.response.str()}});
+    } else {
+      callback({{parser::parse<Apis>(response.response),
+                 GetExpiry(response.headers)}});
+    }
+  };
+  return client.CallApi(resource_url, "GET", {}, header_params, {}, nullptr, "",
+                        network_callback);
+}
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/client/api/ResourcesApi.h
+++ b/olp-cpp-sdk-core/src/client/api/ResourcesApi.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/model/Api.h>
+#include <boost/optional.hpp>
+
+namespace olp {
+namespace client {
+class OlpClient;
+class CancellationContext;
+
+/**
+ * @brief Api to search resource base urls.
+ */
+class ResourcesApi {
+ public:
+  using ApisResult = std::pair<Apis, boost::optional<time_t>>;
+  using ApisResponse = client::ApiResponse<ApisResult, client::ApiError>;
+  using ApisCallback = std::function<void(ApisResponse)>;
+
+  /**
+   * @brief Call to resources service base urls.
+   * @param client Instance of OlpClient used to make REST request.
+   * @param hrn Full catalog name.
+   * @param context A CancellationContext, which can be used to cancel any
+   * pending request.
+   *
+   * @return The Apis response.
+   */
+  static ApisResponse GetApis(const client::OlpClient& client,
+                              const std::string& hrn,
+                              const client::CancellationContext& context);
+
+  /**
+   * @brief Asynchronous version of \c GetApis method.
+   */
+  static CancellationToken GetApis(const client::OlpClient& client,
+                                   const std::string& hrn,
+                                   const ApisCallback& callback);
+};
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/client/repository/ApiCacheRepository.cpp
+++ b/olp-cpp-sdk-core/src/client/repository/ApiCacheRepository.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "ApiCacheRepository.h"
+
+#include <olp/core/cache/KeyValueCache.h>
+#include <olp/core/logging/Log.h>
+
+namespace {
+constexpr auto kLogTag = "ApiCacheRepository";
+constexpr time_t kLookupApiExpiryTime = 3600;
+
+std::string CreateKey(const std::string& hrn, const std::string& service,
+                      const std::string& serviceVersion) {
+  return hrn + "::" + service + "::" + serviceVersion + "::api";
+}
+}  // namespace
+
+namespace olp {
+namespace repository {
+
+ApiCacheRepository::ApiCacheRepository(
+    const client::HRN& hrn, std::shared_ptr<cache::KeyValueCache> cache)
+    : hrn_(hrn.ToCatalogHRNString()), cache_(cache) {}
+
+void ApiCacheRepository::Put(const std::string& service,
+                             const std::string& version, const std::string& url,
+                             boost::optional<time_t> expiry) {
+  auto key = CreateKey(hrn_, service, version);
+  OLP_SDK_LOG_DEBUG_F(kLogTag, "Put -> '%s'", key.c_str());
+
+  cache_->Put(key, url, [&]() { return url; },
+              expiry.get_value_or(kLookupApiExpiryTime));
+}
+
+boost::optional<std::string> ApiCacheRepository::Get(
+    const std::string& service, const std::string& version) {
+  auto key = CreateKey(hrn_, service, version);
+  OLP_SDK_LOG_DEBUG_F(kLogTag, "Get -> '%s'", key.c_str());
+
+  auto url = cache_->Get(key, [](const std::string& value) { return value; });
+  if (url.empty()) {
+    return boost::none;
+  }
+
+  return boost::any_cast<std::string>(url);
+}
+
+}  // namespace repository
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/client/repository/ApiCacheRepository.h
+++ b/olp-cpp-sdk-core/src/client/repository/ApiCacheRepository.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <olp/core/client/HRN.h>
+#include <boost/optional.hpp>
+#include <string>
+
+namespace olp {
+namespace cache {
+class KeyValueCache;
+}  // namespace cache
+
+namespace repository {
+
+class ApiCacheRepository final {
+ public:
+  ApiCacheRepository(const client::HRN& hrn,
+                     std::shared_ptr<cache::KeyValueCache> cache);
+
+  ~ApiCacheRepository() = default;
+
+  void Put(const std::string& service, const std::string& service_version,
+           const std::string& service_url, boost::optional<time_t> expiry);
+
+  boost::optional<std::string> Get(const std::string& service,
+                                   const std::string& service_version);
+
+ private:
+  std::string hrn_;
+  std::shared_ptr<cache::KeyValueCache> cache_;
+};
+
+}  // namespace repository
+}  // namespace olp


### PR DESCRIPTION
This is preparation before ApiLookupClient update. ApiCacheRepository
needed to handle cache, PartitionApi and PlatformApi for apis
requests.

Resolves: OLPEDGE-1697

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>