### PR TITLE
Fix PrefetchWithCancellableFuture test

### DIFF
--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -396,8 +396,8 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWithCancellableFuture) {
     EXPECT_SUCCESS(*tile_result);
     ASSERT_TRUE(tile_result->tile_key_.IsValid());
   }
-
-  ASSERT_EQ(7u, result.size());
+  // one tile on level 10 and 11 and 4 on level 12
+  ASSERT_EQ(6u, result.size());
 }
 
 TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitionsWithInvalidHrn) {


### PR DESCRIPTION
Tiles in PrefetchRequest have levels, which is greater than min
level and sibiling tiles skiped.

Test requests tiles on levels 10 and 12, but root tile on
level 11. Result should be one tiles on levels 10 and 12,
and 4 child tiles.

Relates-To: OLPEDGE-2193

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>