### PR TITLE
Adds PendingUrlRequests and PendingUrlRequest.

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -243,6 +243,8 @@ set(OLP_SDK_CLIENT_SOURCES
     ./src/client/OlpClientSettings.cpp
     ./src/client/OlpClientSettingsFactory.cpp
     ./src/client/PendingRequests.cpp
+    ./src/client/PendingUrlRequests.h
+    ./src/client/PendingUrlRequests.cpp
     ./src/client/Tokenizer.h
 )
 

--- a/olp-cpp-sdk-core/include/olp/core/client/CancellationContext.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/CancellationContext.h
@@ -64,8 +64,6 @@ class CORE_API CancellationContext {
    *
    * @return True if the execution is successful; false if the context was
    * cancelled.
-   *
-   * @deprecated Will be removed. Use `TaskScheduler` instead.
    */
   bool ExecuteOrCancelled(const ExecuteFuncType& execute_fn,
                           const CancelFuncType& cancel_fn = nullptr);

--- a/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
@@ -77,18 +77,21 @@ class NetworkStatistics {
 };
 
 /**
- * @brief An HTTP response.
+ * @brief This class represents the HTTP response created from the
+ * NetworkResponse and the request body.
  */
 class CORE_API HttpResponse {
  public:
   HttpResponse() = default;
+  virtual ~HttpResponse() = default;
+
   /**
    * @brief Creates the `HttpResponse` instance.
    *
    * @param status The HTTP status.
    * @param response The response body.
    */
-  HttpResponse(int status, std::string response = std::string())  // NOLINT
+  HttpResponse(int status, std::string response = {})  // NOLINT
       : status(status), response(std::move(response)) {}
 
   /**
@@ -96,6 +99,7 @@ class CORE_API HttpResponse {
    *
    * @param status The HTTP status.
    * @param response The response body.
+   *
    */
   HttpResponse(int status, std::stringstream&& response)
       : status(status), response(std::move(response)) {}
@@ -106,26 +110,90 @@ class CORE_API HttpResponse {
    * @param status The HTTP status.
    * @param response The response body.
    * @param headers Response headers.
+   *
    */
-  HttpResponse(int status, std::stringstream&& response,
-               http::Headers&& headers)
+  HttpResponse(int status, std::stringstream&& response, http::Headers headers)
       : status(status),
         response(std::move(response)),
         headers(std::move(headers)) {}
+
+  /**
+   * @brief Copy constructor.
+   *
+   * This copy constructor creates a deep copy of the response body if a
+   * non-shareable container type is used.
+   *
+   * @param other The instance of `HttpStatus` to copy from.
+   */
+  HttpResponse(const HttpResponse& other)
+      : status(other.status), headers(other.headers) {
+    response << other.response.rdbuf();
+    if (!response.good()) {
+      // Depending on the users handling of the stringstream it might be that
+      // the read position is already at the end and thus operator<< cannot
+      // read anything, so lets try with the safer but more memory intensive
+      // solution as a second step.
+      response.str(other.response.str());
+    }
+  }
+
+  /**
+   * @brief Copy assign operator.
+   *
+   * This copy assign operator creates a deep copy of the response body if a
+   * non-shareable container type is used.
+   *
+   * @param other The instance of `HttpStatus` to copy from.
+   */
+  HttpResponse& operator=(const HttpResponse& other) {
+    if (this != &other) {
+      status = other.status;
+      response << other.response.rdbuf();
+      headers = other.headers;
+    }
+
+    return *this;
+  }
+
+  // Default move constructor and move assignment.
+  HttpResponse(HttpResponse&&) = default;
+  HttpResponse& operator=(HttpResponse&&) = default;
 
   /**
    * @brief Copy `HttpResponse` content to a vector of unsigned chars.
    *
    * @param output Reference to a vector.
    */
-  void GetResponse(std::vector<unsigned char>& output);
+  void GetResponse(std::vector<unsigned char>& output) {
+    response.seekg(0, std::ios::end);
+    output.resize(response.tellg());
+    response.seekg(0, std::ios::beg);
+    response.read(reinterpret_cast<char*>(output.data()), output.size());
+    response.seekg(0, std::ios::beg);
+  }
 
   /**
    * @brief Copy `HttpResponse` content to a string.
    *
    * @param output Reference to a string.
    */
-  void GetResponse(std::string& output);
+  void GetResponse(std::string& output) { output = response.str(); }
+
+  /**
+   * @brief Return the const reference to the response headers.
+   *
+   * @return The const reference to the headers vector.
+   */
+  const http::Headers& GetHeaders() const { return headers; }
+
+  /**
+   * @brief Return the response status.
+   *
+   * The response status can either be a
+   *
+   * @return The response status.
+   */
+  int GetStatus() const { return status; }
 
   /**
    * @brief Set `NetworkStatistics`.
@@ -145,39 +213,23 @@ class CORE_API HttpResponse {
     return network_statistics_;
   }
 
-  /**
-   * @brief The HTTP status.
-   *
-   * @see `ErrorCode` for information on negative status
-   * numbers.
-   * @see `HttpStatusCode` for information on positive status
-   * numbers.
-   */
+  /// The HTTP Status. This can be either a `ErrorCode` if negative or a
+  /// `HttpStatusCode` if positive.
+  /// @deprecated: This field will be marked as private by 01.2021.
+  /// Please do not use directly, use `GetStatus()` method instead.
   int status{static_cast<int>(olp::http::ErrorCode::UNKNOWN_ERROR)};
-  /**
-   * @brief The HTTP response.
-   */
+  /// The HTTP response.
+  /// @deprecated: This field will be marked as private by 01.2021.
+  /// Please do not use directly, use `GetResponse()` methods instead.
   std::stringstream response;
-
-  /**
-   * @brief HTTP headers.
-   */
+  /// HTTP headers.
+  /// @deprecated: This field will be marked as private by 01.2021.
+  /// Please do not use directly, use `GetHeaders()` method instead.
   http::Headers headers;
 
  private:
   NetworkStatistics network_statistics_;
 };
-
-inline void HttpResponse::GetResponse(std::vector<unsigned char>& output) {
-  response.seekg(0, std::ios::end);
-  output.resize(response.tellg());
-  response.seekg(0, std::ios::beg);
-  response.read(reinterpret_cast<char*>(output.data()), output.size());
-}
-
-inline void HttpResponse::GetResponse(std::string& output) {
-  output = response.str();
-}
 
 }  // namespace client
 }  // namespace olp

