### PR TITLE
Change Prefetch default levels

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
@@ -203,8 +203,8 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
  private:
   std::string layer_id_;
   std::vector<geo::TileKey> tile_keys_;
-  unsigned int min_level_{0};
-  unsigned int max_level_{0};
+  unsigned int min_level_{geo::TileKey().Level()};
+  unsigned int max_level_{geo::TileKey().Level()};
   boost::optional<int64_t> catalog_version_;
   boost::optional<std::string> billing_tag_;
 };

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
@@ -21,8 +21,8 @@
 
 #include <sstream>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include <olp/core/geo/tiling/TileKey.h>
 #include <olp/core/porting/deprecated.h>
@@ -203,8 +203,8 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
  private:
   std::string layer_id_;
   std::vector<geo::TileKey> tile_keys_;
-  unsigned int min_level_{geo::TileKey().Level()};
-  unsigned int max_level_{geo::TileKey().Level()};
+  unsigned int min_level_{geo::TileKey::LevelCount};
+  unsigned int max_level_{geo::TileKey::LevelCount};
   boost::optional<int64_t> catalog_version_;
   boost::optional<std::string> billing_tag_;
 };

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -23,7 +23,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/optional.hpp>
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/CancellationToken.h>
@@ -36,6 +35,7 @@
 #include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/TileRequest.h>
 #include <olp/dataservice/read/Types.h>
