### PR TITLE
Remove the futures from prefetch

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/PrefetchJob.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/PrefetchJob.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "PrefetchJob.h"
+
+#include <olp/core/logging/Log.h>
+#include <olp/dataservice/read/PrefetchTileResult.h>
+
+namespace {
+constexpr auto kLogTag = "PrefetchJob";
+}
+
+namespace olp {
+namespace dataservice {
+namespace read {
+
+PrefetchJob::PrefetchJob(PrefetchTilesResponseCallback user_callback,
+                         uint32_t task_count)
+    : user_callback_(std::move(user_callback)),
+      task_count_{task_count},
+      canceled_{false} {
+  tasks_contexts_.reserve(task_count_);
+  prefetch_result_.reserve(task_count_);
+}
+
+PrefetchJob::~PrefetchJob() = default;
+
+client::CancellationContext PrefetchJob::AddTask() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  tasks_contexts_.emplace_back();
+  return tasks_contexts_.back();
+}
+
+void PrefetchJob::CompleteTask(geo::TileKey tile) {
+  CompleteTask(
+      std::make_shared<PrefetchTileResult>(tile, PrefetchTileNoError()));
+}
+
+void PrefetchJob::CompleteTask(geo::TileKey tile,
+                               const client::ApiError& error) {
+  CompleteTask(std::make_shared<PrefetchTileResult>(tile, error));
+}
+
+void PrefetchJob::CancelOperation() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  canceled_ = true;
+
+  for (auto& context : tasks_contexts_) {
+    context.CancelOperation();
+  }
+}
+
+void PrefetchJob::CompleteTask(std::shared_ptr<PrefetchTileResult> result) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  prefetch_result_.push_back(std::move(result));
+
+  if (!--task_count_) {
+    OLP_SDK_LOG_INFO_F(kLogTag, "Prefetch done, tiles=%zu",
+                       prefetch_result_.size());
+
+    PrefetchTilesResponseCallback user_callback = std::move(user_callback_);
+    if (canceled_) {
+      user_callback({{client::ErrorCode::Cancelled, "Cancelled"}});
+    } else {
+      user_callback(std::move(prefetch_result_));
+    }
+  }
+}
+
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/PrefetchJob.h
+++ b/olp-cpp-sdk-dataservice-read/src/PrefetchJob.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <olp/core/client/CancellationContext.h>
+#include <olp/core/geo/tiling/TileKey.h>
+#include <olp/dataservice/read/Types.h>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+
+class PrefetchJob {
+ public:
+  PrefetchJob(PrefetchTilesResponseCallback user_callback, uint32_t task_count);
+
+  PrefetchJob(const PrefetchJob&) = delete;
+  PrefetchJob(PrefetchJob&&) = delete;
+  PrefetchJob& operator=(const PrefetchJob&) = delete;
+  PrefetchJob& operator=(PrefetchJob&&) = delete;
+
+  ~PrefetchJob();
+
+  client::CancellationContext AddTask();
+
+  void CompleteTask(geo::TileKey tile);
+
+  void CompleteTask(geo::TileKey tile, const client::ApiError& error);
+
+  void CancelOperation();
+
+ protected:
+  void CompleteTask(std::shared_ptr<PrefetchTileResult> result);
+
+ private:
+  PrefetchTilesResponseCallback user_callback_;
+  uint32_t task_count_;
+  bool canceled_;
+
+  std::mutex mutex_;
+  std::vector<client::CancellationContext> tasks_contexts_;
+  PrefetchTilesResult prefetch_result_;
+};
+
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -68,6 +68,10 @@ class PrefetchTilesRepository {
       client::CancellationContext context,
       const client::OlpClientSettings& settings);
 
+  static SubQuadsResult FilterSkippedTiles(const PrefetchTilesRequest& request,
+                                           bool request_only_input_tiles,
+                                           SubQuadsResult sub_tiles);
+
  protected:
   static SubQuadsResponse GetSubQuads(const client::HRN& catalog,
                                       const std::string& layer_id,


### PR DESCRIPTION
Add a PrefetchJob class to help track the prefetch progress
Remove the usage of std::future and additional task that wait for
them.

Relates-To: OLPEDGE-2169

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>