### PR TITLE
Remove static from CatalogRepository methods.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
@@ -69,9 +69,8 @@ client::CancellationToken CatalogClientImpl::GetCatalog(
     auto settings = settings_;
 
     auto get_catalog_task = [=](client::CancellationContext context) {
-      return repository::CatalogRepository::GetCatalog(
-          std::move(catalog), std::move(context), std::move(request),
-          std::move(settings));
+      repository::CatalogRepository repository(catalog, settings);
+      return repository.GetCatalog(request, std::move(context));
     };
 
     return AddTask(task_scheduler_, pending_requests_,
@@ -102,9 +101,8 @@ client::CancellationToken CatalogClientImpl::GetLatestVersion(
     auto settings = settings_;
 
     auto get_latest_version_task = [=](client::CancellationContext context) {
-      return repository::CatalogRepository::GetLatestVersion(
-          std::move(catalog), std::move(context), std::move(request),
-          std::move(settings));
+      repository::CatalogRepository repository(catalog, settings);
+      return repository.GetLatestVersion(request, std::move(context));
     };
 
     return AddTask(task_scheduler_, pending_requests_,
@@ -128,10 +126,13 @@ CatalogClientImpl::GetLatestVersion(CatalogVersionRequest request) {
 
 client::CancellationToken CatalogClientImpl::ListVersions(
     VersionsRequest request, VersionsResponseCallback callback) {
+  auto catalog = catalog_;
+  auto settings = settings_;
+
   auto versions_list_task =
       [=](client::CancellationContext context) -> VersionsResponse {
-    return repository::CatalogRepository::GetVersionsList(catalog_, context,
-                                                          request, settings_);
+    repository::CatalogRepository repository(catalog, settings);
+    return repository.GetVersionsList(request, std::move(context));
   };
 
   return AddTask(task_scheduler_, pending_requests_,

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -425,8 +425,9 @@ CatalogVersionResponse VersionedLayerClientImpl::GetVersion(
   CatalogVersionRequest request;
   request.WithBillingTag(billing_tag);
   request.WithFetchOption(fetch_options);
-  auto response = repository::CatalogRepository::GetLatestVersion(
-      catalog_, context, request, settings_);
+
+  repository::CatalogRepository repository(catalog_, settings_);
+  auto response = repository.GetLatestVersion(request, context);
 
   if (!response.IsSuccessful()) {
     return response;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.h
@@ -38,20 +38,20 @@ namespace repository {
 
 class CatalogRepository final {
  public:
-  static CatalogResponse GetCatalog(client::HRN catalog,
-                                    client::CancellationContext context,
-                                    CatalogRequest request,
-                                    client::OlpClientSettings settings);
+  CatalogRepository(client::HRN catalog, client::OlpClientSettings settings);
 
-  static CatalogVersionResponse GetLatestVersion(
-      client::HRN catalog, client::CancellationContext cancellation_context,
-      CatalogVersionRequest request, client::OlpClientSettings settings);
+  CatalogResponse GetCatalog(const CatalogRequest& request,
+                             client::CancellationContext context);
 
-  static VersionsResponse GetVersionsList(
-      const client::HRN& catalog,
-      client::CancellationContext cancellation_context,
-      const VersionsRequest& request,
-      const client::OlpClientSettings& settings);
+  CatalogVersionResponse GetLatestVersion(const CatalogVersionRequest& request,
+                                          client::CancellationContext context);
+
+  VersionsResponse GetVersionsList(const VersionsRequest& request,
+                                   client::CancellationContext context);
+
+ private:
+  client::HRN catalog_;
+  client::OlpClientSettings settings_;
 };
 
 }  // namespace repository

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -112,13 +112,12 @@ PartitionsResponse PartitionsRepository::GetVersionedPartitions(
     client::OlpClientSettings settings) {
   if (!request.GetVersion()) {
     // get latest version of the layer if it wasn't set by the user
-    auto latest_version_response =
-        repository::CatalogRepository::GetLatestVersion(
-            catalog, cancellation_context,
-            CatalogVersionRequest()
-                .WithFetchOption(request.GetFetchOption())
-                .WithBillingTag(request.GetBillingTag()),
-            settings);
+    CatalogRepository repository(catalog, settings);
+    auto latest_version_response = repository.GetLatestVersion(
+        CatalogVersionRequest()
+            .WithFetchOption(request.GetFetchOption())
+            .WithBillingTag(request.GetBillingTag()),
+        cancellation_context);
 
     if (!latest_version_response.IsSuccessful()) {
       return latest_version_response.GetError();
@@ -141,8 +140,9 @@ PartitionsResponse PartitionsRepository::GetVolatilePartitions(
                              .WithBillingTag(request.GetBillingTag())
                              .WithFetchOption(request.GetFetchOption());
 
-  auto catalog_response = repository::CatalogRepository::GetCatalog(
-      catalog, cancellation_context, catalog_request, settings);
+  CatalogRepository repository(catalog, settings);
+  auto catalog_response =
+      repository.GetCatalog(catalog_request, cancellation_context);
 
   if (!catalog_response.IsSuccessful()) {
     return catalog_response.GetError();

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
@@ -118,8 +118,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionCacheOnlyFound) {
       .Times(1)
       .WillOnce(testing::Return(cached_version));
 
-  auto response = repository::CatalogRepository::GetLatestVersion(
-      kHrn, context, request, settings_);
+  repository::CatalogRepository repository(kHrn, settings_);
+  auto response = repository.GetLatestVersion(request, context);
 
   ASSERT_TRUE(response.IsSuccessful());
   EXPECT_EQ(10, response.GetResult().GetVersion());
@@ -145,9 +145,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionCacheOnlyNotFound) {
         return olp::http::SendOutcome(olp::http::ErrorCode::UNKNOWN_ERROR);
       });
 
-  auto response =
-      olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
-          kHrn, context, request, settings_);
+  repository::CatalogRepository repository(kHrn, settings_);
+  auto response = repository.GetLatestVersion(request, context);
 
   EXPECT_FALSE(response.IsSuccessful());
 }
@@ -171,9 +170,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyNotFound) {
                                        olp::http::HttpStatusCode::NOT_FOUND),
                                    ""));
 
-  auto response =
-      olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
-          kHrn, context, request, settings_);
+  repository::CatalogRepository repository(kHrn, settings_);
+  auto response = repository.GetLatestVersion(request, context);
 
   EXPECT_FALSE(response.IsSuccessful());
 }
@@ -206,9 +204,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyFound) {
                                        olp::http::HttpStatusCode::OK),
                                    kResponseLatestCatalogVersion));
 
-  auto response =
-      olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
-          kHrn, context, request, settings_);
+  repository::CatalogRepository repository(kHrn, settings_);
+  auto response = repository.GetLatestVersion(request, context);
 
   ASSERT_TRUE(response.IsSuccessful());
   ASSERT_EQ(4, response.GetResult().GetVersion());
@@ -244,9 +241,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled1) {
         return olp::http::SendOutcome(unused_request_id);
       });
 
