### PR TITLE
Adding ApiLookupClientImpl

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -230,6 +230,8 @@ set(OLP_SDK_CLIENT_SOURCES
     ./src/client/parser/ApiParser.h
     ./src/client/repository/ApiCacheRepository.cpp
     ./src/client/repository/ApiCacheRepository.h
+    ./src/client/ApiLookupClientImpl.cpp
+    ./src/client/ApiLookupClientImpl.h
     ./src/client/CancellationToken.cpp
     ./src/client/HRN.cpp
     ./src/client/OlpClient.cpp

--- a/olp-cpp-sdk-core/include/olp/core/client/ApiLookupClient.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiLookupClient.h
@@ -22,6 +22,9 @@
 #include <string>
 
 #include <olp/core/CoreApi.h>
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/OlpClient.h>
 
 namespace olp {
 
@@ -54,6 +57,16 @@ struct CORE_API DefaultLookupEndpointProvider {
 
     return std::string();
   }
+};
+
+/**
+ * @brief Client to API lookup requests
+ */
+class CORE_API ApiLookupClient final {
+ public:
+  /// Alias for the parameters and responses.
+  using LookupApiResponse = ApiResponse<OlpClient, ApiError>;
+  using LookupApiCallback = std::function<void(LookupApiResponse)>;
 };
 
 }  // namespace client