+#include <boost/optional.hpp>
 
 namespace olp {
 namespace dataservice {
@@ -311,10 +311,10 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * This method recursively downloads all tile keys from the `min_level`
    * parameter to the `max_level` parameter of the \c PrefetchTilesRequest
-   * object for the given root tiles. If min_level/max_level are the same or
-   * default, only tiles listed in \c PrefetchTilesRequest will be downloaded.
-   * Only tiles will be downloaded which are not already present in the cache,
-   * this helps reduce the network load.
+   * object for the given root tiles. If min_level/max_level are default, only
+   * tiles listed in \c PrefetchTilesRequest will be downloaded. Only tiles will
+   * be downloaded which are not already present in the cache, this helps reduce
+   * the network load.
    *
    * @note This method does not guarantee that all tiles are available offline
    * as the cache might overflow, and data might be evicted at any point.
@@ -337,10 +337,10 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    *
    * This method recursively downloads all tile keys from the `min_level`
    * parameter to the `max_level` parameter of the \c PrefetchTilesRequest
-   * object for the given root tiles. If min_level/max_level are the same or
-   * default, only tiles listed in \c PrefetchTilesRequest will be downloaded.
-   * Only tiles will be downloaded which are not already present in the cache,
-   * this helps reduce the network load.
+   * object for the given root tiles. If min_level/max_level are default, only
+   * tiles listed in \c PrefetchTilesRequest will be downloaded. Only tiles will
+   * be downloaded which are not already present in the cache, this helps reduce
+   * the network load.
    *
    * @note This method does not guarantee that all tiles are available offline
    * as the cache might overflow, and data might be evicted at any point.

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
@@ -201,10 +201,10 @@ class DATASERVICE_READ_API VolatileLayerClient final {
    *
    * This method recursively downloads all tile keys from the `min_level`
    * parameter to the `max_level` parameter of the \c PrefetchTilesRequest
-   * object for the given root tiles. If min_level/max_level are the same or
-   * default, only tiles listed in \c PrefetchTilesRequest will be downloaded.
-   * Only tiles will be downloaded which are not already present in the cache,
-   * this helps reduce the network load.
+   * object for the given root tiles. If min_level/max_level are default, only
+   * tiles listed in \c PrefetchTilesRequest will be downloaded. Only tiles will
+   * be downloaded which are not already present in the cache, this helps reduce
+   * the network load.
    *
    * @note This method does not guarantee that all tiles are available offline
    * as the cache might overflow, and data might be evicted at any point.
@@ -225,10 +225,10 @@ class DATASERVICE_READ_API VolatileLayerClient final {
    *
    * This method recursively downloads all tile keys from the `min_level`
    * parameter to the `max_level` parameter of the \c PrefetchTilesRequest
-   * object for the given root tiles. If min_level/max_level are the same or
-   * default, only tiles listed in \c PrefetchTilesRequest will be downloaded.
-   * Only tiles will be downloaded which are not already present in the cache,
-   * this helps reduce the network load.
+   * object for the given root tiles. If min_level/max_level are default, only
+   * tiles listed in \c PrefetchTilesRequest will be downloaded. Only tiles will
+   * be downloaded which are not already present in the cache, this helps reduce
+   * the network load.
    *
    * @note This method does not guarantee that all tiles are available offline
    * as the cache might overflow, and data might be evicted at any point.

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -229,8 +229,7 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
         // Calculate the minimal set of Tile keys and depth to
         // cover tree.
         bool request_only_input_tiles =
-            !(request.GetMinLevel() >= 0 &&
-              request.GetMinLevel() <= request.GetMaxLevel() &&
+            !(request.GetMinLevel() <= request.GetMaxLevel() &&
               request.GetMaxLevel() < geo::TileKey().Level() &&
               request.GetMinLevel() < geo::TileKey().Level());
         unsigned int min_level =

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -229,14 +229,14 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
         // Calculate the minimal set of Tile keys and depth to
         // cover tree.
         bool request_only_input_tiles =
-            !(request.GetMinLevel() > 0 &&
-              request.GetMinLevel() < request.GetMaxLevel() &&
+            !(request.GetMinLevel() >= 0 &&
+              request.GetMinLevel() <= request.GetMaxLevel() &&
               request.GetMaxLevel() < geo::TileKey().Level() &&
               request.GetMinLevel() < geo::TileKey().Level());
         unsigned int min_level =
-            (request_only_input_tiles ? 0 : request.GetMinLevel());
+            (request_only_input_tiles ? geo::TileKey().Level() : request.GetMinLevel());
         unsigned int max_level =
-            (request_only_input_tiles ? 0 : request.GetMaxLevel());
+            (request_only_input_tiles ? geo::TileKey().Level() : request.GetMaxLevel());
 
         auto sliced_tiles = repository::PrefetchTilesRepository::GetSlicedTiles(
             request.GetTileKeys(), min_level, max_level);

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -230,12 +230,16 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
         // cover tree.
         bool request_only_input_tiles =
             !(request.GetMinLevel() <= request.GetMaxLevel() &&
-              request.GetMaxLevel() < geo::TileKey().Level() &&
-              request.GetMinLevel() < geo::TileKey().Level());
+              request.GetMaxLevel() < geo::TileKey::LevelCount &&
+              request.GetMinLevel() < geo::TileKey::LevelCount);
         unsigned int min_level =
-            (request_only_input_tiles ? geo::TileKey().Level() : request.GetMinLevel());
+            (request_only_input_tiles
+                 ? static_cast<unsigned int>(geo::TileKey::LevelCount)
+                 : request.GetMinLevel());
         unsigned int max_level =
-            (request_only_input_tiles ? geo::TileKey().Level() : request.GetMaxLevel());
+            (request_only_input_tiles
+                 ? static_cast<unsigned int>(geo::TileKey::LevelCount)
+                 : request.GetMaxLevel());
 
         auto sliced_tiles = repository::PrefetchTilesRepository::GetSlicedTiles(
             request.GetTileKeys(), min_level, max_level);

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -46,8 +46,8 @@ constexpr auto kLogTag = "VolatileLayerClientImpl";
 
 bool IsOnlyInputTiles(const PrefetchTilesRequest& request) {
   return !(request.GetMinLevel() <= request.GetMaxLevel() &&
-           request.GetMaxLevel() < geo::TileKey().Level() &&
-           request.GetMinLevel() < geo::TileKey().Level());
+           request.GetMaxLevel() < geo::TileKey::LevelCount &&
+           request.GetMinLevel() < geo::TileKey::LevelCount);
 }
 }  // namespace
 
@@ -191,10 +191,10 @@ client::CancellationToken VolatileLayerClientImpl::PrefetchTiles(
         // cover tree.
         bool request_only_input_tiles = IsOnlyInputTiles(request);
         unsigned int min_level =
-            (request_only_input_tiles ? geo::TileKey().Level()
+            (request_only_input_tiles ? static_cast<unsigned int>(geo::TileKey::LevelCount)
                                       : request.GetMinLevel());
         unsigned int max_level =
-            (request_only_input_tiles ? geo::TileKey().Level()
+            (request_only_input_tiles ? static_cast<unsigned int>(geo::TileKey::LevelCount)
                                       : request.GetMaxLevel());
 
         auto sliced_tiles = repository::PrefetchTilesRepository::GetSlicedTiles(

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -45,8 +45,7 @@ namespace {
 constexpr auto kLogTag = "VolatileLayerClientImpl";
 
 bool IsOnlyInputTiles(const PrefetchTilesRequest& request) {
-  return !(request.GetMinLevel() >= 0 &&
-           request.GetMinLevel() <= request.GetMaxLevel() &&
+  return !(request.GetMinLevel() <= request.GetMaxLevel() &&
            request.GetMaxLevel() < geo::TileKey().Level() &&
            request.GetMinLevel() < geo::TileKey().Level());
 }

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -267,7 +267,8 @@ client::CancellationToken VolatileLayerClientImpl::PrefetchTiles(
           futures->emplace_back(promise->get_future());
           auto context_it = contexts.emplace(contexts.end());
 
-          AddTask(settings.task_scheduler, pending_requests,
+          AddTask(
+              settings.task_scheduler, pending_requests,
                   [=](CancellationContext inner_context) {
                     auto data = repository::DataRepository::GetVolatileData(
                         catalog, layer_id,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -101,8 +101,12 @@ RootTilesForRequest PrefetchTilesRepository::GetSlicedTiles(
 
     // min level should always start from level of root tile for quad tree
     // index, if requested tile is on upper level, adjust min_level up
-    if (tile_key.Level() < min_level || min_level == 0) {
+    if (tile_key.Level() < min_level) {
       min_level = tile_key.Level();
+    }
+    if (max_level == geo::TileKey().Level()) {
+      max_level = min_level;
+    } else {
       max_level = std::max(max_level, min_level);
     }
 
@@ -117,8 +121,8 @@ RootTilesForRequest PrefetchTilesRepository::GetSlicedTiles(
         min_level = min_level - levels_up;
       } else {
         // if min_level is less than steps we need to go up, go some steps down
-        auto levels_down = levels_up - min_level + 1u;
-        min_level = 1u;
+        auto levels_down = levels_up - min_level;
+        min_level = 0u;
         max_level = max_level + levels_down;
       }
     }

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -104,7 +104,7 @@ RootTilesForRequest PrefetchTilesRepository::GetSlicedTiles(
     if (tile_key.Level() < min_level) {
       min_level = tile_key.Level();
     }
-    if (max_level == geo::TileKey().Level()) {
+    if (max_level == geo::TileKey::LevelCount) {
       max_level = min_level;
     } else {
       max_level = std::max(max_level, min_level);

--- a/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
@@ -92,7 +92,7 @@ TEST(PrefetchRepositoryTest, SplitTreeLevelMinLevelSet) {
 TEST(PrefetchRepositoryTest, GetSlicedTilesNoLevels) {
   auto tile = olp::geo::TileKey::FromHereTile("5904591");
   auto root_tiles_depth = PrefetchRepositoryTestable::GetSlicedTiles(
-      {tile}, olp::geo::TileKey().Level(), olp::geo::TileKey().Level());
+      {tile}, olp::geo::TileKey::LevelCount, olp::geo::TileKey::LevelCount);
   ASSERT_EQ(root_tiles_depth.size(), 1);
   auto parent = tile.ChangedLevelBy(-4);
   ASSERT_EQ(root_tiles_depth.size(), 1);
@@ -195,7 +195,8 @@ TEST(PrefetchRepositoryTest, GetSlicedTilesSiblingsNoLevels) {
   auto tile1 = olp::geo::TileKey::FromHereTile("23618366");
   auto tile2 = olp::geo::TileKey::FromHereTile("23618365");
   auto root_tiles_depth = PrefetchRepositoryTestable::GetSlicedTiles(
-      {tile1, tile2}, olp::geo::TileKey().Level(), olp::geo::TileKey().Level());
+      {tile1, tile2}, olp::geo::TileKey::LevelCount,
+      olp::geo::TileKey::LevelCount);
   ASSERT_EQ(root_tiles_depth.size(), 1);
   auto parent1 = tile1.ChangedLevelBy(-4);
   auto parent2 = tile1.ChangedLevelBy(-4);

--- a/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
@@ -91,8 +91,8 @@ TEST(PrefetchRepositoryTest, SplitTreeLevelMinLevelSet) {
 
 TEST(PrefetchRepositoryTest, GetSlicedTilesNoLevels) {
   auto tile = olp::geo::TileKey::FromHereTile("5904591");
-  auto root_tiles_depth =
-      PrefetchRepositoryTestable::GetSlicedTiles({tile}, 0, 0);
+  auto root_tiles_depth = PrefetchRepositoryTestable::GetSlicedTiles(
+      {tile}, olp::geo::TileKey().Level(), olp::geo::TileKey().Level());
   ASSERT_EQ(root_tiles_depth.size(), 1);
   auto parent = tile.ChangedLevelBy(-4);
   ASSERT_EQ(root_tiles_depth.size(), 1);
@@ -118,8 +118,8 @@ TEST(PrefetchRepositoryTest, GetSlicedTilesWithLevelsSpecified) {
         "level");
     auto root_tiles_depth =
         PrefetchRepositoryTestable::GetSlicedTiles({tile}, 1, 13);
-    auto parent = tile.ChangedLevelTo(1);
-    // sliced levels should be 1, 6, 11
+    auto parent = tile.ChangedLevelTo(5);
+    // sliced levels should be 0, 5, 10
     ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
     // 1 tile on each level
     ASSERT_EQ(root_tiles_depth.size(), 3);
@@ -148,8 +148,8 @@ TEST(PrefetchRepositoryTest, GetSlicedTilesMultipleRootTiles) {
         "levels");
     auto root_tiles_depth =
         PrefetchRepositoryTestable::GetSlicedTiles({tile1, tile2}, 1, 13);
-    // sliced levels should be 1, 6, 11
-    auto parent = tile1.ChangedLevelTo(1);
+    // sliced levels should be 0, 5, 10
+    auto parent = tile1.ChangedLevelTo(5);
     ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
     ASSERT_EQ(root_tiles_depth.size(), 3);
   }
@@ -185,8 +185,8 @@ TEST(PrefetchRepositoryTest, GetSlicedTilesMultipleRootTiles) {
 TEST(PrefetchRepositoryTest, GetSlicedTilesSiblingsNoLevels) {
   auto tile1 = olp::geo::TileKey::FromHereTile("23618366");
   auto tile2 = olp::geo::TileKey::FromHereTile("23618365");
-  auto root_tiles_depth =
-      PrefetchRepositoryTestable::GetSlicedTiles({tile1, tile2}, 0, 0);
+  auto root_tiles_depth = PrefetchRepositoryTestable::GetSlicedTiles(
+      {tile1, tile2}, olp::geo::TileKey().Level(), olp::geo::TileKey().Level());
   ASSERT_EQ(root_tiles_depth.size(), 1);
   auto parent1 = tile1.ChangedLevelBy(-4);
   auto parent2 = tile1.ChangedLevelBy(-4);

--- a/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
@@ -154,6 +154,15 @@ TEST(PrefetchRepositoryTest, GetSlicedTilesMultipleRootTiles) {
     ASSERT_EQ(root_tiles_depth.size(), 3);
   }
   {
+    SCOPED_TRACE("Get sliced tiles with min/max levels is zero");
+    auto root_tiles_depth =
+        PrefetchRepositoryTestable::GetSlicedTiles({tile1, tile2}, 0, 0);
+    // sliced levels should be 0
+    auto parent = tile1.ChangedLevelTo(0);
+    ASSERT_EQ(root_tiles_depth.find(parent)->second, 4);
+    ASSERT_EQ(root_tiles_depth.size(), 1);
+  }
+  {
     SCOPED_TRACE(
         "Get sliced tiles with min level greter than first root tile level, "
         "but equal second");

--- a/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
@@ -527,7 +527,7 @@ TEST(VolatileLayerClientImplTest, PrefetchTiles) {
     }
   }
   {
-    SCOPED_TRACE("Prefetch tiles with levels(0, 0).");
+    SCOPED_TRACE("Prefetch tiles with default levels");
 
     SetupNetworkExpectation(*network_mock, kUrlQuadTreeIndexVolatile2,
                             kHttpResponseQuadTreeIndexVolatile,
@@ -542,10 +542,7 @@ TEST(VolatileLayerClientImplTest, PrefetchTiles) {
     std::vector<olp::geo::TileKey> tile_keys = {
         olp::geo::TileKey::FromHereTile(kTileId)};
 
-    auto request = read::PrefetchTilesRequest()
-                       .WithTileKeys(tile_keys)
-                       .WithMinLevel(0)
-                       .WithMaxLevel(0);
+    auto request = read::PrefetchTilesRequest().WithTileKeys(tile_keys);
 
     auto promise =
         std::make_shared<std::promise<read::PrefetchTilesResponse>>();
@@ -705,7 +702,7 @@ TEST(VolatileLayerClientImplTest, PrefetchTilesCancellableFuture) {
     }
   }
   {
-    SCOPED_TRACE("Prefetch tiles with levels(0, 0).");
+    SCOPED_TRACE("Prefetch tiles with default levels");
     SetupNetworkExpectation(*network_mock, kUrlQuadTreeIndexVolatile2,
                             kHttpResponseQuadTreeIndexVolatile,
                             olp::http::HttpStatusCode::OK);
@@ -719,10 +716,7 @@ TEST(VolatileLayerClientImplTest, PrefetchTilesCancellableFuture) {
     std::vector<olp::geo::TileKey> tile_keys = {
         olp::geo::TileKey::FromHereTile(kTileId)};
 
-    auto request = read::PrefetchTilesRequest()
-                       .WithTileKeys(tile_keys)
-                       .WithMinLevel(0)
-                       .WithMaxLevel(0);
+    auto request = read::PrefetchTilesRequest().WithTileKeys(tile_keys);
 
     auto cancellable = client.PrefetchTiles(request);
     auto future = cancellable.GetFuture();

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -252,11 +252,10 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWrongLevels) {
         olp::geo::TileKey::FromHereTile(kTileId)};
 
     {
-      SCOPED_TRACE("min/max levels are 0");
-      auto request = olp::dataservice::read::PrefetchTilesRequest()
-                         .WithTileKeys(tile_keys)
-                         .WithMinLevel(0)
-                         .WithMaxLevel(0);
+      SCOPED_TRACE("min/max levels default");
+      auto request =
+          olp::dataservice::read::PrefetchTilesRequest().WithTileKeys(
+              tile_keys);
 
       std::promise<dataservice_read::PrefetchTilesResponse> promise;
       auto future = promise.get_future();
@@ -350,15 +349,9 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWrongLevels) {
 
       ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
       dataservice_read::PrefetchTilesResponse response = future.get();
-      EXPECT_SUCCESS(response);
-      const auto& result = response.GetResult();
-
-      for (auto tile_result : result) {
-        EXPECT_SUCCESS(*tile_result);
-        ASSERT_TRUE(tile_result->tile_key_.IsValid());
-      }
-
-      ASSERT_EQ(tile_keys.size(), result.size());
+      ASSERT_FALSE(response.IsSuccessful());
+      ASSERT_EQ(static_cast<int>(http::ErrorCode::UNKNOWN_ERROR),
+                response.GetError().GetHttpStatusCode());
     }
   }
 }

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
@@ -375,14 +375,12 @@ TEST_F(VolatileLayerClientTest, Prefetch) {
   }
 
   {
-    SCOPED_TRACE("min/max levels are 0");
+    SCOPED_TRACE("min/max levels default");
 
     std::vector<olp::geo::TileKey> tile_keys = {
         olp::geo::TileKey::FromHereTile(kPrefetchTile)};
-    auto request = olp::dataservice::read::PrefetchTilesRequest()
-                       .WithTileKeys(tile_keys)
-                       .WithMinLevel(0)
-                       .WithMaxLevel(0);
+    auto request =
+        olp::dataservice::read::PrefetchTilesRequest().WithTileKeys(tile_keys);
 
     auto future = client.PrefetchTiles(request).GetFuture();
 

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
@@ -40,9 +40,8 @@
 #include "olp/dataservice/read/PrefetchTileResult.h"
 #include "olp/dataservice/read/VolatileLayerClient.h"
 
-using namespace olp::dataservice::read;
-using namespace olp::dataservice::write::model;
-using namespace testing;
+namespace rd = olp::dataservice::read;
+namespace model = olp::dataservice::write::model;
 
 namespace {
 
@@ -135,7 +134,8 @@ class VolatileLayerClientTest : public ::testing::Test {
         hrn, prefetch_settings_);
 
     {
-      auto batch_request = StartBatchRequest().WithLayers({prefetch_layer_});
+      auto batch_request =
+          model::StartBatchRequest().WithLayers({prefetch_layer_});
 
       auto response = write_client.StartBatch(batch_request).GetFuture().get();
 
@@ -143,8 +143,8 @@ class VolatileLayerClientTest : public ::testing::Test {
       ASSERT_TRUE(response.GetResult().GetId());
       ASSERT_NE("", response.GetResult().GetId().value());
 
-      std::vector<PublishPartitionDataRequest> partition_requests;
-      PublishPartitionDataRequest partition_request;
+      std::vector<model::PublishPartitionDataRequest> partition_requests;
+      model::PublishPartitionDataRequest partition_request;
       partition_requests.push_back(
           partition_request.WithLayerId(prefetch_layer_)
               .WithPartitionId(kPrefetchTile));
@@ -208,16 +208,16 @@ TEST_F(VolatileLayerClientTest, GetPartitions) {
   {
     SCOPED_TRACE("Get Partitions Test");
 
-    VolatileLayerClient client(hrn, GetTestLayer(), settings_);
+    rd::VolatileLayerClient client(hrn, GetTestLayer(), settings_);
 
     olp::client::Condition condition;
-    PartitionsResponse partitions_response;
+    rd::PartitionsResponse partitions_response;
 
-    auto callback = [&](PartitionsResponse response) {
+    auto callback = [&](rd::PartitionsResponse response) {
       partitions_response = std::move(response);
       condition.Notify();
     };
-    client.GetPartitions(PartitionsRequest(), std::move(callback));
+    client.GetPartitions(rd::PartitionsRequest(), std::move(callback));
     ASSERT_TRUE(condition.Wait(kTimeout));
     EXPECT_TRUE(partitions_response.IsSuccessful());
   }
@@ -225,18 +225,18 @@ TEST_F(VolatileLayerClientTest, GetPartitions) {
   {
     SCOPED_TRACE("Get Partitions Test With CacheAndUpdate option");
 
-    VolatileLayerClient client(hrn, GetTestLayer(), settings_);
+    rd::VolatileLayerClient client(hrn, GetTestLayer(), settings_);
 
     olp::client::Condition condition;
-    PartitionsResponse partitions_response;
+    rd::PartitionsResponse partitions_response;
 
-    auto callback = [&](PartitionsResponse response) {
+    auto callback = [&](rd::PartitionsResponse response) {
       partitions_response = std::move(response);
       condition.Notify();
     };
-    client.GetPartitions(
-        PartitionsRequest().WithFetchOption(FetchOptions::CacheWithUpdate),
-        std::move(callback));
+    client.GetPartitions(rd::PartitionsRequest().WithFetchOption(
+                             rd::FetchOptions::CacheWithUpdate),
+                         std::move(callback));
     ASSERT_TRUE(condition.Wait(kTimeout));
     EXPECT_TRUE(partitions_response.IsSuccessful());
   }
@@ -244,16 +244,16 @@ TEST_F(VolatileLayerClientTest, GetPartitions) {
   {
     SCOPED_TRACE("Get Partitions Invalid Layer Test");
 
-    VolatileLayerClient client(hrn, "InvalidLayer", settings_);
+    rd::VolatileLayerClient client(hrn, "InvalidLayer", settings_);
 
     olp::client::Condition condition;
-    PartitionsResponse partitions_response;
+    rd::PartitionsResponse partitions_response;
 
-    auto callback = [&](PartitionsResponse response) {
+    auto callback = [&](rd::PartitionsResponse response) {
       partitions_response = std::move(response);
       condition.Notify();
     };
-    client.GetPartitions(PartitionsRequest(), std::move(callback));
+    client.GetPartitions(rd::PartitionsRequest(), std::move(callback));
     ASSERT_TRUE(condition.Wait(kTimeout));
     EXPECT_FALSE(partitions_response.IsSuccessful());
   }
@@ -261,17 +261,17 @@ TEST_F(VolatileLayerClientTest, GetPartitions) {
   {
     SCOPED_TRACE("Get Partitions Invalid HRN Test");
 
-    VolatileLayerClient client(olp::client::HRN("Invalid"), GetTestLayer(),
-                               settings_);
+    rd::VolatileLayerClient client(olp::client::HRN("Invalid"), GetTestLayer(),
+                                   settings_);
 
     olp::client::Condition condition;
-    PartitionsResponse partitions_response;
+    rd::PartitionsResponse partitions_response;
 
-    auto callback = [&](PartitionsResponse response) {
+    auto callback = [&](rd::PartitionsResponse response) {
       partitions_response = std::move(response);
       condition.Notify();
     };
-    client.GetPartitions(PartitionsRequest(), std::move(callback));
+    client.GetPartitions(rd::PartitionsRequest(), std::move(callback));
     ASSERT_TRUE(condition.Wait(kTimeout));
     EXPECT_FALSE(partitions_response.IsSuccessful());
   }
@@ -282,17 +282,17 @@ TEST_F(VolatileLayerClientTest, GetPartitionsDifferentFetchOptions) {
   {
     SCOPED_TRACE("Get Partitions Online Only");
 
-    VolatileLayerClient client(hrn, GetTestLayer(), settings_);
+    rd::VolatileLayerClient client(hrn, GetTestLayer(), settings_);
 
     olp::client::Condition condition;
-    PartitionsResponse partitions_response;
+    rd::PartitionsResponse partitions_response;
 
-    auto callback = [&](PartitionsResponse response) {
+    auto callback = [&](rd::PartitionsResponse response) {
       partitions_response = std::move(response);
       condition.Notify();
     };
     client.GetPartitions(
-        PartitionsRequest().WithFetchOption(FetchOptions::OnlineOnly),
+        rd::PartitionsRequest().WithFetchOption(rd::FetchOptions::OnlineOnly),
         std::move(callback));
     ASSERT_TRUE(condition.Wait(kTimeout));
     EXPECT_TRUE(partitions_response.IsSuccessful());
@@ -300,35 +300,35 @@ TEST_F(VolatileLayerClientTest, GetPartitionsDifferentFetchOptions) {
   {
     SCOPED_TRACE("Get Partitions Online if not found");
 
-    VolatileLayerClient client(hrn, GetTestLayer(), settings_);
+    rd::VolatileLayerClient client(hrn, GetTestLayer(), settings_);
 
     olp::client::Condition condition;
-    PartitionsResponse partitions_response;
+    rd::PartitionsResponse partitions_response;
 
-    auto callback = [&](PartitionsResponse response) {
+    auto callback = [&](rd::PartitionsResponse response) {
       partitions_response = std::move(response);
       condition.Notify();
     };
-    client.GetPartitions(
-        PartitionsRequest().WithFetchOption(FetchOptions::OnlineIfNotFound),
-        std::move(callback));
+    client.GetPartitions(rd::PartitionsRequest().WithFetchOption(
+                             rd::FetchOptions::OnlineIfNotFound),
+                         std::move(callback));
     ASSERT_TRUE(condition.Wait(kTimeout));
     EXPECT_TRUE(partitions_response.IsSuccessful());
   }
   {
     SCOPED_TRACE("Get Partitions Cache Only");
 
-    VolatileLayerClient client(hrn, GetTestLayer(), settings_);
+    rd::VolatileLayerClient client(hrn, GetTestLayer(), settings_);
 
     olp::client::Condition condition;
-    PartitionsResponse partitions_response;
+    rd::PartitionsResponse partitions_response;
 
-    auto callback = [&](PartitionsResponse response) {
+    auto callback = [&](rd::PartitionsResponse response) {
       partitions_response = std::move(response);
       condition.Notify();
     };
     client.GetPartitions(
-        PartitionsRequest().WithFetchOption(FetchOptions::CacheOnly),
+        rd::PartitionsRequest().WithFetchOption(rd::FetchOptions::CacheOnly),
         std::move(callback));
     ASSERT_TRUE(condition.Wait(kTimeout));
     EXPECT_TRUE(partitions_response.IsSuccessful());
@@ -339,7 +339,7 @@ TEST_F(VolatileLayerClientTest, Prefetch) {
   WritePrefetchTilesData();
 
   olp::client::HRN hrn(prefetch_catalog_);
-  VolatileLayerClient client(hrn, prefetch_layer_, prefetch_settings_);
+  rd::VolatileLayerClient client(hrn, prefetch_layer_, prefetch_settings_);
   {
     SCOPED_TRACE("Prefetch tiles online and store them in memory cache");
     std::vector<olp::geo::TileKey> tile_keys = {
@@ -349,7 +349,7 @@ TEST_F(VolatileLayerClientTest, Prefetch) {
         olp::geo::TileKey::FromHereTile(kPrefetchSubTile1),
         olp::geo::TileKey::FromHereTile(kPrefetchSubTile2)};
 
-    auto request = olp::dataservice::read::PrefetchTilesRequest()
+    auto request = rd::PrefetchTilesRequest()
                        .WithTileKeys(tile_keys)
                        .WithMinLevel(10)
                        .WithMaxLevel(12);
@@ -357,7 +357,7 @@ TEST_F(VolatileLayerClientTest, Prefetch) {
     auto future = client.PrefetchTiles(request).GetFuture();
 
     ASSERT_NE(future.wait_for(kTimeout), std::future_status::timeout);
-    PrefetchTilesResponse response = future.get();
+    rd::PrefetchTilesResponse response = future.get();
     EXPECT_TRUE(response.IsSuccessful());
     ASSERT_FALSE(response.GetResult().empty());
 
@@ -379,13 +379,12 @@ TEST_F(VolatileLayerClientTest, Prefetch) {
 
     std::vector<olp::geo::TileKey> tile_keys = {
         olp::geo::TileKey::FromHereTile(kPrefetchTile)};
-    auto request =
-        olp::dataservice::read::PrefetchTilesRequest().WithTileKeys(tile_keys);
+    auto request = rd::PrefetchTilesRequest().WithTileKeys(tile_keys);
 
     auto future = client.PrefetchTiles(request).GetFuture();
 
     ASSERT_NE(future.wait_for(kTimeout), std::future_status::timeout);
-    PrefetchTilesResponse response = future.get();
+    rd::PrefetchTilesResponse response = future.get();
     EXPECT_TRUE(response.IsSuccessful());
     const auto& result = response.GetResult();
 
@@ -405,7 +404,7 @@ TEST_F(VolatileLayerClientTest, Prefetch) {
 
     std::vector<olp::geo::TileKey> tile_keys = {
         olp::geo::TileKey::FromHereTile(kPrefetchTile)};
-    auto request = olp::dataservice::read::PrefetchTilesRequest()
+    auto request = rd::PrefetchTilesRequest()
                        .WithTileKeys(tile_keys)
                        .WithMinLevel(12)
                        .WithMaxLevel(12);
@@ -413,7 +412,7 @@ TEST_F(VolatileLayerClientTest, Prefetch) {
     auto future = client.PrefetchTiles(request).GetFuture();
 
     ASSERT_NE(future.wait_for(kTimeout), std::future_status::timeout);
-    PrefetchTilesResponse response = future.get();
+    rd::PrefetchTilesResponse response = future.get();
     EXPECT_TRUE(response.IsSuccessful());
     const auto& result = response.GetResult();
 

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -1497,9 +1497,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
         .Times(0);
 
     auto request = read::PrefetchTilesRequest()
-                       .WithTileKeys(tile_keys)
-                       .WithMinLevel(0)
-                       .WithMaxLevel(0);
+                       .WithTileKeys(tile_keys);
 
     auto promise = std::make_shared<std::promise<PrefetchTilesResponse>>();
     auto future = promise->get_future();
@@ -1532,9 +1530,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesWrongLevels) {
           GetResponse(http::HttpStatusCode::FORBIDDEN), HTTP_RESPONSE_403));
 
   auto request = read::PrefetchTilesRequest()
-                     .WithTileKeys(tile_keys)
-                     .WithMinLevel(0)
-                     .WithMaxLevel(0);
+                     .WithTileKeys(tile_keys);
 
   auto client = std::make_shared<read::VersionedLayerClient>(kCatalog, kLayerId,
                                                              4, settings_);

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
@@ -1054,10 +1054,7 @@ TEST_F(DataserviceReadVolatileLayerClientTest,
     std::vector<olp::geo::TileKey> tile_keys = {
         olp::geo::TileKey::FromHereTile("23618366"),
         olp::geo::TileKey::FromHereTile("23618365")};
-    auto request = read::PrefetchTilesRequest()
-                       .WithTileKeys(tile_keys)
-                       .WithMinLevel(0)
-                       .WithMaxLevel(0);
+    auto request = read::PrefetchTilesRequest().WithTileKeys(tile_keys);
     auto promise =
         std::make_shared<std::promise<read::PrefetchTilesResponse>>();
     std::future<read::PrefetchTilesResponse> future = promise->get_future();
@@ -1093,10 +1090,7 @@ TEST_F(DataserviceReadVolatileLayerClientTest, PrefetchTilesWrongLevels) {
 
   read::VolatileLayerClient client(catalog, kLayerId, settings_);
 
-  auto request = read::PrefetchTilesRequest()
-                     .WithTileKeys(tile_keys)
-                     .WithMinLevel(0)
-                     .WithMaxLevel(0);
+  auto request = read::PrefetchTilesRequest().WithTileKeys(tile_keys);
   auto cancel_future = client.PrefetchTiles(request);
   auto raw_future = cancel_future.GetFuture();
 


### PR DESCRIPTION
Prefetch works with input parameters min and max levels. Defaults 
levels should indicate that user wants to get only tiles in request. 
As level 0 is valid, min and max values for request is initialized as 
invalid, that during reques we can distinguish if levels was set by 
user. Fix tests to run with default initialized levels instead of 0/0.

Relates-To: OLPEDGE-2198

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>