### PR TITLE
Simplify the prefetch task.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -318,44 +318,35 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
           }
 
           auto promise = std::make_shared<PrefetchResultPromise>();
-          auto flag = std::make_shared<std::atomic_bool>(false);
           futures->emplace_back(promise->get_future());
           auto context_it = contexts.emplace(contexts.end());
 
-          AddTask(settings.task_scheduler, pending_requests,
-                  [=](CancellationContext inner_context) {
-                    repository::DataCacheRepository data_cache_repository(
-                        catalog, shared_settings->cache);
-                    auto response = std::make_shared<PrefetchTileResult>(
-                        tile, PrefetchTileNoError());
-
-                    if (!data_cache_repository.IsCached(layer_id, handle)) {
-                      auto data = repository::DataRepository::GetVersionedData(
-                          catalog, layer_id, version,
-                          DataRequest().WithDataHandle(handle).WithBillingTag(
-                              request.GetBillingTag()),
-                          inner_context, *shared_settings);
-
-                      if (!data.IsSuccessful()) {
-                        response = std::make_shared<PrefetchTileResult>(
-                            tile, data.GetError());
-                      }
-                    }
-
-                    promise->set_value(response);
-                    flag->exchange(true);
-                    return EmptyResponse(PrefetchTileNoError());
-                  },
-                  [=](EmptyResponse /*result*/) {
-                    if (!flag->load()) {
-                      // If above task was cancelled we might need to set
-                      // promise else below task will wait forever
-                      promise->set_value(std::make_shared<PrefetchTileResult>(
-                          tile,
-                          client::ApiError(ErrorCode::Cancelled, "Cancelled")));
-                    }
-                  },
-                  *context_it);
+          AddTask(
+              settings.task_scheduler, pending_requests,
+              [=](CancellationContext inner_context) {
+                repository::DataCacheRepository data_cache_repository(
+                    catalog, shared_settings->cache);
+                if (data_cache_repository.IsCached(layer_id, handle)) {
+                  // Return an empty success
+                  return DataResponse(nullptr);
+                } else {
+                  return repository::DataRepository::GetVersionedData(
+                      catalog, layer_id, version,
+                      DataRequest().WithDataHandle(handle).WithBillingTag(
+                          request.GetBillingTag()),
+                      inner_context, *shared_settings);
+                }
+              },
+              [=](DataResponse result) {
+                if (result.IsSuccessful()) {
+                  promise->set_value(std::make_shared<PrefetchTileResult>(
+                      tile, PrefetchTileNoError()));
+                } else {
+                  promise->set_value(std::make_shared<PrefetchTileResult>(
+                      tile, result.GetError()));
+                }
+              },
+              *context_it);
           it++;
         }
 

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -261,37 +261,32 @@ client::CancellationToken VolatileLayerClientImpl::PrefetchTiles(
           auto const& handle = it->second;
           auto const& biling_tag = request.GetBillingTag();
           auto promise = std::make_shared<PrefetchResultPromise>();
-          auto flag = std::make_shared<std::atomic_bool>(false);
           futures->emplace_back(promise->get_future());
           auto context_it = contexts.emplace(contexts.end());
 
           AddTask(
               settings.task_scheduler, pending_requests,
               [=](CancellationContext inner_context) {
-                auto data = repository::DataRepository::GetVolatileData(
-                    catalog, layer_id,
-                    DataRequest().WithDataHandle(handle).WithBillingTag(
-                        biling_tag),
-                    inner_context, *shared_settings);
-
-                if (!data.IsSuccessful()) {
-                  promise->set_value(std::make_shared<PrefetchTileResult>(
-                      tile, data.GetError()));
+                repository::DataCacheRepository data_cache_repository(
+                    catalog, shared_settings->cache);
+                if (data_cache_repository.IsCached(layer_id, handle)) {
+                  // Return an empty success
+                  return DataResponse(nullptr);
                 } else {
+                  return repository::DataRepository::GetVolatileData(
+                      catalog, layer_id,
+                      DataRequest().WithDataHandle(handle).WithBillingTag(
+                          biling_tag),
+                      inner_context, *shared_settings);
+                }
+              },
+              [=](DataResponse result) {
+                if (result.IsSuccessful()) {
                   promise->set_value(std::make_shared<PrefetchTileResult>(
                       tile, PrefetchTileNoError()));
-                }
-
-                flag->exchange(true);
-                return EmptyResponse(PrefetchTileNoError());
-              },
-              [=](EmptyResponse) {
-                if (!flag->load()) {
-                  // If above task was cancelled we might need to set
-                  // promise else below task will wait forever
+                } else {
                   promise->set_value(std::make_shared<PrefetchTileResult>(
-                      tile,
-                      client::ApiError(ErrorCode::Cancelled, "Cancelled")));
+                      tile, result.GetError()));
                 }
               },
               *context_it);


### PR DESCRIPTION
Remove the atomic bool flag.
When the task is canceled, the callback is called with a cancel
error, so there is no need to create it manually.
Add the IsCached check to VolatileLayerClient prefetch.

Relates-To: OLPEDGE-2169

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>