### PR TITLE
Add Protect tile keys functionality

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
@@ -125,6 +125,12 @@ using VersionsResponse = Response<VersionsResult>;
 using VersionsResponseCallback = Callback<VersionsResult>;
 /// The list of tile keys.
 using TileKeys = std::vector<geo::TileKey>;
+/// The alias of the protect result.
+using ProtectResult = bool;
+/// The alias of the protect response.
+using ProtectResponse = Response<ProtectResult>;
+/// The callback type of the protect completion.
+using ProtectCallback = Callback<ProtectResult>;
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
@@ -123,14 +123,9 @@ using VersionsResult = model::VersionInfos;
 using VersionsResponse = Response<VersionsResult>;
 /// The versions list of metadata callback type for the versioned client.
 using VersionsResponseCallback = Callback<VersionsResult>;
+
 /// The list of tile keys.
 using TileKeys = std::vector<geo::TileKey>;
-/// The alias of the protect result.
-using ProtectResult = bool;
-/// The alias of the protect response.
-using ProtectResponse = Response<ProtectResult>;
-/// The callback type of the protect completion.
-using ProtectCallback = Callback<ProtectResult>;
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
@@ -123,6 +123,8 @@ using VersionsResult = model::VersionInfos;
 using VersionsResponse = Response<VersionsResult>;
 /// The versions list of metadata callback type for the versioned client.
 using VersionsResponseCallback = Callback<VersionsResult>;
+/// The list of tile keys.
+using TileKeys = std::vector<geo::TileKey>;
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -21,6 +21,7 @@
 
 #include <memory>
 
+#include <boost/optional.hpp>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
@@ -32,7 +33,6 @@
 #include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/TileRequest.h>
 #include <olp/dataservice/read/Types.h>
-#include <boost/optional.hpp>
 #include "repositories/ExecuteOrSchedule.inl"
 
 namespace olp {
@@ -95,7 +95,8 @@ class VersionedLayerClientImpl {
   virtual client::CancellableFuture<AggregatedDataResponse> GetAggregatedData(
       TileRequest request);
 
-  virtual bool Protect(const TileKeys& tiles);
+  virtual client::CancellationToken Protect(const TileKeys& tiles,
+                                            ProtectCallback callback);
 
  private:
   CatalogVersionResponse GetVersion(boost::optional<std::string> billing_tag,

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -21,7 +21,6 @@
 
 #include <memory>
 
-#include <boost/optional.hpp>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
@@ -33,6 +32,7 @@
 #include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/TileRequest.h>
 #include <olp/dataservice/read/Types.h>
+#include <boost/optional.hpp>
 #include "repositories/ExecuteOrSchedule.inl"
 
 namespace olp {
@@ -94,6 +94,8 @@ class VersionedLayerClientImpl {
 
   virtual client::CancellableFuture<AggregatedDataResponse> GetAggregatedData(
       TileRequest request);
+
+  virtual bool Protect(const TileKeys& tiles);
 
  private:
   CatalogVersionResponse GetVersion(boost::optional<std::string> billing_tag,

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -95,8 +95,7 @@ class VersionedLayerClientImpl {
   virtual client::CancellableFuture<AggregatedDataResponse> GetAggregatedData(
       TileRequest request);
 
-  virtual client::CancellationToken Protect(const TileKeys& tiles,
-                                            ProtectCallback callback);
+  virtual bool Protect(const TileKeys& tiles);
 
  private:
   CatalogVersionResponse GetVersion(boost::optional<std::string> billing_tag,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.h
@@ -52,6 +52,9 @@ class DataCacheRepository final {
 
   bool Clear(const std::string& layer_id, const std::string& data_handle);
 
+  std::string CreateKey(const std::string& layer_id,
+                        const std::string& datahandle) const;
+
  private:
   client::HRN hrn_;
   std::shared_ptr<cache::KeyValueCache> cache_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
@@ -86,6 +86,10 @@ class PartitionsCacheRepository final {
                           const std::string& layer_id,
                           std::string& data_handle);
 
+  std::string CreateQuadKey(const std::string& layer, olp::geo::TileKey key,
+                            int32_t depth,
+                            const boost::optional<int64_t>& version) const;
+
  private:
   client::HRN hrn_;
   std::shared_ptr<cache::KeyValueCache> cache_;

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     SerializerTest.cpp
     StreamApiTest.cpp
     StreamLayerClientImplTest.cpp
-    VersionedLayerClientTest.cpp
+    VersionedLayerClientImplTest.cpp
     VolatileLayerClientImplTest.cpp
     VolatileLayerClientTest.cpp
 )


### PR DESCRIPTION
Protect tile keys from eviction and expiration.
If some tile key was marked as protected, it is
expected to stay in cache, that its data can be
accessible.

For protecting tile keys we should protect some
keys in cache. This means find quad tree which
contains data hanle for our key, protect this
quad tree and protect data with found data handle.
At least one tile key needs to be protected to
protect entire quad tree.

Added unit test with changed default expiration,
which requests 2 tiles within one quad tree and
caches it. After calls protect on tile keys,
3 keys should be protected, this means they do
not expire after timeout.

Relates-To: OLPEDGE-2126

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>