### PR TITLE
Fix failed integration test

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthorizeResult.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthorizeResult.h
@@ -83,7 +83,7 @@ class AUTHENTICATION_API Permission {
  private:
   std::string action_;
   std::string resource_;
-  DecisionType decision_;
+  DecisionType decision_{DecisionType::kDeny};
 };
 
 /**

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationMockedResponses.h
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationMockedResponses.h
@@ -112,7 +112,7 @@ const std::string kInvalidAccessTokenResponse = R"JSON(
     {"errorId":"ERROR-cf976ca6-bf6e-44f7-a9e6-e271766c61fe","httpStatus":401,"errorCode":400601,"message":"Invalid accessToken.","error":"invalid_request","error_description":"errorCode: '400601'. Invalid accessToken."}
     )JSON";
 const std::string kAuthorizeResponseValid = R"JSON(
-    {"identity":{"userId":"some_id","countryCode":"USA","emailVerified":false,"realm":"HERE"},"decision":"allow","diagnostics":[{"decision":"allow","permissions":[{"effect":"allow","action":"read","resource":"some_resource"}]}]}
+    {"identity":{"userId":"some_id","countryCode":"USA","emailVerified":false,"realm":"HERE"},"decision":"allow","diagnostics":[{"decision":"allow","permissions":[{"decision":"allow","action":"read","resource":"some_resource"}]}]}
     )JSON";
 const std::string kAuthorizeResponseError = R"JSON(
     {"contracts":[{"contractId":"some_contract_id","customerId":"some_id","customerName":"some_name"}],"errorCode":409400}


### PR DESCRIPTION
* Fix olp::authentication::Permission class which was missing
  default initializer for decision field.
* Change kAuthorizeResponseValid to contain 'decision' field
  in Permission array instead of 'effect' field that was causing
  integration test AuthenticationClientTest.Authorize to fail.

Resolves: OLPEDGE-2190

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>