-  auto response =
-      olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
-          kHrn, context, request, settings_);
+  repository::CatalogRepository repository(kHrn, settings_);
+  auto response = repository.GetLatestVersion(request, context);
 
   ASSERT_FALSE(response.IsSuccessful());
   EXPECT_EQ(olp::client::ErrorCode::Cancelled,
@@ -274,9 +270,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled2) {
         return olp::http::SendOutcome(unused_request_id);
       });
 
-  auto response =
-      olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
-          kHrn, context, request, settings_);
+  repository::CatalogRepository repository(kHrn, settings_);
+  auto response = repository.GetLatestVersion(request, context);
 
   ASSERT_FALSE(response.IsSuccessful());
   EXPECT_EQ(olp::client::ErrorCode::Cancelled,
@@ -300,9 +295,9 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionCancelledBeforeExecution) {
       });
 
   context.CancelOperation();
-  auto response =
-      olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
-          kHrn, context, request, settings_);
+
+  repository::CatalogRepository repository(kHrn, settings_);
+  auto response = repository.GetLatestVersion(request, context);
 
   ASSERT_FALSE(response.IsSuccessful());
   EXPECT_EQ(olp::client::ErrorCode::Cancelled,
@@ -330,9 +325,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionTimeouted) {
 
   settings_.retry_settings.timeout = 0;
 
-  auto response =
-      olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
-          kHrn, context, request, settings_);
+  repository::CatalogRepository repository(kHrn, settings_);
+  auto response = repository.GetLatestVersion(request, context);
 
   ASSERT_FALSE(response.IsSuccessful());
   EXPECT_EQ(olp::client::ErrorCode::RequestTimeout,
@@ -365,8 +359,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyFound) {
                                             olp::http::HttpStatusCode::OK),
                                         kResponseConfig));
 
-  auto response = repository::CatalogRepository::GetCatalog(kHrn, context,
-                                                            request, settings_);
+  repository::CatalogRepository repository(kHrn, settings_);
+  auto response = repository.GetCatalog(request, context);
 
   ASSERT_TRUE(response.IsSuccessful());
 }
@@ -385,8 +379,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogCacheOnlyFound) {
       .Times(1)
       .WillOnce(testing::Return(cached_version));
 
-  auto response = repository::CatalogRepository::GetCatalog(kHrn, context,
-                                                            request, settings_);
+  repository::CatalogRepository repository(kHrn, settings_);
+  auto response = repository.GetCatalog(request, context);
 
   ASSERT_TRUE(response.IsSuccessful());
   EXPECT_EQ(kCatalog, response.GetResult().GetHrn());
@@ -412,9 +406,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogCacheOnlyNotFound) {
         return olp::http::SendOutcome(olp::http::ErrorCode::UNKNOWN_ERROR);
       });
 
