### PR TITLE
Add api to check if partition/tile cached

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -375,6 +375,24 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    */
   bool RemoveFromCache(const geo::TileKey& tile);
 
+  /**
+   * @brief Checks whether the partition is cached.
+   *
+   * @param partition_id The partition ID.
+   *
+   * @return True if the partition data is cached; false otherwise.
+   */
+  bool IsCached(const std::string& partition_id) const;
+
+  /**
+   * @brief Checks whether the tile is cached.
+   *
+   * @param tile The tile key.
+   *
+   * @return True if the tile data is cached; false otherwise.
+   */
+  bool IsCached(const geo::TileKey& tile) const;
+
  private:
   std::unique_ptr<VersionedLayerClientImpl> impl_;
 };

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -112,6 +112,14 @@ VersionedLayerClient::GetAggregatedData(TileRequest request) {
   return impl_->GetAggregatedData(std::move(request));
 }
 
+bool VersionedLayerClient::IsCached(const std::string& partition_id) const {
+  return impl_->IsCached(partition_id);
+}
+
+bool VersionedLayerClient::IsCached(const geo::TileKey& tile) const {
+  return impl_->IsCached(tile);
+}
+
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -85,9 +85,9 @@ class VersionedLayerClientImpl {
 
   virtual bool RemoveFromCache(const geo::TileKey& tile);
 
-  bool IsCached(const std::string& partition_id) const;
+  virtual bool IsCached(const std::string& partition_id) const;
 
-  bool IsCached(const geo::TileKey& tile) const;
+  virtual bool IsCached(const geo::TileKey& tile) const;
 
   virtual client::CancellationToken GetAggregatedData(
       TileRequest request, AggregatedDataResponseCallback callback);


### PR DESCRIPTION
Add functionality to check if certain tile/partition is cached.

For partition we are checking if data handle is found in cache,
if  data handle exist, check if data for corresponding partition 
in cache. 

For tile key search corresponding QuadTreeIndex,
considering that depth for all cached QuadTreeIndex is 4.
If quad tree is found, which should contain our tile, read 
data handle for that tile. If data handle exist, check if data 
for corresponding tile is cached. 

Add integration tests for to check if partition and tile is cached.
Get partition and tile. Check if it is in cache using IsCached
function. Remove partition/tile with RemoveFromCache function and
check again that it is no longer cached.

Relates-To: OLPEDGE-2111

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>