--- a/olp-cpp-sdk-core/src/client/PendingUrlRequests.cpp
+++ b/olp-cpp-sdk-core/src/client/PendingUrlRequests.cpp
@@ -1,0 +1,266 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "PendingUrlRequests.h"
+
+#include "olp/core/logging/Log.h"
+
+namespace {
+constexpr auto kLogTag = "PendingUrlRequest";
+
+olp::client::HttpResponse GetCancelledResponse() {
+  return {olp::client::PendingUrlRequest::kCancelledStatus,
+          "Operation cancelled"};
+}
+}  // namespace
+
+namespace olp {
+namespace client {
+
+size_t PendingUrlRequest::Append(NetworkAsyncCallback callback) {
+  // NOTE: You should not append anything if this request was cancelled
+  std::lock_guard<std::mutex> lock(mutex_);
+  const auto callback_id = callbacks_.size();
+  callbacks_.emplace(callback_id, std::move(callback));
+  return callback_id;
+}
+
+bool PendingUrlRequest::ExecuteOrCancelled(const ExecuteFuncType& func,
+                                           const CancelFuncType& cancel_func) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // Make sure we can only call context_ once
+  if (http_request_id_ != kInvalidRequestId) {
+    OLP_SDK_LOG_WARNING_F(
+        kLogTag,
+        "ExecuteOrCancelled called more than once, request_id=%" PRIu64,
+        http_request_id_);
+    return false;
+  }
+
+  return context_.ExecuteOrCancelled(
+      [&]() -> client::CancellationToken { return func(http_request_id_); },
+      cancel_func);
+}
+
+bool PendingUrlRequest::Cancel(size_t callback_id) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = callbacks_.find(callback_id);
+  if (it == callbacks_.end()) {
+    // Unknown callback_id
+    OLP_SDK_LOG_WARNING_F(
+        kLogTag, "Unknown callback cancelled, callback_id=%zu", callback_id);
+    return false;
+  }
+
+  // Once cancelled, moved the callback out of the callbacks_ map and place it
+  // in the cancelled callbacks vector.
+  cancelled_callbacks_.emplace_back(std::move(it->second));
+  callbacks_.erase(it);
+
+  // If there is no more callback left in the map cancel the Network request
+  if (callbacks_.empty()) {
+    CancelOperation();
+  }
+
+  return true;
+}
+
+void PendingUrlRequest::OnRequestCompleted(HttpResponse response) {
+  std::map<size_t, NetworkAsyncCallback> callbacks;
+  std::vector<NetworkAsyncCallback> cancelled_callbacks;
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    callbacks = std::move(callbacks_);
+    cancelled_callbacks = std::move(cancelled_callbacks_);
+  }
+
+  OLP_SDK_LOG_DEBUG_F(
+      kLogTag,
+      "OnRequestCompleted called, callbacks=%zu, cancelled_callback=%zu",
+      callbacks.size(), cancelled_callbacks.size());
+
+  client::HttpResponse response_out;
+  if (!context_.IsCancelled()) {
+    response_out = std::move(response);
+  } else {
+    response_out = GetCancelledResponse();
+  }
+
+  // If only one callback, move response instead of copy.
+  if (callbacks.size() == 1u && cancelled_callbacks.empty()) {
+    callbacks.begin()->second(std::move(response_out));
+  } else {
+    for (auto& callback : callbacks) {
+      // TODO: We need to switch HttpResponse to shared pimpl once the
+      // deprecation period is completed to avoid unnecessary copy of data.
+      callback.second(response_out);
+
+      // We need to reset the stringstream position else the next copy
+      // constructor will not be able to read anything because the read
+      // position is at the end of the stream.
+      response_out.response.seekg(0, std::ios::beg);
+    }
+
+    if (!cancelled_callbacks.empty() &&
+        response_out.GetStatus() != kCancelledStatus) {
+      response_out = GetCancelledResponse();
+    }
+
+    for (auto& callback : cancelled_callbacks) {
+      callback(response_out);
+
+      // We need to reset the stringstream position else the next copy
+      // constructor will not be able to read anything because the read
+      // position is at the end of the stream.
+      response_out.response.seekg(0, std::ios::beg);
+    }
+  }
+
+  condition_.Notify();
+}
+
+size_t PendingUrlRequests::Size() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return pending_requests_.size() + cancelled_requests_.size();
+}
+
+bool PendingUrlRequests::Cancel(const std::string& url, size_t callback_id) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = pending_requests_.find(url);
+  if (it == pending_requests_.end()) {
+    // Nothing to cancel
+    return true;
+  }
+
+  auto& request_ptr = it->second;
+  auto ret = request_ptr->Cancel(callback_id);
+
+  // If the last callback was cancelled then move this to the cancelled list
+  if (request_ptr->IsCancelled()) {
+    cancelled_requests_.emplace(it->first, it->second);
+    pending_requests_.erase(it);
+  }
+
+  return ret;
+}
+
+bool PendingUrlRequests::CancelAll() {
+  // This only cancells the ongoing Network request the callback trigger
+  // is taking care of the Network callback.
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (auto& request : pending_requests_) {
+    request.second->CancelOperation();
+  }
+
+  return true;
+}
+
+bool PendingUrlRequests::CancelAllAndWait() {
+  PendingRequestsType pending_requests;
+  PendingRequestsType cancelled_requests;
+
+  {
+    // Copy, do not move else the OnRequestCompleted callback
+    // will not work
+    std::lock_guard<std::mutex> lock(mutex_);
+    pending_requests = pending_requests_;
+    cancelled_requests = cancelled_requests_;
+  }
+
+  bool ret = true;
+
+  for (auto& request : pending_requests) {
+    if (request.second && !request.second->CancelAndWait()) {
+      OLP_SDK_LOG_WARNING_F(kLogTag,
+                            "CancelAllAndWait() timeout on pending url=%s",
+                            request.first.c_str());
+      ret = false;
+    }
+  }
+
+  for (auto& request : cancelled_requests) {
+    if (request.second && !request.second->CancelAndWait()) {
+      OLP_SDK_LOG_WARNING_F(kLogTag,
+                            "CancelAllAndWait() timeout on cancelled url=%s",
+                            request.first.c_str());
+      ret = false;
+    }
+  }
+
+  return ret;
+}
+
+PendingUrlRequests::PendingUrlRequestPtr PendingUrlRequests::operator[](
+    const std::string& url) {
+  PendingUrlRequestPtr result_ptr = nullptr;
+
+  // TODO: Check here that the pending request was not cancelled before
+  // adding new callback to it?
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = pending_requests_.find(url);
+    if (it != pending_requests_.end()) {
+      result_ptr = it->second;
+    } else {
+      result_ptr = std::make_shared<PendingUrlRequest>();
+      pending_requests_.emplace(url, result_ptr);
+    }
+  }
+
+  return result_ptr;
+}
+
+void PendingUrlRequests::OnRequestCompleted(http::RequestId request_id,
+                                            const std::string& url,
+                                            HttpResponse response) {
+  PendingUrlRequestPtr request_ptr;
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto pending_it = pending_requests_.find(url);
+    auto cancelled_it = cancelled_requests_.find(url);
+
+    // Either the request is in the pending or in the cancelled requests list.
+    // Check that it is the same request. It might happen that we have a
+    // cancelled request and then a followup valid request with the same URL.
+    if (pending_it != pending_requests_.end() &&
+        request_id == pending_it->second->GetRequestId()) {
+      request_ptr = std::move(pending_it->second);
+      pending_requests_.erase(pending_it);
+    } else if (cancelled_it != cancelled_requests_.end() &&
+               request_id == cancelled_it->second->GetRequestId()) {
+      request_ptr = std::move(cancelled_it->second);
+      cancelled_requests_.erase(cancelled_it);
+    }
+  }
+
+  if (!request_ptr) {
+    // Result but no request
+    return;
+  }
+
+  request_ptr->OnRequestCompleted(std::move(response));
+}
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/client/PendingUrlRequests.h
+++ b/olp-cpp-sdk-core/src/client/PendingUrlRequests.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <map>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+#include "olp/core/client/CancellationContext.h"
+#include "olp/core/client/Condition.h"
+#include "olp/core/client/ErrorCode.h"
+#include "olp/core/client/HttpResponse.h"
+#include "olp/core/client/OlpClient.h"
+#include "olp/core/client/OlpClientSettings.h"
+#include "olp/core/http/HttpStatusCode.h"
+#include "olp/core/http/NetworkConstants.h"
+
+namespace olp {
+namespace client {
+
+/// This class represents one URL request holding one or more callbacks.
+class PendingUrlRequest {
+ public:
+  /// Alias for the CancellationContext execute function.
+  using ExecuteFuncType = std::function<CancellationToken(http::RequestId& id)>;
+  /// Alias for the CancellationContext cancel function.
+  using CancelFuncType = client::CancellationContext::CancelFuncType;
+
+  /// Identifies a invalid request Id.
+  static constexpr http::RequestId kInvalidRequestId =
+      static_cast<http::RequestId>(http::RequestIdConstants::RequestIdInvalid);
+  /// Cancelled Network request error code.
+  static constexpr int kCancelledStatus =
+      static_cast<int>(http::ErrorCode::CANCELLED_ERROR);
+
+  /// Append one callback to the request.
+  size_t Append(NetworkAsyncCallback callback);
+
+  /// Calls the managed CancellationContext ExecuteOrCancelled so that it can
+  /// remember the func returned CancellationToken to be able to cancel any
+  /// async operation taking place in our name. Should be called with the
+  /// Network trigger lambda.
+  bool ExecuteOrCancelled(const ExecuteFuncType& func,
+                          const CancelFuncType& cancel_func = nullptr);
+
+  /// Get the Network request Id associated with this request.
+  http::RequestId GetRequestId() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return http_request_id_;
+  }
+
+  /// Cancels the ongoing Network request. Do not block for long!
+  /// NOTE: This should only be called if you know what you are doing.
+  void CancelOperation() { context_.CancelOperation(); }
+
+  /// Cancel one individual request or the entire request if no callback left
+  /// to serve.
+  bool Cancel(size_t callback_id);
+
+  /// If cancelled this will return true.
+  bool IsCancelled() const { return context_.IsCancelled(); }
+
+  /// Cancels current network request and waits for response.
+  bool CancelAndWait(
+      std::chrono::milliseconds timeout = std::chrono::seconds(60)) {
+    // Cancel Network call, wait for the Network callback
+    context_.CancelOperation();
+    return condition_.Wait(timeout);
+  }
+
+  /// Will be called when the Network response arrives.
+  void OnRequestCompleted(HttpResponse response);
+
+ private:
+  /// Keeping the class thread safe.
+  mutable std::mutex mutex_;
+  /// The id of the Network request to identify the correct response to the
+  /// correct request.
+  http::RequestId http_request_id_{kInvalidRequestId};
+  /// Notifies once this request has been completed. Will be used by
+  /// CancelAndWait().
+  Condition condition_;
+  /// Keeps track of the Network call and cancels it in case user wants to
+  /// cancel the entire request or the last call
+  CancellationContext context_;
+  /// The list of pending requests
+  std::map<size_t, NetworkAsyncCallback> callbacks_;
+  /// The list of cancelled requests
+  std::vector<NetworkAsyncCallback> cancelled_callbacks_;
+};
+
+/// This class holds all URL based requests.
+class PendingUrlRequests {
+ public:
+  /// Alias for a shareable pending request
+  using PendingUrlRequestPtr = std::shared_ptr<PendingUrlRequest>;
+
+  /// Get the total size of requests pending and cancelled requests.
+  size_t Size() const;
+
+  /// Cancel one callback from a request based on callback ID.
+  bool Cancel(const std::string& url, size_t callback_id);
+
+  /// Cancel all pending requests, non-blocking.
+  bool CancelAll();
+
+  /// Cancel pending requests and wait for all requests to finish, blocking.
+  bool CancelAllAndWait();
+
+  /// Get the existing pending request associated with the url or create a new
+  /// one if not present yet.
+  PendingUrlRequestPtr operator[](const std::string& url);
+
+  /// Should be called inside the Network callback when request is finished.
+  void OnRequestCompleted(http::RequestId request_id, const std::string& url,
+                          HttpResponse response);
+
+ private:
+  /// The type of the contained used to store pending or cancelled requests.
+  using PendingRequestsType =
+      std::unordered_map<std::string, PendingUrlRequestPtr>;
+
+  mutable std::mutex mutex_;
+  PendingRequestsType pending_requests_;
+  PendingRequestsType cancelled_requests_;
+};
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ set(OLP_CPP_SDK_CORE_TESTS_SOURCES
     ./client/DefaultLookupEndpointProviderTest.cpp
     ./client/HRNTest.cpp
     ./client/OlpClientTest.cpp
+    ./client/PendingUrlRequestsTest.cpp
     ./client/TaskContextTest.cpp
 
     ./geo/coordinates/GeoCoordinates3dTest.cpp
@@ -76,6 +77,7 @@ if (ANDROID OR IOS)
     target_include_directories(${OLP_SDK_CORE_TESTS_LIB}
         PRIVATE
             ../src/cache
+            ../src/client
     )
     if (ANDROID)
         include(${CMAKE_SOURCE_DIR}/cmake/android/gen_android_test.cmake)

--- a/olp-cpp-sdk-core/tests/client/PendingUrlRequestsTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/PendingUrlRequestsTest.cpp
@@ -1,0 +1,569 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <future>
+#include <queue>
+#include <sstream>
+#include <string>
+
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/OlpClient.h>
+#include <olp/core/http/Network.h>
+#include <olp/core/logging/Log.h>
+#include "client/PendingUrlRequests.h"
+
+namespace {
+using olp::client::HttpResponse;
+using olp::http::ErrorCode;
+using ::testing::_;
+
+namespace client = olp::client;
+namespace http = olp::http;
+
+static const std::string kGoodResponse = "Response1234";
+static const std::string kBadResponse = "Cancelled";
+static constexpr int kCancelledStatus =
+    static_cast<int>(http::ErrorCode::CANCELLED_ERROR);
+
+client::HttpResponse GetHttpResponse(ErrorCode error, std::string status) {
+  return client::HttpResponse(static_cast<int>(error), status);
+}
+
+client::HttpResponse GetHttpResponse(int http_status, std::string status,
+                                     http::Headers headers = {}) {
+  std::stringstream stream;
+  stream.str(std::move(status));
+  return client::HttpResponse(http_status, std::move(stream),
+                              std::move(headers));
+}
+
+client::HttpResponse GetCancelledResponse() {
+  return {kCancelledStatus, "Operation cancelled"};
+}
+
+TEST(HttpResponseTest, Copy) {
+  {
+    SCOPED_TRACE("Error response");
+
+    auto response = GetHttpResponse(ErrorCode::CANCELLED_ERROR, kBadResponse);
+    auto copy_response = response;
+
+    std::string status;
+    std::string copy_status;
+    response.GetResponse(status);
+    copy_response.GetResponse(copy_status);
+
+    EXPECT_FALSE(status.empty());
+    EXPECT_FALSE(copy_status.empty());
+    EXPECT_TRUE(response.GetHeaders().empty());
+    EXPECT_TRUE(copy_response.GetHeaders().empty());
+    EXPECT_EQ(kBadResponse, status);
+    EXPECT_EQ(response.GetStatus(),
+              static_cast<int>(ErrorCode::CANCELLED_ERROR));
+    EXPECT_EQ(copy_response.GetStatus(), response.GetStatus());
+    EXPECT_EQ(status, copy_status);
+  }
+
+  {
+    SCOPED_TRACE("Valid response");
+
+    http::Headers headers = {{"header1", "value1"}, {"header2", "value2"}};
+    auto response =
+        GetHttpResponse(http::HttpStatusCode::OK, kGoodResponse, headers);
+    auto copy_response = response;
+
+    std::string status;
+    std::string copy_status;
+    response.GetResponse(status);
+    copy_response.GetResponse(copy_status);
+
+    EXPECT_FALSE(status.empty());
+    EXPECT_FALSE(copy_status.empty());
+    EXPECT_EQ(response.GetHeaders(), headers);
+    EXPECT_EQ(copy_response.GetHeaders(), headers);
+    EXPECT_EQ(kGoodResponse, status);
+    EXPECT_EQ(response.GetStatus(), http::HttpStatusCode::OK);
+    EXPECT_EQ(copy_response.GetStatus(), response.GetStatus());
+    EXPECT_EQ(status, copy_status);
+  }
+}
+
+TEST(HttpResponseTest, Move) {
+  {
+    SCOPED_TRACE("Error response");
+
+    auto response = GetHttpResponse(ErrorCode::CANCELLED_ERROR, kBadResponse);
+    auto copy_response = std::move(response);
+
+    std::string status;
+    std::string copy_status;
+    response.GetResponse(status);
+    copy_response.GetResponse(copy_status);
+
+    EXPECT_TRUE(status.empty());
+    EXPECT_FALSE(copy_status.empty());
+    EXPECT_TRUE(response.GetHeaders().empty());
+    EXPECT_TRUE(copy_response.GetHeaders().empty());
+    EXPECT_EQ(kBadResponse, copy_status);
+    EXPECT_EQ(copy_response.GetStatus(),
+              static_cast<int>(ErrorCode::CANCELLED_ERROR));
+  }
+
+  {
+    SCOPED_TRACE("Valid response");
+
+    http::Headers headers = {{"header1", "value1"}, {"header2", "value2"}};
+    auto response =
+        GetHttpResponse(http::HttpStatusCode::OK, kGoodResponse, headers);
+    auto copy_response = std::move(response);
+
+    std::string status;
+    std::string copy_status;
+    response.GetResponse(status);
+    copy_response.GetResponse(copy_status);
+
+    EXPECT_TRUE(status.empty());
+    EXPECT_FALSE(copy_status.empty());
+    EXPECT_TRUE(response.GetHeaders().empty());
+    EXPECT_EQ(copy_response.GetHeaders(), headers);
+    EXPECT_EQ(kGoodResponse, copy_status);
+    EXPECT_EQ(copy_response.GetStatus(), http::HttpStatusCode::OK);
+  }
+}
+
+void CheckHttResponse(client::HttpResponse& in, int status,
+                      const std::string& response,
+                      const http::Headers& headers) {
+  std::string response_in;
+  in.GetResponse(response_in);
+  EXPECT_EQ(response_in, response);
+  EXPECT_EQ(in.GetHeaders(), headers);
+  EXPECT_EQ(in.GetStatus(), status);
+}
+
+TEST(PendingUrlRequestsTest, IsCancelled) {
+  client::PendingUrlRequests pending_requests;
+  const std::string url1 = "url1";
+  const std::string url2 = "url2";
+
+  {
+    SCOPED_TRACE("Cancel one request");
+
+    auto request_valid = pending_requests[url1];
+    auto request_cancelled = pending_requests[url2];
+    ASSERT_TRUE(request_valid && request_cancelled);
+
+    request_valid->Append([&](client::HttpResponse) {});
+    auto request_id = request_cancelled->Append([&](client::HttpResponse) {});
+
+    ASSERT_FALSE(request_valid->IsCancelled());
+    ASSERT_FALSE(request_cancelled->IsCancelled());
+
+    EXPECT_TRUE(pending_requests.Cancel(url2, request_id));
+    EXPECT_FALSE(request_valid->IsCancelled());
+    EXPECT_TRUE(request_cancelled->IsCancelled());
+  }
+
+  {
+    SCOPED_TRACE("Cancel all requests");
+
+    auto request1 = pending_requests[url1];
+    auto request2 = pending_requests[url2];
+    ASSERT_TRUE(request1 && request2);
+
+    request1->Append([&](client::HttpResponse) {});
+    request2->Append([&](client::HttpResponse) {});
+
+    ASSERT_FALSE(request1->IsCancelled());
+    ASSERT_FALSE(request2->IsCancelled());
+
+    EXPECT_TRUE(pending_requests.CancelAll());
+    EXPECT_TRUE(request1->IsCancelled());
+    EXPECT_TRUE(request2->IsCancelled());
+  }
+}
+
+TEST(PendingUrlRequestsTest, CancelAllAndWait) {
+  client::PendingUrlRequests pending_requests;
+  const std::string url1 = "url1";
+  const std::string url2 = "url2";
+
+  auto request1 = pending_requests[url1];
+  auto request2 = pending_requests[url2];
+  ASSERT_TRUE(request1 && request2);
+
+  auto check_cancelled = [&](client::HttpResponse response) {
+    ASSERT_EQ(response.GetStatus(), kCancelledStatus);
+  };
+
+  request1->Append(check_cancelled);
+  request2->Append(check_cancelled);
+
+  auto cancel_call = [&](http::RequestId request_id, const std::string& url) {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    pending_requests.OnRequestCompleted(request_id, url,
+                                        GetCancelledResponse());
+  };
+
+  const http::RequestId request_id = 1234;
+  std::future<void> future1, future2;
+
+  request1->ExecuteOrCancelled([&](http::RequestId& id) {
+    id = request_id;
+    return client::CancellationToken([&] {
+      future1 = std::async(std::launch::async, cancel_call, id, url1);
+    });
+  });
+
+  request2->ExecuteOrCancelled([&](http::RequestId& id) {
+    id = request_id + 1;
+    return client::CancellationToken([&] {
+      future2 = std::async(std::launch::async, cancel_call, id, url2);
+    });
+  });
+
+  // Once CancelAllAndWait is called, it should wait for all responses else we
+  // face crashes
+  ASSERT_TRUE(pending_requests.CancelAllAndWait());
+  ASSERT_EQ(future1.wait_for(std::chrono::milliseconds(1)),
+            std::future_status::ready);
+  ASSERT_EQ(future2.wait_for(std::chrono::milliseconds(1)),
+            std::future_status::ready);
+}
+
+TEST(PendingUrlRequestsTest, ExecuteOrCancelled) {
+  client::PendingUrlRequests pending_requests;
+  const std::string url = "url";
+
+  // Check that ExecuteOrCancelled is behaving correctly
+  auto request_ptr = pending_requests[url];
+  ASSERT_TRUE(request_ptr);
+  ASSERT_FALSE(request_ptr->IsCancelled());
+  ASSERT_EQ(request_ptr.use_count(), 2);
+
+  bool is_cancelled = false;
+  bool cancel_func_called = false;
+
+  // Set request Id
+  request_ptr->ExecuteOrCancelled(
+      [&](http::RequestId&) {
+        return client::CancellationToken([&] { is_cancelled = true; });
+      },
+      [] { EXPECT_TRUE(false) << "Cancel function should not be called!"; });
+
+  // Now cancel request and call again
+  request_ptr->CancelOperation();
+
+  request_ptr->ExecuteOrCancelled(
+      [](http::RequestId&) {
+        EXPECT_TRUE(false) << "Execute function should not be called!";
+        return client::CancellationToken();
+      },
+      [&] { cancel_func_called = true; });
+
+  EXPECT_TRUE(is_cancelled);
+  EXPECT_TRUE(cancel_func_called);
+}
+
+TEST(PendingUrlRequestsTest, SameUrlAfterCancel) {
+  // This test covers the user case were you have a cancelled request and
+  // afterwards a new request with the same URL. In this case both should
+  // exist at the same time, one in the pending request list the other in the
+  // cancelled list.
+  client::PendingUrlRequests pending_requests;
+  const std::string url = "url1";
+
+  // Add request to be cancelled
+  auto request_ptr = pending_requests[url];
+  ASSERT_TRUE(request_ptr);
+  ASSERT_FALSE(request_ptr->IsCancelled());
+  ASSERT_EQ(request_ptr.use_count(), 2);
+
+  client::HttpResponse response_cancelled;
+  auto cancel_id = request_ptr->Append([&](client::HttpResponse response) {
+    response_cancelled = std::move(response);
+  });
+
+  const http::RequestId request_id = 1234;
+  request_ptr->ExecuteOrCancelled([&](http::RequestId& id) {
+    id = request_id;
+    return client::CancellationToken();
+  });
+
+  // Now cancel the request
+  EXPECT_TRUE(pending_requests.Cancel(url, cancel_id));
+  ASSERT_TRUE(request_ptr->IsCancelled());
+
+  // Add second request with the same url
+  auto new_request_ptr = pending_requests[url];
+  ASSERT_TRUE(new_request_ptr);
+  ASSERT_FALSE(new_request_ptr->IsCancelled());
+  ASSERT_EQ(new_request_ptr.use_count(), 2);
+  ASSERT_FALSE(new_request_ptr == request_ptr);
+
+  client::HttpResponse response_valid;
+  new_request_ptr->Append([&](client::HttpResponse response) {
+    response_valid = std::move(response);
+  });
+
+  const http::RequestId new_request_id = 1 + request_id;
+  new_request_ptr->ExecuteOrCancelled([&](http::RequestId& id) {
+    id = new_request_id;
+    return client::CancellationToken();
+  });
+
+  // First trigger the valid response, then the cancelled
+  http::Headers headers = {{"header1", "value1"}, {"header2", "value2"}};
+  const auto response_in =
+      GetHttpResponse(http::HttpStatusCode::OK, kGoodResponse, headers);
+  pending_requests.OnRequestCompleted(request_id, url, response_in);
+}
+
+TEST(PendingUrlRequestsTest, CallbackCalled) {
+  client::PendingUrlRequests pending_requests;
+  const std::string url = "url1";
+
+  {
+    SCOPED_TRACE("Single callback");
+
+    auto request_ptr = pending_requests[url];
+    ASSERT_TRUE(request_ptr);
+    ASSERT_FALSE(request_ptr->IsCancelled());
+    ASSERT_EQ(request_ptr.use_count(), 2);
+
+    // Add one callback and check that it is triggered
+    client::HttpResponse response_out;
+    EXPECT_EQ(0u, request_ptr->Append([&](client::HttpResponse response) {
+      response_out = std::move(response);
+    }));
+
+    // Set request Id
+    const http::RequestId request_id = 1234;
+    request_ptr->ExecuteOrCancelled(
+        [&](http::RequestId& id) {
+          id = request_id;
+          return client::CancellationToken();
+        },
+        [] { EXPECT_TRUE(false) << "Cancel function should not be called!"; });
+
+    // Relese the pending request from local var to make sure we don't have
+    // any issues there.
+    request_ptr.reset();
+
+    // Now mark the request as completed and expect the callback to be called
+    http::Headers headers = {{"header1", "value1"}, {"header2", "value2"}};
+    const auto response_in =
+        GetHttpResponse(http::HttpStatusCode::OK, kGoodResponse, headers);
+    pending_requests.OnRequestCompleted(request_id, url, response_in);
+
+    EXPECT_NO_FATAL_FAILURE(CheckHttResponse(
+        response_out, response_in.GetStatus(), kGoodResponse, headers));
+
+    ASSERT_EQ(pending_requests.Size(), 0u)
+        << "Pending requests should be empty";
+  }
+
+  {
+    SCOPED_TRACE("Multiple callbacks");
+
+    auto request_ptr = pending_requests[url];
+    ASSERT_TRUE(request_ptr);
+    ASSERT_FALSE(request_ptr->IsCancelled());
+    ASSERT_EQ(request_ptr.use_count(), 2);
+
+    // Add one callback and check that it is triggered
+    client::HttpResponse response_out_1, response_out_2;
+
+    EXPECT_EQ(0u, request_ptr->Append([&](client::HttpResponse response) {
+      response_out_1 = std::move(response);
+    }));
+
+    EXPECT_EQ(1u, request_ptr->Append([&](client::HttpResponse response) {
+      response_out_2 = std::move(response);
+    }));
+
+    // Set request Id
+    const http::RequestId request_id = 1234;
+    request_ptr->ExecuteOrCancelled(
+        [&](http::RequestId& id) {
+          id = request_id;
+          return client::CancellationToken();
+        },
+        [] { EXPECT_TRUE(false) << "Cancel function should not be called!"; });
+
+    // Relese the pending request from local var to make sure we don't have
+    // any issues there.
+    request_ptr.reset();
+
+    // Now mark the request as completed and expect the callback to be called
+    http::Headers headers = {{"header1", "value1"}, {"header2", "value2"}};
+    pending_requests.OnRequestCompleted(
+        request_id, url,
+        GetHttpResponse(http::HttpStatusCode::OK, kGoodResponse, headers));
+
+    EXPECT_NO_FATAL_FAILURE(CheckHttResponse(
+        response_out_1, http::HttpStatusCode::OK, kGoodResponse, headers));
+
+    EXPECT_NO_FATAL_FAILURE(CheckHttResponse(
+        response_out_2, http::HttpStatusCode::OK, kGoodResponse, headers));
+
+    ASSERT_EQ(pending_requests.Size(), 0u)
+        << "Pending requests should be empty";
+  }
+  {
+    SCOPED_TRACE("Multiple callbacks, one cancelled");
+
+    auto request_ptr = pending_requests[url];
+    ASSERT_TRUE(request_ptr);
+    ASSERT_FALSE(request_ptr->IsCancelled());
+    ASSERT_EQ(request_ptr.use_count(), 2);
+
+    client::HttpResponse response_good, response_cancelled;
+
+    EXPECT_EQ(0u, request_ptr->Append([&](client::HttpResponse response) {
+      response_good = std::move(response);
+    }));
+
+    auto callback_id = request_ptr->Append([&](client::HttpResponse response) {
+      response_cancelled = std::move(response);
+    });
+    EXPECT_EQ(callback_id, 1u);
+
+    // Set request Id
+    const http::RequestId request_id = 1234;
+    request_ptr->ExecuteOrCancelled(
+        [&](http::RequestId& id) {
+          id = request_id;
+          return client::CancellationToken();
+        },
+        [] { EXPECT_TRUE(false) << "Cancel function should not be called!"; });
+
+    // Cancel second request and check that request is not cancelled fully
+    pending_requests.Cancel(url, callback_id);
+    ASSERT_FALSE(request_ptr->IsCancelled());
+
+    http::Headers headers = {{"header1", "value1"}, {"header2", "value2"}};
+    pending_requests.OnRequestCompleted(
+        request_id, url,
+        GetHttpResponse(http::HttpStatusCode::OK, kGoodResponse, headers));
+
+    EXPECT_NO_FATAL_FAILURE(CheckHttResponse(
+        response_good, http::HttpStatusCode::OK, kGoodResponse, headers));
+
+    std::string cancelled_response;
+    auto cancelled_expected = GetCancelledResponse();
+    cancelled_expected.GetResponse(cancelled_response);
+    EXPECT_NO_FATAL_FAILURE(CheckHttResponse(response_cancelled,
+                                             cancelled_expected.GetStatus(),
+                                             cancelled_response, {}));
+  }
+}
+
+TEST(PendingUrlRequestsTest, CancelCallback) {
+  client::PendingUrlRequests pending_requests;
+  const std::string url1 = "url1", url2 = "url2", url3 = "url3";
+  http::RequestId request_id = 1234;
+
+  auto response_call = [&](http::RequestId request_id, const std::string& url) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    pending_requests.OnRequestCompleted(
+        request_id, url,
+        GetHttpResponse(http::HttpStatusCode::OK, kGoodResponse));
+  };
+
+  {
+    SCOPED_TRACE("Single callback cancelled");
+
+    auto request_ptr = pending_requests[url1];
+    ASSERT_TRUE(request_ptr);
+
+    // Add one callback and check that it is triggered and it is cancelled
+    auto callback_id = request_ptr->Append([&](client::HttpResponse response) {
+      ASSERT_EQ(response.GetStatus(), kCancelledStatus);
+    });
+
+    request_ptr->ExecuteOrCancelled([&](http::RequestId& id) {
+      id = ++request_id;
+      return client::CancellationToken();
+    });
+
+    EXPECT_TRUE(pending_requests.Cancel(url1, callback_id));
+
+    // Trigger and wait for response
+    std::async(std::launch::async, response_call, request_id, url1).get();
+  }
+
+  {
+    SCOPED_TRACE("Multiple callbacks, one cancelled");
+
+    auto request_ptr = pending_requests[url1];
+    ASSERT_TRUE(request_ptr);
+
+    // Add one callback and check that it is triggered and it is cancelled
+    request_ptr->Append([&](client::HttpResponse response) {
+      ASSERT_NE(response.GetStatus(), kCancelledStatus);
+    });
+
+    request_ptr->ExecuteOrCancelled([&](http::RequestId& id) {
+      id = ++request_id;
+      return client::CancellationToken();
+    });
+
+    auto callback_id = request_ptr->Append([&](client::HttpResponse response) {
+      ASSERT_EQ(response.GetStatus(), kCancelledStatus);
+    });
+
+    EXPECT_TRUE(pending_requests.Cancel(url1, callback_id));
+
+    // Trigger and wait for response
+    std::async(std::launch::async, response_call, request_id, url1).get();
+  }
+
+  {
+    SCOPED_TRACE("Multiple callbacks, unknown cancelled");
+
+    auto request_ptr = pending_requests[url1];
+    ASSERT_TRUE(request_ptr);
+
+    // Add one callback and check that it is triggered and it is cancelled
+    request_ptr->Append([&](client::HttpResponse response) {
+      ASSERT_NE(response.GetStatus(), kCancelledStatus);
+    });
+
+    auto callback_id = request_ptr->Append([&](client::HttpResponse response) {
+      ASSERT_NE(response.GetStatus(), kCancelledStatus);
+    });
+
+    request_ptr->ExecuteOrCancelled([&](http::RequestId& id) {
+      id = ++request_id;
+      return client::CancellationToken();
+    });
+
+    EXPECT_FALSE(pending_requests.Cancel(url1, callback_id + 15));
+
+    // Trigger and wait for response
+    std::async(std::launch::async, response_call, request_id, url1).get();
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
Both classes will be used by OlpClient to merge same URL requests and
thus avoid requesting the same data multiple times. For this a change
is needed in HttpResponse to handle the std::stringstream copy on
copy constructor and copy assignment operator. Without this it is not
possible to copy an existing HttpResponse and return it to multiple
waiting callbacks. At the same time we deprecate the public members
of HttpResponse and prepare it to be changed by 01.2020 into a shared
pimpl class so that we do not need to deep copy the responses.
The PendingUrlRequest class manages one Network request, for which it
remebers the request id and is able to cancel it, and is able to hold
one or multiple response callback. It also handles correctly one, more
or all callbacks cancellation scenarios, incl. cancelling the network
request once all pending callbacks are cancelled.

Both PendingUrlRequests and PendingUrlRequest are mutex protected and
thread safe, additionaly PendingUrlRequests class takes care to not
get a conflict in case a URL request was cancelled fully and there is
a new request comming for the same URL. In this case a new request will
be triggered and the old one will be taken out from the pending request
and placed in a separate container for cacelled requests only.

Relates-To: OLPEDGE-1805

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>