--- a/olp-cpp-sdk-core/src/client/ApiLookupClientImpl.cpp
+++ b/olp-cpp-sdk-core/src/client/ApiLookupClientImpl.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "ApiLookupClientImpl.h"
+
+#include <olp/core/logging/Log.h>
+#include "client/api/PlatformApi.h"
+#include "client/api/ResourcesApi.h"
+#include "repository/ApiCacheRepository.h"
+
+namespace olp {
+namespace client {
+
+namespace {
+constexpr auto kLogTag = "ApiLookupClientImpl";
+
+std::string FindApi(const Apis& apis, const std::string& service,
+                    const std::string& version) {
+  auto it = std::find_if(apis.begin(), apis.end(), [&](const Api& obj) -> bool {
+    return (obj.GetApi() == service && obj.GetVersion() == version);
+  });
+  if (it == apis.end()) {
+    return {};
+  }
+
+  return it->GetBaseUrl();
+}
+
+}  // namespace
+
+ApiLookupClientImpl::ApiLookupClientImpl(const HRN& catalog,
+                                         const OlpClientSettings& settings)
+    : catalog_(catalog), settings_(settings) {
+  auto provider = DefaultLookupEndpointProvider();
+  const auto& base_url = provider(catalog_.GetPartition());
+  lookup_client_.SetBaseUrl(base_url);
+  lookup_client_.SetSettings(settings_);
+}
+
+ApiLookupClient::LookupApiResponse ApiLookupClientImpl::LookupApi(
+    const std::string& service, const std::string& service_version,
+    FetchOptions options, CancellationContext context) {
+  repository::ApiCacheRepository repository(catalog_, settings_.cache);
+  const auto hrn = catalog_.ToCatalogHRNString();
+
+  if (options != OnlineOnly && options != CacheWithUpdate) {
+    auto url = repository.Get(service, service_version);
+    if (url) {
+      OLP_SDK_LOG_DEBUG_F(kLogTag, "LookupApi(%s/%s) found in cache, hrn='%s'",
+                          service.c_str(), service_version.c_str(),
+                          hrn.c_str());
+      OlpClient result_client;
+      result_client.SetBaseUrl(*url);
+      result_client.SetSettings(settings_);
+      return result_client;
+    } else if (options == CacheOnly) {
+      return {{client::ErrorCode::NotFound,
+               "CacheOnly: resource not found in cache"}};
+    }
+  }
+
+  OLP_SDK_LOG_DEBUG_F(kLogTag,
+                      "LookupApi(%s/%s) cache miss, requesting, hrn='%s'",
+                      service.c_str(), service_version.c_str(), hrn.c_str());
+
+  PlatformApi::ApisResponse api_response;
+  if (service == "config") {
+    api_response = PlatformApi::GetApis(lookup_client_, context);
+  } else {
+    api_response = ResourcesApi::GetApis(lookup_client_, hrn, context);
+  }
+
+  if (!api_response.IsSuccessful()) {
+    OLP_SDK_LOG_WARNING_F(kLogTag,
+                          "LookupApi(%s/%s) unsuccessful, hrn='%s', error='%s'",
+                          service.c_str(), service_version.c_str(), hrn.c_str(),
+                          api_response.GetError().GetMessage().c_str());
+    return api_response.GetError();
+  }
+
+  const auto& api_result = api_response.GetResult();
+  if (options != OnlineOnly && options != CacheWithUpdate) {
+    for (const auto& service_api : api_result.first) {
+      repository.Put(service_api.GetApi(), service_api.GetVersion(),
+                     service_api.GetBaseUrl(), api_result.second);
+    }
+  }
+
+  auto url = FindApi(api_result.first, service, service_version);
+  if (url.empty()) {
+    OLP_SDK_LOG_WARNING_F(
+        kLogTag, "LookupApi(%s/%s) service not found, hrn='%s'",
+        service.c_str(), service_version.c_str(), hrn.c_str());
+
+    return {{client::ErrorCode::ServiceUnavailable,
+             "Service/Version not available for given HRN"}};
+  }
+
+  OLP_SDK_LOG_DEBUG_F(
+      kLogTag, "LookupApi(%s/%s) found, hrn='%s', service_url='%s'",
+      service.c_str(), service_version.c_str(), hrn.c_str(), url.c_str());
+
+  OlpClient result_client;
+  result_client.SetBaseUrl(url);
+  result_client.SetSettings(settings_);
+  return result_client;
+}
+
+CancellationToken ApiLookupClientImpl::LookupApi(
+    const std::string& service, const std::string& service_version,
+    FetchOptions options, ApiLookupClient::LookupApiCallback callback) {
+  repository::ApiCacheRepository repository(catalog_, settings_.cache);
+  const auto hrn = catalog_.ToCatalogHRNString();
+
+  if (options != OnlineOnly && options != CacheWithUpdate) {
+    auto url = repository.Get(service, service_version);
+    if (url) {
+      OLP_SDK_LOG_DEBUG_F(kLogTag, "LookupApi(%s/%s) found in cache, hrn='%s'",
+                          service.c_str(), service_version.c_str(),
+                          hrn.c_str());
+      OlpClient result_client;
+      result_client.SetBaseUrl(*url);
+      result_client.SetSettings(settings_);
+      callback(result_client);
+      return CancellationToken();
+    } else if (options == CacheOnly) {
+      ApiLookupClient::LookupApiResponse response{
+          {client::ErrorCode::NotFound,
+           "CacheOnly: resource not found in cache"}};
+      callback(response);
+      return CancellationToken();
+    }
+  }
+
+  OLP_SDK_LOG_DEBUG_F(kLogTag,
+                      "LookupApi(%s/%s) cache miss, requesting, hrn='%s'",
+                      service.c_str(), service_version.c_str(), hrn.c_str());
+
+  PlatformApi::ApisCallback lookup_callback =
+      [=](PlatformApi::ApisResponse response) mutable -> void {
+    if (!response.IsSuccessful()) {
+      OLP_SDK_LOG_WARNING_F(
+          kLogTag, "LookupApi(%s/%s) unsuccessful, hrn='%s', error='%s'",
+          service.c_str(), service_version.c_str(), hrn.c_str(),
+          response.GetError().GetMessage().c_str());
+      callback(response.GetError());
+      return;
+    }
+
+    const auto& api_result = response.GetResult();
+    if (options != OnlineOnly && options != CacheWithUpdate) {
+      for (const auto& service_api : api_result.first) {
+        repository.Put(service_api.GetApi(), service_api.GetVersion(),
+                       service_api.GetBaseUrl(), api_result.second);
+      }
+    }
+
+    const auto url = FindApi(api_result.first, service, service_version);
+    if (url.empty()) {
+      OLP_SDK_LOG_WARNING_F(
+          kLogTag, "LookupApi(%s/%s) service not found, hrn='%s'",
+          service.c_str(), service_version.c_str(), hrn.c_str());
+
+      callback({{client::ErrorCode::ServiceUnavailable,
+                 "Service/Version not available for given HRN"}});
+      return;
+    }
+
+    OLP_SDK_LOG_DEBUG_F(
+        kLogTag, "LookupApi(%s/%s) found, hrn='%s', service_url='%s'",
+        service.c_str(), service_version.c_str(), hrn.c_str(), url.c_str());
+
+    OlpClient result_client;
+    result_client.SetBaseUrl(url);
+    result_client.SetSettings(settings_);
+    callback(result_client);
+  };
+
+  if (service == "config") {
+    return PlatformApi::GetApis(lookup_client_, lookup_callback);
+  }
+  return ResourcesApi::GetApis(lookup_client_, hrn, lookup_callback);
+}
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/client/ApiLookupClientImpl.h
+++ b/olp-cpp-sdk-core/src/client/ApiLookupClientImpl.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiLookupClient.h>
+#include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/CancellationContext.h>
+#include <olp/core/client/FetchOptions.h>
+#include <olp/core/client/HRN.h>
+#include <olp/core/client/OlpClient.h>
+#include <olp/core/client/OlpClientSettings.h>
+
+namespace olp {
+namespace client {
+
+class ApiLookupClientImpl final {
+ public:
+  ApiLookupClientImpl(const HRN& catalog, const OlpClientSettings& settings);
+
+  ApiLookupClient::LookupApiResponse LookupApi(
+      const std::string& service, const std::string& service_version,
+      FetchOptions options, CancellationContext context);
+
+  CancellationToken LookupApi(const std::string& service,
+                              const std::string& service_version,
+                              FetchOptions options,
+                              ApiLookupClient::LookupApiCallback callback);
+
+ private:
+  const HRN& catalog_;
+  const OlpClientSettings& settings_;
+  OlpClient lookup_client_;
+};
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(OLP_CPP_SDK_CORE_TESTS_SOURCES
     ./cache/InMemoryCacheTest.cpp
     ./cache/ProtectedKeyListTest.cpp
 
+    ./client/ApiLookupClientImplTest.cpp
     ./client/CancellationContextTest.cpp
     ./client/ConditionTest.cpp
     ./client/DefaultLookupEndpointProviderTest.cpp
@@ -65,6 +66,7 @@ if (ANDROID OR IOS)
             gmock
             gtest
             olp-cpp-sdk-core
+            olp-cpp-sdk-tests-common
     )
 
     # Some tests include private headers of core. This should be fixed in tests,
@@ -97,6 +99,7 @@ else()
             gtest
             gtest_main
             olp-cpp-sdk-core
+            olp-cpp-sdk-tests-common
     )
     # Some tests include private headers of core. This should be fixed in tests,
     # only then here.

--- a/olp-cpp-sdk-core/tests/client/ApiLookupClientImplTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/ApiLookupClientImplTest.cpp
@@ -1,0 +1,629 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock.h>
+#include <matchers/NetworkUrlMatchers.h>
+#include <mocks/CacheMock.h>
+#include <mocks/NetworkMock.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include "client/ApiLookupClientImpl.h"
+
+namespace {
+namespace client = olp::client;
+
+constexpr auto kConfigBaseUrl =
+    "https://config.data.api.platform.in.here.com/config/v1";
+
+constexpr auto kResponseLookupResource =
+    R"jsonString([{"api":"random_service","version":"v8","baseURL":"https://config.data.api.platform.in.here.com/config/v1","parameters":{}},{"api":"pipelines","version":"v1","baseURL":"https://pipelines.api.platform.in.here.com/pipeline-service","parameters":{}},{"api":"pipelines","version":"v2","baseURL":"https://pipelines.api.platform.in.here.com/pipeline-service","parameters":{}}])jsonString";
+
+constexpr auto kResponseLookupPlatform =
+    R"jsonString([{"api":"config","version":"v1","baseURL":"https://config.data.api.platform.in.here.com/config/v1","parameters":{}},{"api":"pipelines","version":"v1","baseURL":"https://pipelines.api.platform.in.here.com/pipeline-service","parameters":{}},{"api":"pipelines","version":"v2","baseURL":"https://pipelines.api.platform.in.here.com/pipeline-service","parameters":{}}])jsonString";
+
+class ApiLookupClientImplTest : public ::testing::Test {
+  void SetUp() override {
+    cache_ = std::make_shared<testing::StrictMock<CacheMock>>();
+    network_ = std::make_shared<testing::StrictMock<NetworkMock>>();
+
+    settings_.cache = cache_;
+    settings_.network_request_handler = network_;
+    settings_.task_scheduler =
+        client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1);
+    settings_.retry_settings.timeout = 1;
+  }
+
+ protected:
+  client::OlpClientSettings settings_;
+  std::shared_ptr<testing::StrictMock<CacheMock>> cache_;
+  std::shared_ptr<testing::StrictMock<NetworkMock>> network_;
+};
+
+TEST_F(ApiLookupClientImplTest, LookupApi) {
+  using testing::_;
+  using testing::Return;
+
+  const std::string catalog =
+      "hrn:here:data::olp-here-test:hereos-internal-test-v2";
+  const auto catalog_hrn = client::HRN::FromString(catalog);
+  const std::string service_name = "random_service";
+  const std::string service_url = "http://random_service.com";
+  const std::string service_version = "v8";
+  const std::string config_url =
+      "https://config.data.api.platform.in.here.com/config/v1";
+  const std::string cache_key =
+      catalog + "::" + service_name + "::" + service_version + "::api";
+  const std::string lookup_url =
+      "https://api-lookup.data.api.platform.here.com/lookup/v1/resources/" +
+      catalog + "/apis";
+  const std::string lookup_url_platform =
+      "https://api-lookup.data.api.platform.here.com/lookup/v1/platform/apis";
+
+  {
+    SCOPED_TRACE("Fetch from cache [CacheOnly] positive");
+    EXPECT_CALL(*cache_, Get(cache_key, _))
+        .Times(1)
+        .WillOnce(Return(service_url));
+
+    client::CancellationContext context;
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    auto response = client.LookupApi(service_name, service_version,
+                                     client::FetchOptions::CacheOnly, context);
+
+    EXPECT_TRUE(response.IsSuccessful());
+    EXPECT_EQ(response.GetResult().GetBaseUrl(), service_url);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Fetch from cache [CacheOnly] negative");
+    EXPECT_CALL(*cache_, Get(cache_key, _))
+        .Times(1)
+        .WillOnce(Return(boost::any()));
+
+    client::CancellationContext context;
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    auto response = client.LookupApi(service_name, service_version,
+                                     client::FetchOptions::CacheOnly, context);
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(), client::ErrorCode::NotFound);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Fetch from network");
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
+        .Times(1)
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     kResponseLookupResource));
+    EXPECT_CALL(*cache_, Put(_, _, _, _)).Times(0);
+
+    client::CancellationContext context;
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    auto response = client.LookupApi(service_name, service_version,
+                                     client::FetchOptions::OnlineOnly, context);
+
+    EXPECT_TRUE(response.IsSuccessful());
+    EXPECT_EQ(response.GetResult().GetBaseUrl(), kConfigBaseUrl);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Expiry from headers, resource");
+
+    const time_t expiry = 13;
+    const olp::http::Header header = {"Cache-Control",
+                                      "max-age=" + std::to_string(expiry)};
+
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
+        .Times(1)
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     kResponseLookupResource, {header}));
+    EXPECT_CALL(*cache_, Put(_, _, _, expiry))
+        .Times(3)
+        .WillRepeatedly(Return(true));
+    EXPECT_CALL(*cache_, Get(cache_key, _))
+        .Times(1)
+        .WillOnce(Return(boost::any()));
+
+    client::CancellationContext context;
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    auto response =
+        client.LookupApi(service_name, service_version,
+                         client::FetchOptions::OnlineIfNotFound, context);
+
+    EXPECT_TRUE(response.IsSuccessful());
+    EXPECT_EQ(response.GetResult().GetBaseUrl(), kConfigBaseUrl);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Expiry from headers, platform");
+
+    const time_t expiry = 13;
+    const olp::http::Header header = {"Cache-Control",
+                                      "max-age=" + std::to_string(expiry)};
+
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url_platform), _, _, _, _))
+        .Times(1)
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     kResponseLookupPlatform, {header}));
+    EXPECT_CALL(*cache_, Put(_, _, _, expiry))
+        .Times(3)
+        .WillRepeatedly(Return(true));
+    EXPECT_CALL(*cache_, Get(_, _)).Times(1).WillOnce(Return(boost::any()));
+
+    client::CancellationContext context;
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    auto response = client.LookupApi(
+        "config", "v1", client::FetchOptions::OnlineIfNotFound, context);
+
+    EXPECT_TRUE(response.IsSuccessful());
+    EXPECT_EQ(response.GetResult().GetBaseUrl(), kConfigBaseUrl);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Unknown service name");
+
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
+        .Times(1)
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     kResponseLookupResource));
+
+    client::CancellationContext context;
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    auto response = client.LookupApi("unknown_service", service_version,
+                                     client::FetchOptions::OnlineOnly, context);
+
+    const auto& error = response.GetError();
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(error.GetErrorCode(), client::ErrorCode::ServiceUnavailable);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Unknown service version");
+
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
+        .Times(1)
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     kResponseLookupResource));
+
+    client::CancellationContext context;
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    auto response = client.LookupApi(service_name, "123",
+                                     client::FetchOptions::OnlineOnly, context);
+
+    const auto& error = response.GetError();
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(error.GetErrorCode(), client::ErrorCode::ServiceUnavailable);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Network error propagated to the user");
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
+        .Times(1)
+        .WillOnce(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                   olp::http::HttpStatusCode::UNAUTHORIZED),
+                               "Inappropriate"));
+
+    client::CancellationContext context;
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    auto response = client.LookupApi(service_name, service_version,
+                                     client::FetchOptions::OnlineOnly, context);
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(),
+              client::ErrorCode::AccessDenied);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Network request cancelled by network internally");
+    client::CancellationContext context;
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
+        .Times(1)
+        .WillOnce([=](olp::http::NetworkRequest /*request*/,
+                      olp::http::Network::Payload /*payload*/,
+                      olp::http::Network::Callback /*callback*/,
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/)
+                      -> olp::http::SendOutcome {
+          return olp::http::SendOutcome(olp::http::ErrorCode::CANCELLED_ERROR);
+        });
+
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    auto response = client.LookupApi(service_name, service_version,
+                                     client::FetchOptions::OnlineOnly, context);
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(), client::ErrorCode::Cancelled);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Network request timed out");
+    client::CancellationContext context;
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
+        .Times(1)
+        .WillOnce([=](olp::http::NetworkRequest /*request*/,
+                      olp::http::Network::Payload /*payload*/,
+                      olp::http::Network::Callback /*callback*/,
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/)
+                      -> olp::http::SendOutcome {
+          // note no network response thread spawns
+          constexpr auto unused_request_id = 12;
+          return olp::http::SendOutcome(unused_request_id);
+        });
+    EXPECT_CALL(*network_, Cancel(_)).Times(1).WillOnce(Return());
+
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    auto response = client.LookupApi(service_name, service_version,
+                                     client::FetchOptions::OnlineOnly, context);
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(),
+              client::ErrorCode::RequestTimeout);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Network request cancelled by user");
+    client::CancellationContext context;
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
+        .Times(1)
+        .WillOnce([=, &context](
+                      olp::http::NetworkRequest /*request*/,
+                      olp::http::Network::Payload /*payload*/,
+                      olp::http::Network::Callback /*callback*/,
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/)
+                      -> olp::http::SendOutcome {
+          // spawn a 'user' response of cancelling
+          std::thread([&context]() { context.CancelOperation(); }).detach();
+
+          // note no network response thread spawns
+
+          constexpr auto unused_request_id = 12;
+          return olp::http::SendOutcome(unused_request_id);
+        });
+    EXPECT_CALL(*network_, Cancel(_)).Times(1).WillOnce(Return());
+
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    auto response = client.LookupApi(service_name, service_version,
+                                     client::FetchOptions::OnlineOnly, context);
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(), client::ErrorCode::Cancelled);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Network request cancelled before execution setup");
+    client::CancellationContext context;
+
+    context.CancelOperation();
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    auto response = client.LookupApi(service_name, service_version,
+                                     client::FetchOptions::OnlineOnly, context);
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(), client::ErrorCode::Cancelled);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+}
+
+TEST_F(ApiLookupClientImplTest, LookupApiAsync) {
+  using testing::_;
+  using testing::Return;
+
+  const std::string catalog =
+      "hrn:here:data::olp-here-test:hereos-internal-test-v2";
+  const auto catalog_hrn = client::HRN::FromString(catalog);
+  const std::string service_name = "random_service";
+  const std::string service_url = "http://random_service.com";
+  const std::string service_version = "v8";
+  const std::string config_url =
+      "https://config.data.api.platform.in.here.com/config/v1";
+  const std::string cache_key =
+      catalog + "::" + service_name + "::" + service_version + "::api";
+  const std::string lookup_url =
+      "https://api-lookup.data.api.platform.here.com/lookup/v1/resources/" +
+      catalog + "/apis";
+  const std::string lookup_url_platform =
+      "https://api-lookup.data.api.platform.here.com/lookup/v1/platform/apis";
+
+  {
+    SCOPED_TRACE("Fetch from cache [CacheOnly] positive");
+    EXPECT_CALL(*cache_, Get(cache_key, _))
+        .Times(1)
+        .WillOnce(Return(service_url));
+
+    std::promise<client::ApiLookupClient::LookupApiResponse> promise;
+    auto future = promise.get_future();
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    client.LookupApi(
+        service_name, service_version, client::FetchOptions::CacheOnly,
+        [&promise](client::ApiLookupClient::LookupApiResponse response) {
+          promise.set_value(std::move(response));
+        });
+
+    auto response = future.get();
+
+    EXPECT_TRUE(response.IsSuccessful());
+    EXPECT_EQ(response.GetResult().GetBaseUrl(), service_url);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Fetch from cache [CacheOnly] negative");
+    EXPECT_CALL(*cache_, Get(cache_key, _))
+        .Times(1)
+        .WillOnce(Return(boost::any()));
+
+    std::promise<client::ApiLookupClient::LookupApiResponse> promise;
+    auto future = promise.get_future();
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    client.LookupApi(
+        service_name, service_version, client::FetchOptions::CacheOnly,
+        [&promise](client::ApiLookupClient::LookupApiResponse response) {
+          promise.set_value(std::move(response));
+        });
+
+    auto response = future.get();
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(), client::ErrorCode::NotFound);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Fetch from network");
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
+        .Times(1)
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     kResponseLookupResource));
+    EXPECT_CALL(*cache_, Put(cache_key, _, _, _)).Times(0);
+
+    std::promise<client::ApiLookupClient::LookupApiResponse> promise;
+    auto future = promise.get_future();
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    client.LookupApi(
+        service_name, service_version, client::FetchOptions::OnlineOnly,
+        [&promise](client::ApiLookupClient::LookupApiResponse response) {
+          promise.set_value(std::move(response));
+        });
+
+    auto response = future.get();
+
+    EXPECT_TRUE(response.IsSuccessful());
+    EXPECT_EQ(response.GetResult().GetBaseUrl(), kConfigBaseUrl);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Expiry from headers, resource");
+
+    const time_t expiry = 13;
+    const olp::http::Header header = {"Cache-Control",
+                                      "max-age=" + std::to_string(expiry)};
+
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
+        .Times(1)
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     kResponseLookupResource, {header}));
+    EXPECT_CALL(*cache_, Put(_, _, _, expiry))
+        .Times(3)
+        .WillRepeatedly(Return(true));
+    EXPECT_CALL(*cache_, Get(cache_key, _))
+        .Times(1)
+        .WillOnce(Return(boost::any()));
+
+    std::promise<client::ApiLookupClient::LookupApiResponse> promise;
+    auto future = promise.get_future();
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    client.LookupApi(
+        service_name, service_version, client::FetchOptions::OnlineIfNotFound,
+        [&promise](client::ApiLookupClient::LookupApiResponse response) {
+          promise.set_value(std::move(response));
+        });
+
+    auto response = future.get();
+
+    EXPECT_TRUE(response.IsSuccessful());
+    EXPECT_EQ(response.GetResult().GetBaseUrl(), kConfigBaseUrl);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Expiry from headers, platform");
+
+    const time_t expiry = 13;
+    const olp::http::Header header = {"Cache-Control",
+                                      "max-age=" + std::to_string(expiry)};
+
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url_platform), _, _, _, _))
+        .Times(1)
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     kResponseLookupPlatform, {header}));
+    EXPECT_CALL(*cache_, Put(_, _, _, expiry))
+        .Times(3)
+        .WillRepeatedly(Return(true));
+    EXPECT_CALL(*cache_, Get(_, _)).Times(1).WillOnce(Return(boost::any()));
+
+    std::promise<client::ApiLookupClient::LookupApiResponse> promise;
+    auto future = promise.get_future();
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    client.LookupApi(
+        "config", "v1", client::FetchOptions::OnlineIfNotFound,
+        [&promise](client::ApiLookupClient::LookupApiResponse response) {
+          promise.set_value(std::move(response));
+        });
+
+    auto response = future.get();
+
+    EXPECT_TRUE(response.IsSuccessful());
+    EXPECT_EQ(response.GetResult().GetBaseUrl(), kConfigBaseUrl);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Unknown service name");
+
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
+        .Times(1)
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     kResponseLookupResource));
+
+    std::promise<client::ApiLookupClient::LookupApiResponse> promise;
+    auto future = promise.get_future();
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    client.LookupApi(
+        "unknown_service", service_version, client::FetchOptions::OnlineOnly,
+        [&promise](client::ApiLookupClient::LookupApiResponse response) {
+          promise.set_value(std::move(response));
+        });
+
+    auto response = future.get();
+    const auto& error = response.GetError();
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(error.GetErrorCode(), client::ErrorCode::ServiceUnavailable);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Unknown service version");
+
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
+        .Times(1)
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     kResponseLookupResource));
+
+    std::promise<client::ApiLookupClient::LookupApiResponse> promise;
+    auto future = promise.get_future();
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    client.LookupApi(
+        service_name, "123", client::FetchOptions::OnlineOnly,
+        [&promise](client::ApiLookupClient::LookupApiResponse response) {
+          promise.set_value(std::move(response));
+        });
+
+    auto response = future.get();
+    const auto& error = response.GetError();
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(error.GetErrorCode(), client::ErrorCode::ServiceUnavailable);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Network error propagated to the user");
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
+        .Times(1)
+        .WillOnce(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                   olp::http::HttpStatusCode::UNAUTHORIZED),
+                               "Inappropriate"));
+
+    std::promise<client::ApiLookupClient::LookupApiResponse> promise;
+    auto future = promise.get_future();
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    client.LookupApi(
+        service_name, service_version, client::FetchOptions::OnlineOnly,
+        [&promise](client::ApiLookupClient::LookupApiResponse response) {
+          promise.set_value(std::move(response));
+        });
+
+    auto response = future.get();
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(),
+              client::ErrorCode::AccessDenied);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Network request cancelled by network internally");
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
+        .Times(1)
+        .WillOnce([](olp::http::NetworkRequest /*request*/,
+                     olp::http::Network::Payload /*payload*/,
+                     olp::http::Network::Callback /*callback*/,
+                     olp::http::Network::HeaderCallback /*header_callback*/,
+                     olp::http::Network::DataCallback /*data_callback*/)
+                      -> olp::http::SendOutcome {
+          return olp::http::SendOutcome(olp::http::ErrorCode::CANCELLED_ERROR);
+        });
+
+    std::promise<client::ApiLookupClient::LookupApiResponse> promise;
+    auto future = promise.get_future();
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    client.LookupApi(
+        service_name, service_version, client::FetchOptions::OnlineOnly,
+        [&promise](client::ApiLookupClient::LookupApiResponse response) {
+          promise.set_value(std::move(response));
+        });
+
+    auto response = future.get();
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(), client::ErrorCode::Cancelled);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
Pimpl part of ApiLookupClient. Also added unit tests similar to
dataservice::read::ApiClientLookup.

Resolves: OLPEDGE-1697

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>