### PR TITLE
Remove static from PartitionsRepository methods.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -106,10 +106,11 @@ client::CancellationToken VersionedLayerClientImpl::GetPartitions(
       if (!version_response.IsSuccessful()) {
         return version_response.GetError();
       }
+      const auto version = version_response.GetResult().GetVersion();
 
-      return repository::PartitionsRepository::GetVersionedPartitions(
-          catalog, layer_id, version_response.GetResult().GetVersion(), context,
-          std::move(request), settings);
+      repository::PartitionsRepository repository(catalog, settings);
+      return repository.GetVersionedPartitions(layer_id, request, version,
+                                               context);
     };
 
     return AddTask(settings.task_scheduler, pending_requests_,
@@ -455,9 +456,9 @@ bool VersionedLayerClientImpl::RemoveFromCache(
 
 bool VersionedLayerClientImpl::RemoveFromCache(const geo::TileKey& tile) {
   read::QuadTreeIndex cached_tree;
-  if (repository::PartitionsRepository::FindQuadTree(
-          catalog_, settings_, layer_id_, catalog_version_.load(), tile,
-          cached_tree)) {
+  repository::PartitionsRepository repository(catalog_, settings_);
+  if (repository.FindQuadTree(layer_id_, catalog_version_.load(), tile,
+                              cached_tree)) {
     auto data = cached_tree.Find(tile, false);
     if (!data) {
       return true;
@@ -499,9 +500,9 @@ bool VersionedLayerClientImpl::IsCached(const std::string& partition_id) const {
 
 bool VersionedLayerClientImpl::IsCached(const geo::TileKey& tile) const {
   read::QuadTreeIndex cached_tree;
-  if (repository::PartitionsRepository::FindQuadTree(
-          catalog_, settings_, layer_id_, catalog_version_.load(), tile,
-          cached_tree)) {
+  repository::PartitionsRepository repository(catalog_, settings_);
+  if (repository.FindQuadTree(layer_id_, catalog_version_.load(), tile,
+                              cached_tree)) {
     auto data = cached_tree.Find(tile, false);
     if (!data) {
       return false;
@@ -539,9 +540,9 @@ client::CancellationToken VersionedLayerClientImpl::GetAggregatedData(
     }
 
     auto version = version_response.GetResult().GetVersion();
+    repository::PartitionsRepository repository(catalog_, settings_);
     auto partition_response =
-        repository::PartitionsRepository::GetAggregatedTile(
-            catalog, layer_id, context, request, version, settings);
+        repository.GetAggregatedTile(layer_id, request, version, context);
     if (!partition_response.IsSuccessful()) {
       return partition_response.GetError();
     }
@@ -629,8 +630,8 @@ bool VersionedLayerClientImpl::Protect(const TileKeys& tiles) {
       add_data_handle(tile, *it);
     } else {
       read::QuadTreeIndex cached_tree;
-      if (repository::PartitionsRepository::FindQuadTree(
-              catalog_, settings_, layer_id_, version, tile, cached_tree) &&
+      repository::PartitionsRepository repository(catalog_, settings_);
+      if (repository.FindQuadTree(layer_id_, version, tile, cached_tree) &&
           add_data_handle(tile, cached_tree)) {
         keys_to_protect.emplace_back(partitions_cache_repository.CreateQuadKey(
             layer_id_, cached_tree.GetRootTile(), kQuadTreeDepth, version));

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -82,9 +82,9 @@ client::CancellationToken VolatileLayerClientImpl::GetPartitions(
     auto settings = settings_;
 
     auto data_task = [=](client::CancellationContext context) {
-      return repository::PartitionsRepository::GetVolatilePartitions(
-          std::move(catalog), std::move(layer_id), std::move(context),
-          std::move(request), std::move(settings));
+      repository::PartitionsRepository repository(catalog, settings);
+      return repository.GetVolatilePartitions(std::move(layer_id), request,
+                                              std::move(context));
     };
 
     return AddTask(settings.task_scheduler, pending_requests_,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -61,8 +61,8 @@ DataResponse DataRepository::GetVersionedTile(
     const TileRequest& request, int64_t version,
     client::CancellationContext context,
     const client::OlpClientSettings& settings) {
-  auto response = PartitionsRepository::GetTile(catalog, layer_id, context,
-                                                request, version, settings);
+  PartitionsRepository repository(catalog, settings);
+  auto response = repository.GetTile(layer_id, request, version, context);
 
   if (!response.IsSuccessful()) {
     OLP_SDK_LOG_WARNING_F(
@@ -94,9 +94,9 @@ DataResponse DataRepository::GetVersionedData(
 
   if (!request.GetDataHandle()) {
     // get data handle for a partition to be queried
+    PartitionsRepository repository(catalog, settings);
     auto partitions_response =
-        repository::PartitionsRepository::GetPartitionById(
-            catalog, layer_id, version, context, request, settings);
+        repository.GetPartitionById(layer_id, version, request, context);
 
     if (!partitions_response.IsSuccessful()) {
       return partitions_response.GetError();
@@ -209,9 +209,9 @@ DataResponse DataRepository::GetVolatileData(
   }
 
   if (!request.GetDataHandle()) {
+    PartitionsRepository repository(catalog, settings);
     auto partitions_response =
-        repository::PartitionsRepository::GetPartitionById(
-            catalog, layer_id, boost::none, context, request, settings);
+        repository.GetPartitionById(layer_id, boost::none, request, context);
 
     if (!partitions_response.IsSuccessful()) {
       return partitions_response.GetError();

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -47,57 +47,51 @@ using QuadTreeIndexResponse = Response<QuadTreeIndex>;
 
 class PartitionsRepository {
  public:
-  static PartitionsResponse GetVersionedPartitions(
-      client::HRN catalog, std::string layer, int64_t version,
-      client::CancellationContext cancellation_context,
-      read::PartitionsRequest data_request, client::OlpClientSettings settings);
+  PartitionsRepository(client::HRN catalog, client::OlpClientSettings settings);
 
-  static PartitionsResponse GetVolatilePartitions(
-      client::HRN catalog, std::string layer,
-      client::CancellationContext cancellation_context,
-      read::PartitionsRequest data_request, client::OlpClientSettings settings);
+  PartitionsResponse GetVersionedPartitions(
+      std::string layer, const read::PartitionsRequest& request,
+      std::int64_t version, client::CancellationContext context);
 
-  static PartitionsResponse GetPartitionById(
-      const client::HRN& catalog, const std::string& layer,
-      boost::optional<int64_t> version,
-      client::CancellationContext cancellation_context,
-      const DataRequest& data_request, client::OlpClientSettings settings);
+  PartitionsResponse GetVolatilePartitions(
+      std::string layer, const read::PartitionsRequest& request,
+      client::CancellationContext context);
 
-  static model::Partition PartitionFromSubQuad(const model::SubQuad& sub_quad,
-                                               const std::string& partition);
+  PartitionsResponse GetPartitionById(const std::string& layer,
+                                      boost::optional<int64_t> version,
+                                      const DataRequest& request,
+                                      client::CancellationContext context);
 
-  static PartitionResponse GetAggregatedTile(
-      const client::HRN& catalog, const std::string& layer,
-      client::CancellationContext cancellation_context,
-      const TileRequest& request, boost::optional<int64_t> version,
-      const client::OlpClientSettings& settings);
+  model::Partition PartitionFromSubQuad(const model::SubQuad& sub_quad,
+                                        const std::string& partition);
 
-  static PartitionResponse GetTile(
-      const client::HRN& catalog, const std::string& layer,
-      client::CancellationContext cancellation_context,
-      const TileRequest& request, boost::optional<int64_t> version,
-      const client::OlpClientSettings& settings);
+  PartitionResponse GetAggregatedTile(const std::string& layer,
+                                      const TileRequest& request,
+                                      boost::optional<int64_t> version,
+                                      client::CancellationContext context);
 
-  static bool FindQuadTree(const client::HRN& catalog,
-                           const client::OlpClientSettings& settings,
-                           const std::string& layer,
-                           boost::optional<int64_t> version,
-                           const olp::geo::TileKey& tile_key,
-                           read::QuadTreeIndex& tree);
+  PartitionResponse GetTile(const std::string& layer,
+                            const TileRequest& request,
+                            boost::optional<int64_t> version,
+                            client::CancellationContext context);
+
+  bool FindQuadTree(const std::string& layer, boost::optional<int64_t> version,
+                    const olp::geo::TileKey& tile_key,
+                    read::QuadTreeIndex& tree);
 
  private:
-  static QuadTreeIndexResponse GetQuadTreeIndexForTile(
-      const client::HRN& catalog, const std::string& layer,
-      client::CancellationContext cancellation_context,
-      const TileRequest& request, boost::optional<int64_t> version,
-      const client::OlpClientSettings& settings);
+  QuadTreeIndexResponse GetQuadTreeIndexForTile(
+      const std::string& layer, const TileRequest& request,
+      boost::optional<int64_t> version, client::CancellationContext context);
 
-  static PartitionsResponse GetPartitions(
-      client::HRN catalog, std::string layer, boost::optional<int64_t> version,
-      client::CancellationContext cancellation_context,
-      read::PartitionsRequest request,
-      const client::OlpClientSettings& settings,
+  PartitionsResponse GetPartitions(
+      std::string layer, const read::PartitionsRequest& request,
+      boost::optional<std::int64_t> version,
+      client::CancellationContext context,
       boost::optional<time_t> expiry = boost::none);
+
+  client::HRN catalog_;
+  client::OlpClientSettings settings_;
 };
 }  // namespace repository
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -310,9 +310,9 @@ SubQuadsResponse PrefetchTilesRepository::GetVolatileSubQuads(
     result.emplace(subtile, subquad->GetDataHandle());
 
     // add to bulk partitions for cacheing
+    PartitionsRepository repository(catalog, settings);
     partitions.GetMutablePartitions().emplace_back(
-        PartitionsRepository::PartitionFromSubQuad(*subquad,
-                                                   subtile.ToHereTile()));
+        repository.PartitionFromSubQuad(*subquad, subtile.ToHereTile()));
   }
 
   // add to cache

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -159,8 +159,7 @@ const std::string kBlobDataHandle1476147 =
 
 const std::string kErrorServiceUnavailable = "Service unavailable";
 
-class PartitionsRepositoryTest : public ::testing::Test,
-                                 protected repository::PartitionsRepository {};
+class PartitionsRepositoryTest : public ::testing::Test {};
 
 TEST_F(PartitionsRepositoryTest, GetPartitionById) {
   using testing::Eq;
@@ -214,9 +213,10 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
             Return(parser::parse<model::Partition>(query_cache_response)));
 
     client::CancellationContext context;
-    auto response = repository::PartitionsRepository::GetPartitionById(
-        catalog_hrn, kVersionedLayerId, kVersion, context,
-        DataRequest(request).WithFetchOption(read::CacheOnly), settings);
+    repository::PartitionsRepository repository(catalog_hrn, settings);
+    auto response = repository.GetPartitionById(
+        kVersionedLayerId, kVersion,
+        DataRequest(request).WithFetchOption(read::CacheOnly), context);
 
     ASSERT_TRUE(response.IsSuccessful());
     const auto& result = response.GetResult();
@@ -237,9 +237,10 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         .WillOnce(Return(boost::any()));
 
     client::CancellationContext context;
-    auto response = repository::PartitionsRepository::GetPartitionById(
-        catalog_hrn, kVersionedLayerId, kVersion, context,
-        DataRequest(request).WithFetchOption(read::CacheOnly), settings);
+    repository::PartitionsRepository repository(catalog_hrn, settings);
+    auto response = repository.GetPartitionById(
+        kVersionedLayerId, kVersion,
+        DataRequest(request).WithFetchOption(read::CacheOnly), context);
 
     ASSERT_FALSE(response.IsSuccessful());
     const auto& result = response.GetError();
@@ -251,9 +252,10 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     SCOPED_TRACE("Fetch with missing partition id");
 
     client::CancellationContext context;
-    auto response = repository::PartitionsRepository::GetPartitionById(
-        catalog_hrn, kVersionedLayerId, kVersion, context,
-        DataRequest(request).WithPartitionId(boost::none), settings);
+    repository::PartitionsRepository repository(catalog_hrn, settings);
+    auto response = repository.GetPartitionById(
+        kVersionedLayerId, kVersion,
+        DataRequest(request).WithPartitionId(boost::none), context);
 
     ASSERT_FALSE(response.IsSuccessful());
     const auto& result = response.GetError();
@@ -276,9 +278,10 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
 
     EXPECT_CALL(*cache, Put(Eq(cache_key), _, _, _)).Times(0);
 
-    auto response = repository::PartitionsRepository::GetPartitionById(
-        catalog_hrn, kVersionedLayerId, kVersion, context,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), settings);
+    repository::PartitionsRepository repository(catalog_hrn, settings);
+    auto response = repository.GetPartitionById(
+        kVersionedLayerId, kVersion,
+        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
 
     ASSERT_TRUE(response.IsSuccessful());
     const auto& partitions = response.GetResult().GetPartitions();
@@ -304,9 +307,10 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
                                      kOlpSdkHttpResponsePartitionById));
     EXPECT_CALL(*cache, Put(Eq(cache_key_no_version), _, _, _)).Times(0);
 
-    auto response = repository::PartitionsRepository::GetPartitionById(
-        catalog_hrn, kVersionedLayerId, boost::none, context,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), settings);
+    repository::PartitionsRepository repository(catalog_hrn, settings);
+    auto response = repository.GetPartitionById(
+        kVersionedLayerId, boost::none,
+        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
 
     ASSERT_TRUE(response.IsSuccessful());
     const auto& partitions = response.GetResult().GetPartitions();
@@ -331,9 +335,10 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
                                "Inappropriate"));
 
     client::CancellationContext context;
-    auto response = repository::PartitionsRepository::GetPartitionById(
-        catalog_hrn, kVersionedLayerId, kVersion, context,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), settings);
+    repository::PartitionsRepository repository(catalog_hrn, settings);
+    auto response = repository.GetPartitionById(
+        kVersionedLayerId, kVersion,
+        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -353,9 +358,10 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
                                "{Inappropriate}"));
 
     client::CancellationContext context;
-    auto response = repository::PartitionsRepository::GetPartitionById(
-        catalog_hrn, kVersionedLayerId, kVersion, context,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), settings);
+    repository::PartitionsRepository repository(catalog_hrn, settings);
+    auto response = repository.GetPartitionById(
+        kVersionedLayerId, kVersion,
+        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -378,9 +384,10 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
                                      "{Inappropriate}"));
 
     client::CancellationContext context;
-    auto response = repository::PartitionsRepository::GetPartitionById(
-        catalog_hrn, kVersionedLayerId, kVersion, context,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), settings);
+    repository::PartitionsRepository repository(catalog_hrn, settings);
+    auto response = repository.GetPartitionById(
+        kVersionedLayerId, kVersion,
+        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -405,9 +412,10 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
           return olp::http::SendOutcome(olp::http::ErrorCode::CANCELLED_ERROR);
         });
 
-    auto response = repository::PartitionsRepository::GetPartitionById(
-        catalog_hrn, kVersionedLayerId, kVersion, context,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), settings);
+    repository::PartitionsRepository repository(catalog_hrn, settings);
+    auto response = repository.GetPartitionById(
+        kVersionedLayerId, kVersion,
+        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -433,9 +441,10 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
           return olp::http::SendOutcome(olp::http::ErrorCode::CANCELLED_ERROR);
         });
 
-    auto response = repository::PartitionsRepository::GetPartitionById(
-        catalog_hrn, kVersionedLayerId, kVersion, context,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), settings);
+    repository::PartitionsRepository repository(catalog_hrn, settings);
+    auto response = repository.GetPartitionById(
+        kVersionedLayerId, kVersion,
+        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -462,9 +471,10 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         });
     EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
 
-    auto response = repository::PartitionsRepository::GetPartitionById(
-        catalog_hrn, kVersionedLayerId, kVersion, context,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), settings);
+    repository::PartitionsRepository repository(catalog_hrn, settings);
+    auto response = repository.GetPartitionById(
+        kVersionedLayerId, kVersion,
+        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -493,9 +503,10 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         });
     EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
 
-    auto response = repository::PartitionsRepository::GetPartitionById(
-        catalog_hrn, kVersionedLayerId, kVersion, context,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), settings);
+    repository::PartitionsRepository repository(catalog_hrn, settings);
+    auto response = repository.GetPartitionById(
+        kVersionedLayerId, kVersion,
+        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -527,9 +538,10 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         });
     EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
 
-    auto response = repository::PartitionsRepository::GetPartitionById(
-        catalog_hrn, kVersionedLayerId, kVersion, context,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), settings);
+    repository::PartitionsRepository repository(catalog_hrn, settings);
+    auto response = repository.GetPartitionById(
+        kVersionedLayerId, kVersion,
+        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -562,9 +574,10 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         });
     EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
 
-    auto response = repository::PartitionsRepository::GetPartitionById(
-        catalog_hrn, kVersionedLayerId, kVersion, context,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), settings);
+    repository::PartitionsRepository repository(catalog_hrn, settings);
+    auto response = repository.GetPartitionById(
+        kVersionedLayerId, kVersion,
+        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -578,9 +591,10 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
 
     client::CancellationContext context;
     context.CancelOperation();
-    auto response = repository::PartitionsRepository::GetPartitionById(
-        catalog_hrn, kVersionedLayerId, kVersion, context,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), settings);
+    repository::PartitionsRepository repository(catalog_hrn, settings);
+    auto response = repository.GetPartitionById(
+        kVersionedLayerId, kVersion,
+        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -631,8 +645,10 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
     read::PartitionsRequest request;
     request.WithPartitionIds({kPartitionId, kInvalidPartitionId});
     request.WithFetchOption(read::CacheOnly);
-    auto response = repository::PartitionsRepository::GetVersionedPartitions(
-        catalog, kVersionedLayerId, kVersion, context, request, settings);
+
+    repository::PartitionsRepository repository(catalog, settings);
+    auto response = repository.GetVersionedPartitions(
+        kVersionedLayerId, request, kVersion, context);
 
     ASSERT_FALSE(response.IsSuccessful());
     EXPECT_TRUE(response.GetResult().GetPartitions().empty());
@@ -660,8 +676,10 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
     client::CancellationContext context;
     read::PartitionsRequest request;
     request.WithPartitionIds({kPartitionId});
-    auto response = repository::PartitionsRepository::GetVersionedPartitions(
-        catalog, kVersionedLayerId, kVersion, context, request, settings);
+
+    repository::PartitionsRepository repository(catalog, settings);
+    auto response = repository.GetVersionedPartitions(
+        kVersionedLayerId, request, kVersion, context);
 
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
     EXPECT_EQ(response.GetResult().GetPartitions().size(), 1);
@@ -688,15 +706,18 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
 
     client::CancellationContext context;
     read::PartitionsRequest request;
-    auto response = repository::PartitionsRepository::GetVersionedPartitions(
-        catalog, kVersionedLayerId, kVersion, context, request, settings);
+
+    repository::PartitionsRepository repository(catalog, settings);
+    auto response = repository.GetVersionedPartitions(
+        kVersionedLayerId, request, kVersion, context);
 
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
     EXPECT_TRUE(response.GetResult().GetPartitions().empty());
 
     request.WithFetchOption(read::CacheOnly);
-    response = repository::PartitionsRepository::GetVersionedPartitions(
-        catalog, kVersionedLayerId, kVersion, context, request, settings);
+
+    response = repository.GetVersionedPartitions(kVersionedLayerId, request,
+                                                 kVersion, context);
 
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
     EXPECT_TRUE(response.GetResult().GetPartitions().empty());
@@ -745,8 +766,10 @@ TEST_F(PartitionsRepositoryTest, GetVolatilePartitions) {
 
     client::CancellationContext context;
     read::PartitionsRequest request;
-    auto response = repository::PartitionsRepository::GetVolatilePartitions(
-        catalog, kVolatileLayerId, context, request, settings);
+
+    repository::PartitionsRepository repository(catalog, settings);
+    auto response =
+        repository.GetVolatilePartitions(kVolatileLayerId, request, context);
 
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
     EXPECT_EQ(response.GetResult().GetPartitions().size(), 4);
@@ -763,9 +786,9 @@ TEST_F(PartitionsRepositoryTest, GetVolatilePartitions) {
     read::PartitionsRequest request;
     request.WithFetchOption(read::CacheOnly);
 
+    repository::PartitionsRepository repository(catalog, settings);
     auto cache_only_response =
-        repository::PartitionsRepository::GetVolatilePartitions(
-            catalog, kVolatileLayerId, context, request, settings);
+        repository.GetVolatilePartitions(kVolatileLayerId, request, context);
 
     ASSERT_TRUE(cache_only_response.IsSuccessful())
         << cache_only_response.GetError().GetMessage();
@@ -807,8 +830,9 @@ TEST_F(PartitionsRepositoryTest, AdditionalFields) {
                                 read::PartitionsRequest::kCrc,
                                 read::PartitionsRequest::kDataSize});
 
-  auto response = repository::PartitionsRepository::GetVersionedPartitions(
-      catalog, kVersionedLayerId, kVersion, context, request, settings);
+  repository::PartitionsRepository repository(catalog, settings);
+  auto response = repository.GetVersionedPartitions(kVersionedLayerId, request,
+                                                    kVersion, context);
 
   ASSERT_TRUE(response.IsSuccessful());
   auto result = response.GetResult();
@@ -821,8 +845,8 @@ TEST_F(PartitionsRepositoryTest, AdditionalFields) {
 
   request.WithFetchOption(read::CacheOnly);
 
-  auto response_2 = repository::PartitionsRepository::GetVersionedPartitions(
-      catalog, kVersionedLayerId, kVersion, context, request, settings);
+  auto response_2 = repository.GetVersionedPartitions(
+      kVersionedLayerId, request, kVersion, context);
 
   ASSERT_TRUE(response_2.IsSuccessful());
 
@@ -865,7 +889,9 @@ TEST_F(PartitionsRepositoryTest, CheckCashedPartitions) {
     auto request = olp::dataservice::read::TileRequest().WithTileKey(
         olp::geo::TileKey::FromHereTile("5904591"));
     olp::client::CancellationContext context;
-    auto response = GetTile(hrn, layer, context, request, version, settings);
+
+    repository::PartitionsRepository repository(hrn, settings);
+    auto response = repository.GetTile(layer, request, version, context);
 
     ASSERT_TRUE(response.IsSuccessful());
     ASSERT_EQ(response.GetResult().GetDataHandle(),
@@ -879,7 +905,9 @@ TEST_F(PartitionsRepositoryTest, CheckCashedPartitions) {
     auto request = olp::dataservice::read::TileRequest()
                        .WithTileKey(olp::geo::TileKey::FromHereTile("1476147"))
                        .WithFetchOption(read::CacheOnly);
-    auto response = GetTile(hrn, layer, context, request, version, settings);
+
+    repository::PartitionsRepository repository(hrn, settings);
+    auto response = repository.GetTile(layer, request, version, context);
 
     // check if partition was stored to cache
     ASSERT_TRUE(response.IsSuccessful());
@@ -927,8 +955,9 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
 
-    auto response = PartitionsRepository::GetAggregatedTile(
-        hrn, layer, context, request, version, settings);
+    repository::PartitionsRepository repository(hrn, settings);
+    auto response =
+        repository.GetAggregatedTile(layer, request, version, context);
     const auto& result = response.GetResult();
 
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
@@ -966,8 +995,9 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
 
-    auto response = PartitionsRepository::GetAggregatedTile(
-        hrn, layer, context, request, version, settings);
+    repository::PartitionsRepository repository(hrn, settings);
+    auto response =
+        repository.GetAggregatedTile(layer, request, version, context);
     const auto& result = response.GetResult();
 
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
@@ -995,8 +1025,9 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
 
     EXPECT_CALL(*mock_cache, Get(_)).WillOnce(Return(quad_tree.GetRawData()));
 
-    auto response = PartitionsRepository::GetAggregatedTile(
-        hrn, layer, context, request, version, settings);
+    repository::PartitionsRepository repository(hrn, settings);
+    auto response =
+        repository.GetAggregatedTile(layer, request, version, context);
     const auto& result = response.GetResult();
 
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
@@ -1029,8 +1060,10 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
 
-    auto response = PartitionsRepository::GetAggregatedTile(
-        hrn, layer, context, request, version, settings);
+    repository::PartitionsRepository repository(hrn, settings);
+    auto response =
+        repository.GetAggregatedTile(layer, request, version, context);
+
     const auto& result = response.GetResult();
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
     ASSERT_EQ(result.GetPartition(), tile_key.ToHereTile());
@@ -1066,8 +1099,9 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
 
-    auto response = PartitionsRepository::GetAggregatedTile(
-        hrn, layer, context, request, version, settings);
+    repository::PartitionsRepository repository(hrn, settings);
+    auto response =
+        repository.GetAggregatedTile(layer, request, version, context);
     const auto& error = response.GetError();
 
     ASSERT_FALSE(response.IsSuccessful());
@@ -1093,8 +1127,9 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
-    auto response = PartitionsRepository::GetAggregatedTile(
-        hrn, layer, context, request, version, settings);
+    repository::PartitionsRepository repository(hrn, settings);
+    auto response =
+        repository.GetAggregatedTile(layer, request, version, context);
     const auto& error = response.GetError();
 
     ASSERT_FALSE(response.IsSuccessful());
@@ -1125,8 +1160,9 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
-    auto response = PartitionsRepository::GetAggregatedTile(
-        hrn, layer, context, request, version, settings);
+    repository::PartitionsRepository repository(hrn, settings);
+    auto response =
+        repository.GetAggregatedTile(layer, request, version, context);
     const auto& error = response.GetError();
 
     ASSERT_FALSE(response.IsSuccessful());
@@ -1165,8 +1201,9 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
-    auto response = PartitionsRepository::GetAggregatedTile(
-        hrn, layer, context, request, version, settings);
+    repository::PartitionsRepository repository(hrn, settings);
+    auto response =
+        repository.GetAggregatedTile(layer, request, version, context);
     const auto& error = response.GetError();
 
     ASSERT_FALSE(response.IsSuccessful());
@@ -1204,8 +1241,9 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
-    auto response = PartitionsRepository::GetAggregatedTile(
-        hrn, layer, context, request, version, settings);
+    repository::PartitionsRepository repository(hrn, settings);
+    auto response =
+        repository.GetAggregatedTile(layer, request, version, context);
     const auto& error = response.GetError();
 
     ASSERT_FALSE(response.IsSuccessful());
@@ -1254,8 +1292,8 @@ TEST_F(PartitionsRepositoryTest, GetTile) {
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
 
-    auto response = PartitionsRepository::GetTile(hrn, layer, context, request,
-                                                  version, settings);
+    repository::PartitionsRepository repository(hrn, settings);
+    auto response = repository.GetTile(layer, request, version, context);
     ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
   }
 }


### PR DESCRIPTION
PartitionsRepository contains only static methods and they all are taking
HRN and OlpClientSettings as args. Moving these args to constructor
will simplify further extending, e.g. with ApiClientLookup.

Resolves: OLPEDGE-2200

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>