### PR TITLE
Adapt dataservice::read to ApiLookupClient.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/ApiLookupClient.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiLookupClient.h
@@ -76,6 +76,7 @@ class CORE_API ApiLookupClient final {
 
   explicit ApiLookupClient(const HRN& catalog,
                            const OlpClientSettings& settings);
+
   ~ApiLookupClient();
 
   /**

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
@@ -40,7 +40,9 @@ constexpr auto kLogTag = "CatalogClientImpl";
 
 CatalogClientImpl::CatalogClientImpl(client::HRN catalog,
                                      client::OlpClientSettings settings)
-    : catalog_(std::move(catalog)), settings_(std::move(settings)) {
+    : catalog_(std::move(catalog)),
+      settings_(std::move(settings)),
+      lookup_client_(catalog_, settings_) {
   if (!settings_.cache) {
     settings_.cache = client::OlpClientSettingsFactory::CreateDefaultCache({});
   }
@@ -67,9 +69,11 @@ client::CancellationToken CatalogClientImpl::GetCatalog(
                                   CatalogResponseCallback callback) {
     auto catalog = catalog_;
     auto settings = settings_;
+    auto lookup_client = lookup_client_;
 
     auto get_catalog_task = [=](client::CancellationContext context) {
-      repository::CatalogRepository repository(catalog, settings);
+      repository::CatalogRepository repository(catalog, settings,
+                                               lookup_client);
       return repository.GetCatalog(request, std::move(context));
     };
 
@@ -99,9 +103,11 @@ client::CancellationToken CatalogClientImpl::GetLatestVersion(
                                          CatalogVersionCallback callback) {
     auto catalog = catalog_;
     auto settings = settings_;
+    auto lookup_client = lookup_client_;
 
     auto get_latest_version_task = [=](client::CancellationContext context) {
-      repository::CatalogRepository repository(catalog, settings);
+      repository::CatalogRepository repository(catalog, settings,
+                                               lookup_client);
       return repository.GetLatestVersion(request, std::move(context));
     };
 
@@ -128,10 +134,11 @@ client::CancellationToken CatalogClientImpl::ListVersions(
     VersionsRequest request, VersionsResponseCallback callback) {
   auto catalog = catalog_;
   auto settings = settings_;
+  auto lookup_client = lookup_client_;
 
   auto versions_list_task =
       [=](client::CancellationContext context) -> VersionsResponse {
-    repository::CatalogRepository repository(catalog, settings);
+    repository::CatalogRepository repository(catalog, settings, lookup_client);
     return repository.GetVersionsList(request, std::move(context));
   };
 

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
@@ -22,6 +22,7 @@
 #include <future>
 #include <memory>
 
+#include <olp/core/client/ApiLookupClient.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettings.h>
@@ -73,6 +74,7 @@ class CatalogClientImpl final {
   client::OlpClientSettings settings_;
   std::shared_ptr<thread::TaskScheduler> task_scheduler_;
   std::shared_ptr<client::PendingRequests> pending_requests_;
+  client::ApiLookupClient lookup_client_;
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -32,7 +32,6 @@
 #include <olp/core/logging/Log.h>
 #include <olp/core/thread/TaskScheduler.h>
 #include <olp/dataservice/read/CatalogVersionRequest.h>
-#include "ApiClientLookup.h"
 #include "Common.h"
 #include "PrefetchJob.h"
 #include "generated/api/QueryApi.h"
@@ -66,7 +65,8 @@ VersionedLayerClientImpl::VersionedLayerClientImpl(
       settings_(std::move(settings)),
       pending_requests_(std::make_shared<client::PendingRequests>()),
       catalog_version_(catalog_version ? catalog_version.get()
-                                       : kInvalidVersion) {
+                                       : kInvalidVersion),
+      lookup_client_(catalog_, settings_) {
   if (!settings_.cache) {
     settings_.cache = client::OlpClientSettingsFactory::CreateDefaultCache({});
   }
@@ -98,6 +98,7 @@ client::CancellationToken VersionedLayerClientImpl::GetPartitions(
     auto catalog = catalog_;
     auto layer_id = layer_id_;
     auto settings = settings_;
+    auto lookup_client = lookup_client_;
 
     auto partitions_task =
         [=](client::CancellationContext context) mutable -> PartitionsResponse {
@@ -108,7 +109,8 @@ client::CancellationToken VersionedLayerClientImpl::GetPartitions(
       }
       const auto version = version_response.GetResult().GetVersion();
 
-      repository::PartitionsRepository repository(catalog, settings);
+      repository::PartitionsRepository repository(
+          std::move(catalog), std::move(settings), std::move(lookup_client));
       return repository.GetVersionedPartitions(layer_id, request, version,
                                                context);
     };
@@ -149,6 +151,7 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
     auto catalog = catalog_;
     auto layer_id = layer_id_;
     auto settings = settings_;
+    auto lookup_client = lookup_client_;
 
     auto data_task =
         [=](client::CancellationContext context) mutable -> DataResponse {
@@ -162,8 +165,8 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
         version = version_response.GetResult().GetVersion();
       }
 
-      repository::DataRepository repository(std::move(catalog),
-                                            std::move(settings));
+      repository::DataRepository repository(
+          std::move(catalog), std::move(settings), std::move(lookup_client));
       return repository.GetVersionedData(layer_id, request, version, context);
     };
 
@@ -198,6 +201,7 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
   auto layer_id = layer_id_;
   auto settings = settings_;
   auto pending_requests = pending_requests_;
+  auto lookup_client = lookup_client_;
 
   auto token = AddTask(
       settings.task_scheduler, pending_requests,
@@ -238,7 +242,8 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
                  ? static_cast<unsigned int>(geo::TileKey::LevelCount)
                  : request.GetMaxLevel());
 
-        repository::PrefetchTilesRepository repository(catalog, settings);
+        repository::PrefetchTilesRepository repository(catalog, settings,
+                                                       lookup_client);
         auto sliced_tiles = repository.GetSlicedTiles(request.GetTileKeys(),
                                                       min_level, max_level);
 
@@ -254,7 +259,6 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
 
         auto sub_tiles = repository.GetSubTiles(layer_id, request, version,
                                                 sliced_tiles, context);
-
         if (!sub_tiles.IsSuccessful()) {
           return sub_tiles.GetError();
         }
@@ -298,8 +302,8 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
                       return DataResponse(nullptr);
                     } else {
                       // Fetch from online
-                      repository::DataRepository repository(catalog,
-                                                            *shared_settings);
+                      repository::DataRepository repository(
+                          catalog, *shared_settings, lookup_client);
                       return repository.GetVersionedData(
                           layer_id,
                           DataRequest().WithDataHandle(handle).WithBillingTag(
@@ -367,7 +371,7 @@ CatalogVersionResponse VersionedLayerClientImpl::GetVersion(
   request.WithBillingTag(billing_tag);
   request.WithFetchOption(fetch_options);
 
-  repository::CatalogRepository repository(catalog_, settings_);
+  repository::CatalogRepository repository(catalog_, settings_, lookup_client_);
   auto response = repository.GetLatestVersion(request, context);
 
   if (!response.IsSuccessful()) {
@@ -410,6 +414,7 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
     auto layer_id = layer_id_;
     auto settings = settings_;
     auto pending_requests = pending_requests_;
+    auto lookup_client = lookup_client_;
 
     auto data_task = [=](client::CancellationContext context) -> DataResponse {
       auto version_response = GetVersion(request.GetBillingTag(),
@@ -418,8 +423,8 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
         return version_response.GetError();
       }
 
-      repository::DataRepository repository(std::move(catalog),
-                                            std::move(settings));
+      repository::DataRepository repository(
+          std::move(catalog), std::move(settings), std::move(lookup_client));
       return repository.GetVersionedTile(
           layer_id, request, version_response.GetResult().GetVersion(),
           context);
@@ -466,7 +471,8 @@ bool VersionedLayerClientImpl::RemoveFromCache(
 
 bool VersionedLayerClientImpl::RemoveFromCache(const geo::TileKey& tile) {
   read::QuadTreeIndex cached_tree;
-  repository::PartitionsRepository repository(catalog_, settings_);
+  repository::PartitionsRepository repository(catalog_, settings_,
+                                              lookup_client_);
   if (repository.FindQuadTree(layer_id_, catalog_version_.load(), tile,
                               cached_tree)) {
     auto data = cached_tree.Find(tile, false);
@@ -510,7 +516,8 @@ bool VersionedLayerClientImpl::IsCached(const std::string& partition_id) const {
 
 bool VersionedLayerClientImpl::IsCached(const geo::TileKey& tile) const {
   read::QuadTreeIndex cached_tree;
-  repository::PartitionsRepository repository(catalog_, settings_);
+  repository::PartitionsRepository repository(catalog_, settings_,
+                                              lookup_client_);
   if (repository.FindQuadTree(layer_id_, catalog_version_.load(), tile,
                               cached_tree)) {
     auto data = cached_tree.Find(tile, false);
@@ -530,6 +537,7 @@ client::CancellationToken VersionedLayerClientImpl::GetAggregatedData(
   auto layer_id = layer_id_;
   auto settings = settings_;
   auto pending_requests = pending_requests_;
+  auto lookup_client = lookup_client_;
 
   auto data_task =
       [=](client::CancellationContext context) -> AggregatedDataResponse {
@@ -550,7 +558,8 @@ client::CancellationToken VersionedLayerClientImpl::GetAggregatedData(
     }
 
     auto version = version_response.GetResult().GetVersion();
-    repository::PartitionsRepository repository(catalog_, settings_);
+    repository::PartitionsRepository repository(catalog_, settings_,
+                                                lookup_client_);
     auto partition_response =
         repository.GetAggregatedTile(layer_id, request, version, context);
     if (!partition_response.IsSuccessful()) {
@@ -565,8 +574,8 @@ client::CancellationToken VersionedLayerClientImpl::GetAggregatedData(
                             .WithDataHandle(fetch_partition.GetDataHandle())
                             .WithFetchOption(request.GetFetchOption());
 
-    repository::DataRepository data_repository(std::move(catalog),
-                                               std::move(settings));
+    repository::DataRepository data_repository(
+        std::move(catalog), std::move(settings), std::move(lookup_client));
     auto data_response = data_repository.GetVersionedData(
         layer_id, data_request, version, context);
 
@@ -642,7 +651,8 @@ bool VersionedLayerClientImpl::Protect(const TileKeys& tiles) {
       add_data_handle(tile, *it);
     } else {
       read::QuadTreeIndex cached_tree;
-      repository::PartitionsRepository repository(catalog_, settings_);
+      repository::PartitionsRepository repository(catalog_, settings_,
+                                                  lookup_client_);
       if (repository.FindQuadTree(layer_id_, version, tile, cached_tree) &&
           add_data_handle(tile, cached_tree)) {
         keys_to_protect.emplace_back(partitions_cache_repository.CreateQuadKey(

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -21,6 +21,7 @@
 
 #include <memory>
 
+#include <olp/core/client/ApiLookupClient.h>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
@@ -108,6 +109,7 @@ class VersionedLayerClientImpl {
   client::OlpClientSettings settings_;
   std::shared_ptr<client::PendingRequests> pending_requests_;
   std::atomic<int64_t> catalog_version_;
+  client::ApiLookupClient lookup_client_;
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <olp/core/client/ApiLookupClient.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettings.h>
@@ -76,6 +77,7 @@ class VolatileLayerClientImpl {
   std::string layer_id_;
   client::OlpClientSettings settings_;
   std::shared_ptr<client::PendingRequests> pending_requests_;
+  client::ApiLookupClient lookup_client_;
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <olp/core/cache/KeyValueCache.h>
+#include <olp/core/client/ApiLookupClient.h>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
@@ -38,7 +39,8 @@ namespace repository {
 
 class CatalogRepository final {
  public:
-  CatalogRepository(client::HRN catalog, client::OlpClientSettings settings);
+  CatalogRepository(client::HRN catalog, client::OlpClientSettings settings,
+                    client::ApiLookupClient client);
 
   CatalogResponse GetCatalog(const CatalogRequest& request,
                              client::CancellationContext context);
@@ -52,6 +54,7 @@ class CatalogRepository final {
  private:
   client::HRN catalog_;
   client::OlpClientSettings settings_;
+  client::ApiLookupClient lookup_client_;
 };
 
 }  // namespace repository

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <olp/core/client/ApiLookupClient.h>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
@@ -34,7 +35,8 @@ namespace repository {
 
 class DataRepository final {
  public:
-  DataRepository(client::HRN catalog, client::OlpClientSettings settings);
+  DataRepository(client::HRN catalog, client::OlpClientSettings settings,
+                 client::ApiLookupClient client);
 
   DataResponse GetVersionedTile(const std::string& layer_id,
                                 const TileRequest& request, int64_t version,
@@ -56,7 +58,9 @@ class DataRepository final {
  private:
   client::HRN catalog_;
   client::OlpClientSettings settings_;
+  client::ApiLookupClient lookup_client_;
 };
+
 }  // namespace repository
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 
+#include <olp/core/client/ApiLookupClient.h>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
@@ -47,7 +48,8 @@ using QuadTreeIndexResponse = Response<QuadTreeIndex>;
 
 class PartitionsRepository {
  public:
-  PartitionsRepository(client::HRN catalog, client::OlpClientSettings settings);
+  PartitionsRepository(client::HRN catalog, client::OlpClientSettings settings,
+                       client::ApiLookupClient client);
 
   PartitionsResponse GetVersionedPartitions(
       std::string layer, const read::PartitionsRequest& request,
@@ -92,6 +94,7 @@ class PartitionsRepository {
 
   client::HRN catalog_;
   client::OlpClientSettings settings_;
+  client::ApiLookupClient lookup_client_;
 };
 }  // namespace repository
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -23,6 +23,7 @@
 #include <string>
 
 #include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiLookupClient.h>
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/HRN.h>
@@ -47,7 +48,8 @@ using SubTilesResponse = client::ApiResponse<SubTilesResult, client::ApiError>;
 class PrefetchTilesRepository {
  public:
   PrefetchTilesRepository(client::HRN catalog,
-                          client::OlpClientSettings settings);
+                          client::OlpClientSettings settings,
+                          client::ApiLookupClient client);
 
   /**
    * @brief Given tile keys, return all related tile keys that are between
@@ -91,6 +93,7 @@ class PrefetchTilesRepository {
  private:
   client::HRN catalog_;
   client::OlpClientSettings settings_;
+  client::ApiLookupClient lookup_client_;
 };
 
 }  // namespace repository

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
@@ -61,6 +61,7 @@ namespace {
 namespace read = olp::dataservice::read;
 namespace model = olp::dataservice::read::model;
 namespace repository = olp::dataservice::read::repository;
+using olp::client::ApiLookupClient;
 using ::testing::_;
 
 const std::string kCatalog =
@@ -89,6 +90,9 @@ class CatalogRepositoryTest : public ::testing::Test {
 
     settings_.network_request_handler = network_;
     settings_.cache = cache_;
+
+    lookup_client_ =
+        std::make_shared<olp::client::ApiLookupClient>(kHrn, settings_);
   }
 
   void TearDown() override {
@@ -102,6 +106,7 @@ class CatalogRepositoryTest : public ::testing::Test {
   std::shared_ptr<CacheMock> cache_;
   std::shared_ptr<NetworkMock> network_;
   olp::client::OlpClientSettings settings_;
+  std::shared_ptr<olp::client::ApiLookupClient> lookup_client_;
 };
 
 TEST_F(CatalogRepositoryTest, GetLatestVersionCacheOnlyFound) {
@@ -118,7 +123,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionCacheOnlyFound) {
       .Times(1)
       .WillOnce(testing::Return(cached_version));
 
-  repository::CatalogRepository repository(kHrn, settings_);
+  ApiLookupClient lookup_client(kHrn, settings_);
+  repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetLatestVersion(request, context);
 
   ASSERT_TRUE(response.IsSuccessful());
@@ -145,7 +151,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionCacheOnlyNotFound) {
         return olp::http::SendOutcome(olp::http::ErrorCode::UNKNOWN_ERROR);
       });
 
-  repository::CatalogRepository repository(kHrn, settings_);
+  ApiLookupClient lookup_client(kHrn, settings_);
+  repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetLatestVersion(request, context);
 
   EXPECT_FALSE(response.IsSuccessful());
@@ -170,7 +177,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyNotFound) {
                                        olp::http::HttpStatusCode::NOT_FOUND),
                                    ""));
 
-  repository::CatalogRepository repository(kHrn, settings_);
+  ApiLookupClient lookup_client(kHrn, settings_);
+  repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetLatestVersion(request, context);
 
   EXPECT_FALSE(response.IsSuccessful());
@@ -204,7 +212,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyFound) {
                                        olp::http::HttpStatusCode::OK),
                                    kResponseLatestCatalogVersion));
 
-  repository::CatalogRepository repository(kHrn, settings_);
+  ApiLookupClient lookup_client(kHrn, settings_);
+  repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetLatestVersion(request, context);
 
   ASSERT_TRUE(response.IsSuccessful());
@@ -241,7 +250,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled1) {
         return olp::http::SendOutcome(unused_request_id);
       });
 
-  repository::CatalogRepository repository(kHrn, settings_);
+  ApiLookupClient lookup_client(kHrn, settings_);
+  repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetLatestVersion(request, context);
 
   ASSERT_FALSE(response.IsSuccessful());
@@ -270,7 +280,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled2) {
         return olp::http::SendOutcome(unused_request_id);
       });
 
-  repository::CatalogRepository repository(kHrn, settings_);
+  ApiLookupClient lookup_client(kHrn, settings_);
+  repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetLatestVersion(request, context);
 
   ASSERT_FALSE(response.IsSuccessful());
@@ -296,7 +307,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionCancelledBeforeExecution) {
 
   context.CancelOperation();
 
-  repository::CatalogRepository repository(kHrn, settings_);
+  ApiLookupClient lookup_client(kHrn, settings_);
+  repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetLatestVersion(request, context);
 
   ASSERT_FALSE(response.IsSuccessful());
@@ -325,7 +337,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionTimeouted) {
 
   settings_.retry_settings.timeout = 0;
 
-  repository::CatalogRepository repository(kHrn, settings_);
+  ApiLookupClient lookup_client(kHrn, settings_);
+  repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetLatestVersion(request, context);
 
   ASSERT_FALSE(response.IsSuccessful());
@@ -359,7 +372,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyFound) {
                                             olp::http::HttpStatusCode::OK),
                                         kResponseConfig));
 
-  repository::CatalogRepository repository(kHrn, settings_);
+  ApiLookupClient lookup_client(kHrn, settings_);
+  repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetCatalog(request, context);
 
   ASSERT_TRUE(response.IsSuccessful());
@@ -379,7 +393,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogCacheOnlyFound) {
       .Times(1)
       .WillOnce(testing::Return(cached_version));
 
-  repository::CatalogRepository repository(kHrn, settings_);
+  ApiLookupClient lookup_client(kHrn, settings_);
+  repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetCatalog(request, context);
 
   ASSERT_TRUE(response.IsSuccessful());
@@ -406,7 +421,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogCacheOnlyNotFound) {
         return olp::http::SendOutcome(olp::http::ErrorCode::UNKNOWN_ERROR);
       });
 
-  repository::CatalogRepository repository(kHrn, settings_);
+  ApiLookupClient lookup_client(kHrn, settings_);
+  repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetLatestVersion(request, context);
 
   EXPECT_FALSE(response.IsSuccessful());
@@ -431,7 +447,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyNotFound) {
                                        olp::http::HttpStatusCode::NOT_FOUND),
                                    ""));
 
-  repository::CatalogRepository repository(kHrn, settings_);
+  ApiLookupClient lookup_client(kHrn, settings_);
+  repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetCatalog(request, context);
 
   EXPECT_FALSE(response.IsSuccessful());
@@ -455,7 +472,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogCancelledBeforeExecution) {
 
   context.CancelOperation();
 
-  repository::CatalogRepository repository(kHrn, settings_);
+  ApiLookupClient lookup_client(kHrn, settings_);
+  repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetCatalog(request, context);
 
   ASSERT_FALSE(response.IsSuccessful());
@@ -493,7 +511,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled1) {
         return olp::http::SendOutcome(unused_request_id);
       });
 
-  repository::CatalogRepository repository(kHrn, settings_);
+  ApiLookupClient lookup_client(kHrn, settings_);
+  repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetCatalog(request, context);
 
   ASSERT_FALSE(response.IsSuccessful());
@@ -522,7 +541,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled2) {
         return olp::http::SendOutcome(unused_request_id);
       });
 
-  repository::CatalogRepository repository(kHrn, settings_);
+  ApiLookupClient lookup_client(kHrn, settings_);
+  repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetCatalog(request, context);
 
   ASSERT_FALSE(response.IsSuccessful());
@@ -550,7 +570,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogTimeout) {
       });
   settings_.retry_settings.timeout = 0;
 
-  repository::CatalogRepository repository(kHrn, settings_);
+  ApiLookupClient lookup_client(kHrn, settings_);
+  repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetCatalog(request, context);
 
   ASSERT_FALSE(response.IsSuccessful());
@@ -579,7 +600,8 @@ TEST_F(CatalogRepositoryTest, GetVersionsList) {
                                    olp::http::HttpStatusCode::OK),
                                kHttpResponse));
 
-    repository::CatalogRepository repository(kHrn, settings_);
+    ApiLookupClient lookup_client(kHrn, settings_);
+    repository::CatalogRepository repository(kHrn, settings_, lookup_client);
     auto response = repository.GetVersionsList(request, context);
 
     ASSERT_TRUE(response.IsSuccessful());
@@ -610,7 +632,8 @@ TEST_F(CatalogRepositoryTest, GetVersionsList) {
                                    olp::http::HttpStatusCode::OK),
                                kHttpResponse));
 
-    repository::CatalogRepository repository(kHrn, settings_);
+    ApiLookupClient lookup_client(kHrn, settings_);
+    repository::CatalogRepository repository(kHrn, settings_, lookup_client);
     auto response = repository.GetVersionsList(request, context);
 
     ASSERT_TRUE(response.IsSuccessful());
@@ -641,7 +664,8 @@ TEST_F(CatalogRepositoryTest, GetVersionsList) {
                                    olp::http::HttpStatusCode::FORBIDDEN),
                                "Forbidden"));
 
-    repository::CatalogRepository repository(kHrn, settings_);
+    ApiLookupClient lookup_client(kHrn, settings_);
+    repository::CatalogRepository repository(kHrn, settings_, lookup_client);
     auto response = repository.GetVersionsList(request, context);
 
     ASSERT_FALSE(response.IsSuccessful());

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -43,6 +43,7 @@ PORTING_PUSH_WARNINGS()
 PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
 
 namespace {
+using olp::client::ApiLookupClient;
 using olp::client::ErrorCode;
 using olp::client::HRN;
 using olp::client::OlpClientSettings;
@@ -176,6 +177,10 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
   settings.network_request_handler = network;
   settings.retry_settings.timeout = 1;
 
+  ApiLookupClient lookup_client(catalog_hrn, settings);
+  repository::PartitionsRepository repository(catalog_hrn, settings,
+                                              lookup_client);
+
   const DataRequest request{DataRequest().WithPartitionId(kPartitionId)};
   const std::string part_cache_key =
       kCatalog + "::" + kVersionedLayerId + "::" + kPartitionId + "::";
@@ -213,7 +218,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
             Return(parser::parse<model::Partition>(query_cache_response)));
 
     client::CancellationContext context;
-    repository::PartitionsRepository repository(catalog_hrn, settings);
     auto response = repository.GetPartitionById(
         kVersionedLayerId, kVersion,
         DataRequest(request).WithFetchOption(read::CacheOnly), context);
@@ -237,7 +241,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         .WillOnce(Return(boost::any()));
 
     client::CancellationContext context;
-    repository::PartitionsRepository repository(catalog_hrn, settings);
     auto response = repository.GetPartitionById(
         kVersionedLayerId, kVersion,
         DataRequest(request).WithFetchOption(read::CacheOnly), context);
@@ -252,7 +255,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     SCOPED_TRACE("Fetch with missing partition id");
 
     client::CancellationContext context;
-    repository::PartitionsRepository repository(catalog_hrn, settings);
     auto response = repository.GetPartitionById(
         kVersionedLayerId, kVersion,
         DataRequest(request).WithPartitionId(boost::none), context);
@@ -278,7 +280,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
 
     EXPECT_CALL(*cache, Put(Eq(cache_key), _, _, _)).Times(0);
 
-    repository::PartitionsRepository repository(catalog_hrn, settings);
     auto response = repository.GetPartitionById(
         kVersionedLayerId, kVersion,
         DataRequest(request).WithFetchOption(read::OnlineOnly), context);
@@ -307,7 +308,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
                                      kOlpSdkHttpResponsePartitionById));
     EXPECT_CALL(*cache, Put(Eq(cache_key_no_version), _, _, _)).Times(0);
 
-    repository::PartitionsRepository repository(catalog_hrn, settings);
     auto response = repository.GetPartitionById(
         kVersionedLayerId, boost::none,
         DataRequest(request).WithFetchOption(read::OnlineOnly), context);
@@ -335,7 +335,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
                                "Inappropriate"));
 
     client::CancellationContext context;
-    repository::PartitionsRepository repository(catalog_hrn, settings);
     auto response = repository.GetPartitionById(
         kVersionedLayerId, kVersion,
         DataRequest(request).WithFetchOption(read::OnlineOnly), context);
@@ -358,7 +357,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
                                "{Inappropriate}"));
 
     client::CancellationContext context;
-    repository::PartitionsRepository repository(catalog_hrn, settings);
     auto response = repository.GetPartitionById(
         kVersionedLayerId, kVersion,
         DataRequest(request).WithFetchOption(read::OnlineOnly), context);
@@ -384,7 +382,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
                                      "{Inappropriate}"));
 
     client::CancellationContext context;
-    repository::PartitionsRepository repository(catalog_hrn, settings);
     auto response = repository.GetPartitionById(
         kVersionedLayerId, kVersion,
         DataRequest(request).WithFetchOption(read::OnlineOnly), context);
@@ -412,7 +409,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
           return olp::http::SendOutcome(olp::http::ErrorCode::CANCELLED_ERROR);
         });
 
-    repository::PartitionsRepository repository(catalog_hrn, settings);
     auto response = repository.GetPartitionById(
         kVersionedLayerId, kVersion,
         DataRequest(request).WithFetchOption(read::OnlineOnly), context);
@@ -441,7 +437,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
           return olp::http::SendOutcome(olp::http::ErrorCode::CANCELLED_ERROR);
         });
 
-    repository::PartitionsRepository repository(catalog_hrn, settings);
     auto response = repository.GetPartitionById(
         kVersionedLayerId, kVersion,
         DataRequest(request).WithFetchOption(read::OnlineOnly), context);
@@ -471,7 +466,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         });
     EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
 
-    repository::PartitionsRepository repository(catalog_hrn, settings);
     auto response = repository.GetPartitionById(
         kVersionedLayerId, kVersion,
         DataRequest(request).WithFetchOption(read::OnlineOnly), context);
@@ -503,7 +497,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         });
     EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
 
-    repository::PartitionsRepository repository(catalog_hrn, settings);
     auto response = repository.GetPartitionById(
         kVersionedLayerId, kVersion,
         DataRequest(request).WithFetchOption(read::OnlineOnly), context);
@@ -538,7 +531,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         });
     EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
 
-    repository::PartitionsRepository repository(catalog_hrn, settings);
     auto response = repository.GetPartitionById(
         kVersionedLayerId, kVersion,
         DataRequest(request).WithFetchOption(read::OnlineOnly), context);
@@ -574,7 +566,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         });
     EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
 
-    repository::PartitionsRepository repository(catalog_hrn, settings);
     auto response = repository.GetPartitionById(
         kVersionedLayerId, kVersion,
         DataRequest(request).WithFetchOption(read::OnlineOnly), context);
@@ -591,7 +582,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
 
     client::CancellationContext context;
     context.CancelOperation();
-    repository::PartitionsRepository repository(catalog_hrn, settings);
     auto response = repository.GetPartitionById(
         kVersionedLayerId, kVersion,
         DataRequest(request).WithFetchOption(read::OnlineOnly), context);
@@ -642,11 +632,14 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
         .WillOnce(Return(boost::any()));
 
     client::CancellationContext context;
+    olp::client::ApiLookupClient lookup_client(catalog, settings);
+    repository::PartitionsRepository repository(catalog, settings,
+                                                lookup_client);
+
     read::PartitionsRequest request;
     request.WithPartitionIds({kPartitionId, kInvalidPartitionId});
     request.WithFetchOption(read::CacheOnly);
 
-    repository::PartitionsRepository repository(catalog, settings);
     auto response = repository.GetVersionedPartitions(
         kVersionedLayerId, request, kVersion, context);
 
@@ -674,10 +667,12 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
                                      kOlpSdkHttpResponsePartitionById));
 
     client::CancellationContext context;
+    olp::client::ApiLookupClient lookup_client(catalog, settings);
+    repository::PartitionsRepository repository(catalog, settings,
+                                                lookup_client);
     read::PartitionsRequest request;
     request.WithPartitionIds({kPartitionId});
 
-    repository::PartitionsRepository repository(catalog, settings);
     auto response = repository.GetVersionedPartitions(
         kVersionedLayerId, request, kVersion, context);
 
@@ -705,9 +700,11 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
                                      kOlpSdkHttpResponseEmptyPartitionList));
 
     client::CancellationContext context;
+    olp::client::ApiLookupClient lookup_client(catalog, settings);
+    repository::PartitionsRepository repository(catalog, settings,
+                                                lookup_client);
     read::PartitionsRequest request;
 
-    repository::PartitionsRepository repository(catalog, settings);
     auto response = repository.GetVersionedPartitions(
         kVersionedLayerId, request, kVersion, context);
 
@@ -765,9 +762,11 @@ TEST_F(PartitionsRepositoryTest, GetVolatilePartitions) {
     settings.retry_settings.timeout = 1;
 
     client::CancellationContext context;
+    olp::client::ApiLookupClient lookup_client(catalog, settings);
+    repository::PartitionsRepository repository(catalog, settings,
+                                                lookup_client);
     read::PartitionsRequest request;
 
-    repository::PartitionsRepository repository(catalog, settings);
     auto response =
         repository.GetVolatilePartitions(kVolatileLayerId, request, context);
 
@@ -782,11 +781,13 @@ TEST_F(PartitionsRepositoryTest, GetVolatilePartitions) {
     settings.cache = default_cache;
     settings.retry_settings.timeout = 0;
 
+    olp::client::ApiLookupClient lookup_client(catalog, settings);
+    repository::PartitionsRepository repository(catalog, settings,
+                                                lookup_client);
     client::CancellationContext context;
     read::PartitionsRequest request;
     request.WithFetchOption(read::CacheOnly);
 
-    repository::PartitionsRepository repository(catalog, settings);
     auto cache_only_response =
         repository.GetVolatilePartitions(kVolatileLayerId, request, context);
 
@@ -821,6 +822,8 @@ TEST_F(PartitionsRepositoryTest, AdditionalFields) {
   settings.cache = default_cache;
   settings.network_request_handler = mock_network;
 
+  olp::client::ApiLookupClient lookup_client(catalog, settings);
+  repository::PartitionsRepository repository(catalog, settings, lookup_client);
   client::CancellationContext context;
   read::PartitionsRequest request;
 
@@ -830,7 +833,6 @@ TEST_F(PartitionsRepositoryTest, AdditionalFields) {
                                 read::PartitionsRequest::kCrc,
                                 read::PartitionsRequest::kDataSize});
 
-  repository::PartitionsRepository repository(catalog, settings);
   auto response = repository.GetVersionedPartitions(kVersionedLayerId, request,
                                                     kVersion, context);
 
@@ -884,13 +886,15 @@ TEST_F(PartitionsRepositoryTest, CheckCashedPartitions) {
   int64_t version = 4;
   auto layer = "testlayer";
 
+  olp::client::ApiLookupClient lookup_client(hrn, settings);
+  repository::PartitionsRepository repository(hrn, settings, lookup_client);
+
   {
     SCOPED_TRACE("query partitions and store to cache");
     auto request = olp::dataservice::read::TileRequest().WithTileKey(
         olp::geo::TileKey::FromHereTile("5904591"));
     olp::client::CancellationContext context;
 
-    repository::PartitionsRepository repository(hrn, settings);
     auto response = repository.GetTile(layer, request, version, context);
 
     ASSERT_TRUE(response.IsSuccessful());
@@ -906,7 +910,6 @@ TEST_F(PartitionsRepositoryTest, CheckCashedPartitions) {
                        .WithTileKey(olp::geo::TileKey::FromHereTile("1476147"))
                        .WithFetchOption(read::CacheOnly);
 
-    repository::PartitionsRepository repository(hrn, settings);
     auto response = repository.GetTile(layer, request, version, context);
 
     // check if partition was stored to cache
@@ -955,7 +958,8 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
 
-    repository::PartitionsRepository repository(hrn, settings);
+    olp::client::ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, settings, lookup_client);
     auto response =
         repository.GetAggregatedTile(layer, request, version, context);
     const auto& result = response.GetResult();
@@ -995,7 +999,8 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
 
-    repository::PartitionsRepository repository(hrn, settings);
+    olp::client::ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, settings, lookup_client);
     auto response =
         repository.GetAggregatedTile(layer, request, version, context);
     const auto& result = response.GetResult();
@@ -1025,9 +1030,11 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
 
     EXPECT_CALL(*mock_cache, Get(_)).WillOnce(Return(quad_tree.GetRawData()));
 
-    repository::PartitionsRepository repository(hrn, settings);
+    olp::client::ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, settings, lookup_client);
     auto response =
         repository.GetAggregatedTile(layer, request, version, context);
+
     const auto& result = response.GetResult();
 
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
@@ -1060,11 +1067,13 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
 
-    repository::PartitionsRepository repository(hrn, settings);
+    olp::client::ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, settings, lookup_client);
     auto response =
         repository.GetAggregatedTile(layer, request, version, context);
 
     const auto& result = response.GetResult();
+
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
     ASSERT_EQ(result.GetPartition(), tile_key.ToHereTile());
   }
@@ -1099,9 +1108,11 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
 
-    repository::PartitionsRepository repository(hrn, settings);
+    olp::client::ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, settings, lookup_client);
     auto response =
         repository.GetAggregatedTile(layer, request, version, context);
+
     const auto& error = response.GetError();
 
     ASSERT_FALSE(response.IsSuccessful());
@@ -1127,7 +1138,8 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
-    repository::PartitionsRepository repository(hrn, settings);
+    olp::client::ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, settings, lookup_client);
     auto response =
         repository.GetAggregatedTile(layer, request, version, context);
     const auto& error = response.GetError();
@@ -1160,9 +1172,11 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
-    repository::PartitionsRepository repository(hrn, settings);
+    olp::client::ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, settings, lookup_client);
     auto response =
         repository.GetAggregatedTile(layer, request, version, context);
+
     const auto& error = response.GetError();
 
     ASSERT_FALSE(response.IsSuccessful());
@@ -1201,9 +1215,11 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
-    repository::PartitionsRepository repository(hrn, settings);
+    olp::client::ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, settings, lookup_client);
     auto response =
         repository.GetAggregatedTile(layer, request, version, context);
+
     const auto& error = response.GetError();
 
     ASSERT_FALSE(response.IsSuccessful());
@@ -1241,7 +1257,8 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
-    repository::PartitionsRepository repository(hrn, settings);
+    olp::client::ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, settings, lookup_client);
     auto response =
         repository.GetAggregatedTile(layer, request, version, context);
     const auto& error = response.GetError();
@@ -1292,8 +1309,10 @@ TEST_F(PartitionsRepositoryTest, GetTile) {
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
 
-    repository::PartitionsRepository repository(hrn, settings);
+    olp::client::ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, settings, lookup_client);
     auto response = repository.GetTile(layer, request, version, context);
+
     ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
   }
 }

--- a/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
@@ -34,7 +34,9 @@ class PrefetchRepositoryTestable
   using repository::PrefetchTilesRepository::GetSlicedTiles;
   using repository::PrefetchTilesRepository::SplitSubtree;
 
-  PrefetchRepositoryTestable() : PrefetchTilesRepository(kCatalog, {}) {}
+  PrefetchRepositoryTestable()
+      : PrefetchTilesRepository(kCatalog, {},
+                                olp::client::ApiLookupClient(kCatalog, {})) {}
 };
 
 TEST(PrefetchRepositoryTest, SplitTreeLevels) {


### PR DESCRIPTION
We have new ApiLookupClient class in the core for Api requests. It
should replace internal ApiClientLookup for both read and write libs.
New lookup shared between repositories, so only one OlpClient used for
api requests, this will help to merge requests for same client.

Resolves: OLPEDGE-1697

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>