### PR TITLE
Fix Prefetch volatile test

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -191,7 +191,6 @@ client::CancellationToken VolatileLayerClientImpl::PrefetchTiles(
         // cover tree.
         bool request_only_input_tiles = IsOnlyInputTiles(request);
         unsigned int min_level =
-            (request_only_input_tiles
             (request_only_input_tiles ? static_cast<unsigned int>(geo::TileKey::LevelCount)
                                       : request.GetMinLevel());
         unsigned int max_level =

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -192,12 +192,11 @@ client::CancellationToken VolatileLayerClientImpl::PrefetchTiles(
         bool request_only_input_tiles = IsOnlyInputTiles(request);
         unsigned int min_level =
             (request_only_input_tiles
-                 ? static_cast<unsigned int>(geo::TileKey::LevelCount)
-                 : request.GetMinLevel());
+            (request_only_input_tiles ? static_cast<unsigned int>(geo::TileKey::LevelCount)
+                                      : request.GetMinLevel());
         unsigned int max_level =
-            (request_only_input_tiles
-                 ? static_cast<unsigned int>(geo::TileKey::LevelCount)
-                 : request.GetMaxLevel());
+            (request_only_input_tiles ? static_cast<unsigned int>(geo::TileKey::LevelCount)
+                                      : request.GetMaxLevel());
 
         auto sliced_tiles = repository::PrefetchTilesRepository::GetSlicedTiles(
             tile_keys, min_level, max_level);

--- a/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
@@ -490,8 +490,6 @@ TEST(VolatileLayerClientImplTest, PrefetchTiles) {
                             olp::http::HttpStatusCode::OK);
     SetupNetworkExpectation(*network_mock, kUrlPrefetchBlobData1, kData1,
                             olp::http::HttpStatusCode::OK);
-    SetupNetworkExpectation(*network_mock, kUrlPrefetchBlobData2, kData2,
-                            olp::http::HttpStatusCode::OK);
 
     EXPECT_CALL(*network_mock, Send(IsGetRequest(kUrlLookup), _, _, _, _))
         .WillRepeatedly(
@@ -554,8 +552,7 @@ TEST(VolatileLayerClientImplTest, PrefetchTiles) {
 
     ASSERT_NE(future.wait_for(kTimeout), std::future_status::timeout);
     read::PrefetchTilesResponse response = future.get();
-    ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
-    ASSERT_TRUE(response.GetResult().empty());
+    ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
   }
   {
     SCOPED_TRACE("Levels not specified.");
@@ -585,8 +582,7 @@ TEST(VolatileLayerClientImplTest, PrefetchTiles) {
 
     ASSERT_NE(future.wait_for(kTimeout), std::future_status::timeout);
     read::PrefetchTilesResponse response = future.get();
-    ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
-    ASSERT_TRUE(response.GetResult().empty());
+    ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
   }
   // negative tests
   {
@@ -671,8 +667,6 @@ TEST(VolatileLayerClientImplTest, PrefetchTilesCancellableFuture) {
                             olp::http::HttpStatusCode::OK);
     SetupNetworkExpectation(*network_mock, kUrlPrefetchBlobData1, kData1,
                             olp::http::HttpStatusCode::OK);
-    SetupNetworkExpectation(*network_mock, kUrlPrefetchBlobData2, kData2,
-                            olp::http::HttpStatusCode::OK);
 
     EXPECT_CALL(*network_mock, Send(IsGetRequest(kUrlLookup), _, _, _, _))
         .WillRepeatedly(
@@ -723,8 +717,7 @@ TEST(VolatileLayerClientImplTest, PrefetchTilesCancellableFuture) {
 
     ASSERT_NE(future.wait_for(kTimeout), std::future_status::timeout);
     read::PrefetchTilesResponse response = future.get();
-    ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
-    ASSERT_TRUE(response.GetResult().empty());
+    ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
   }
   {
     SCOPED_TRACE("Levels not specified.");
@@ -748,8 +741,7 @@ TEST(VolatileLayerClientImplTest, PrefetchTilesCancellableFuture) {
 
     ASSERT_NE(future.wait_for(kTimeout), std::future_status::timeout);
     read::PrefetchTilesResponse response = future.get();
-    ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
-    ASSERT_TRUE(response.GetResult().empty());
+    ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
   }
   // negative tests
   {

--- a/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
@@ -46,9 +46,6 @@ constexpr auto kUrlQueryPartition269 =
 constexpr auto kUrlQuadTreeIndexVolatile =
     R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/testlayer/quadkeys/92259/depths/4)";
 
-constexpr auto kUrlQuadTreeIndexVolatile2 =
-    R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/testlayer/quadkeys/23064/depths/4)";
-
 constexpr auto kHttpResponseLookup =
     R"jsonString([{"api":"query","version":"v1","baseURL":"https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2","parameters":{}},
     {"api":"volatile-blob","version":"v1","baseURL":"https://volatile-blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2","parameters":{}}])jsonString";

--- a/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
@@ -74,7 +74,6 @@ const auto kHrn = olp::client::HRN::FromString(kCatalog);
 const auto kPartitionId = "269";
 const auto kTileId = "5904591";
 const auto kData1 = "SomeData1";
-const auto kData2 = "SomeData2";
 const auto kTimeout = std::chrono::seconds(5);
 
 template <class T>

--- a/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
@@ -67,9 +67,6 @@ constexpr auto kBlobDataHandle = R"(4eed6ed1-0d32-43b9-ae79-043cb4256432)";
 constexpr auto kUrlPrefetchBlobData1 =
     R"(https://volatile-blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/f9a9fd8e-eb1b-48e5-bfdb-4392b3826443)";
 
-constexpr auto kUrlPrefetchBlobData2 =
-    R"(https://volatile-blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1)";
-
 const std::string kCatalog =
     "hrn:here:data::olp-here-test:hereos-internal-test-v2";
 const std::string kLayerId = "testlayer";

--- a/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
@@ -536,7 +536,10 @@ TEST(VolatileLayerClientImplTest, PrefetchTiles) {
     std::vector<olp::geo::TileKey> tile_keys = {
         olp::geo::TileKey::FromHereTile(kTileId)};
 
-    auto request = read::PrefetchTilesRequest().WithTileKeys(tile_keys);
+    auto request = read::PrefetchTilesRequest()
+                       .WithTileKeys(tile_keys)
+                       .WithMinLevel(olp::geo::TileKey::LevelCount)
+                       .WithMaxLevel(olp::geo::TileKey::LevelCount);
 
     auto promise =
         std::make_shared<std::promise<read::PrefetchTilesResponse>>();
@@ -548,7 +551,7 @@ TEST(VolatileLayerClientImplTest, PrefetchTiles) {
 
     ASSERT_NE(future.wait_for(kTimeout), std::future_status::timeout);
     read::PrefetchTilesResponse response = future.get();
-    ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
+    ASSERT_FALSE(response.IsSuccessful());
   }
   {
     SCOPED_TRACE("Levels not specified.");
@@ -578,7 +581,7 @@ TEST(VolatileLayerClientImplTest, PrefetchTiles) {
 
     ASSERT_NE(future.wait_for(kTimeout), std::future_status::timeout);
     read::PrefetchTilesResponse response = future.get();
-    ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
+    ASSERT_FALSE(response.IsSuccessful());
   }
   // negative tests
   {
@@ -706,14 +709,17 @@ TEST(VolatileLayerClientImplTest, PrefetchTilesCancellableFuture) {
     std::vector<olp::geo::TileKey> tile_keys = {
         olp::geo::TileKey::FromHereTile(kTileId)};
 
-    auto request = read::PrefetchTilesRequest().WithTileKeys(tile_keys);
+    auto request = read::PrefetchTilesRequest()
+                       .WithTileKeys(tile_keys)
+                       .WithMinLevel(olp::geo::TileKey::LevelCount)
+                       .WithMaxLevel(olp::geo::TileKey::LevelCount);
 
     auto cancellable = client.PrefetchTiles(request);
     auto future = cancellable.GetFuture();
 
     ASSERT_NE(future.wait_for(kTimeout), std::future_status::timeout);
     read::PrefetchTilesResponse response = future.get();
-    ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
+    ASSERT_FALSE(response.IsSuccessful());
   }
   {
     SCOPED_TRACE("Levels not specified.");
@@ -737,7 +743,7 @@ TEST(VolatileLayerClientImplTest, PrefetchTilesCancellableFuture) {
 
     ASSERT_NE(future.wait_for(kTimeout), std::future_status::timeout);
     read::PrefetchTilesResponse response = future.get();
-    ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
+    ASSERT_FALSE(response.IsSuccessful());
   }
   // negative tests
   {

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
@@ -342,8 +342,9 @@ TEST_F(VolatileLayerClientTest, Prefetch) {
   rd::VolatileLayerClient client(hrn, prefetch_layer_, prefetch_settings_);
   {
     SCOPED_TRACE("Prefetch tiles online and store them in memory cache");
-    std::vector<olp::geo::TileKey> tile_keys = {
-        olp::geo::TileKey::FromHereTile(kPrefetchTile)};
+    auto root_tile =
+        olp::geo::TileKey::FromHereTile(kPrefetchTile).ChangedLevelBy(-2);
+    std::vector<olp::geo::TileKey> tile_keys = {root_tile};
     std::vector<olp::geo::TileKey> expected_tile_keys = {
         olp::geo::TileKey::FromHereTile(kPrefetchTile),
         olp::geo::TileKey::FromHereTile(kPrefetchSubTile1),


### PR DESCRIPTION
When requesting tiles we should get tiles
only on input levels, if default levels not set.
Filter quads to be on requested levels, and
have relation parent/child with root tiles from
request.

Relates-To: OLPEDGE-2204

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>