-  auto response =
-      olp::dataservice::read::repository::CatalogRepository::GetLatestVersion(
-          kHrn, context, request, settings_);
+  repository::CatalogRepository repository(kHrn, settings_);
+  auto response = repository.GetLatestVersion(request, context);
 
   EXPECT_FALSE(response.IsSuccessful());
 }
@@ -438,8 +431,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyNotFound) {
                                        olp::http::HttpStatusCode::NOT_FOUND),
                                    ""));
 
-  auto response = repository::CatalogRepository::GetCatalog(kHrn, context,
-                                                            request, settings_);
+  repository::CatalogRepository repository(kHrn, settings_);
+  auto response = repository.GetCatalog(request, context);
 
   EXPECT_FALSE(response.IsSuccessful());
 }
@@ -461,8 +454,9 @@ TEST_F(CatalogRepositoryTest, GetCatalogCancelledBeforeExecution) {
       });
 
   context.CancelOperation();
-  auto response = repository::CatalogRepository::GetCatalog(kHrn, context,
-                                                            request, settings_);
+
+  repository::CatalogRepository repository(kHrn, settings_);
+  auto response = repository.GetCatalog(request, context);
 
   ASSERT_FALSE(response.IsSuccessful());
   EXPECT_EQ(olp::client::ErrorCode::Cancelled,
@@ -499,8 +493,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled1) {
         return olp::http::SendOutcome(unused_request_id);
       });
 
-  auto response = repository::CatalogRepository::GetCatalog(kHrn, context,
-                                                            request, settings_);
+  repository::CatalogRepository repository(kHrn, settings_);
+  auto response = repository.GetCatalog(request, context);
 
   ASSERT_FALSE(response.IsSuccessful());
   EXPECT_EQ(olp::client::ErrorCode::Cancelled,
@@ -528,8 +522,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled2) {
         return olp::http::SendOutcome(unused_request_id);
       });
 
-  auto response = repository::CatalogRepository::GetCatalog(kHrn, context,
-                                                            request, settings_);
+  repository::CatalogRepository repository(kHrn, settings_);
+  auto response = repository.GetCatalog(request, context);
 
   ASSERT_FALSE(response.IsSuccessful());
   EXPECT_EQ(olp::client::ErrorCode::Cancelled,
@@ -556,8 +550,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogTimeout) {
       });
   settings_.retry_settings.timeout = 0;
 
-  auto response = repository::CatalogRepository::GetCatalog(kHrn, context,
-                                                            request, settings_);
+  repository::CatalogRepository repository(kHrn, settings_);
+  auto response = repository.GetCatalog(request, context);
 
   ASSERT_FALSE(response.IsSuccessful());
   EXPECT_EQ(olp::client::ErrorCode::RequestTimeout,
@@ -585,8 +579,8 @@ TEST_F(CatalogRepositoryTest, GetVersionsList) {
                                    olp::http::HttpStatusCode::OK),
                                kHttpResponse));
 
-    auto response = repository::CatalogRepository::GetVersionsList(
-        kHrn, context, request, settings_);
+    repository::CatalogRepository repository(kHrn, settings_);
+    auto response = repository.GetVersionsList(request, context);
 
     ASSERT_TRUE(response.IsSuccessful());
     auto result = response.GetResult();
@@ -616,8 +610,8 @@ TEST_F(CatalogRepositoryTest, GetVersionsList) {
                                    olp::http::HttpStatusCode::OK),
                                kHttpResponse));
 
-    auto response = repository::CatalogRepository::GetVersionsList(
-        kHrn, context, request, settings_);
+    repository::CatalogRepository repository(kHrn, settings_);
+    auto response = repository.GetVersionsList(request, context);
 
     ASSERT_TRUE(response.IsSuccessful());
     auto result = response.GetResult();
@@ -647,8 +641,8 @@ TEST_F(CatalogRepositoryTest, GetVersionsList) {
                                    olp::http::HttpStatusCode::FORBIDDEN),
                                "Forbidden"));
 
-    auto response = repository::CatalogRepository::GetVersionsList(
-        kHrn, context, request, settings_);
+    repository::CatalogRepository repository(kHrn, settings_);
+    auto response = repository.GetVersionsList(request, context);
 
     ASSERT_FALSE(response.IsSuccessful());
     EXPECT_EQ(olp::client::ErrorCode::AccessDenied,


### PR DESCRIPTION
CatalogRepository contains only static methods and they all are taking
HRN and OlpClientSettings as args. Moving these args to constructor
will simplify further extending, e.g. with ApiClientLookup.

Resolves: OLPEDGE-2200

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>