### PR TITLE
Fix Prefetch empty responce

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -263,12 +263,6 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
             repository::PrefetchTilesRepository::FilterSkippedTiles(
                 request, request_only_input_tiles, sub_tiles.MoveResult());
 
-        if (tiles_result.empty()) {
-          OLP_SDK_LOG_WARNING_F(
-              kLogTag, "PrefetchTiles: subtiles empty, key=%s", key.c_str());
-          return {{ErrorCode::InvalidArgument, "Subquads retrieval failed"}};
-        }
-
         OLP_SDK_LOG_INFO_F(kLogTag, "Prefetch start, key=%s, tiles=%zu",
                            key.c_str(), tiles_result.size());
 
@@ -292,6 +286,10 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
               AddTask(
                   settings.task_scheduler, pending_requests,
                   [=](CancellationContext inner_context) {
+                    if (handle.empty()) {
+                      return DataResponse{
+                          {olp::client::ErrorCode::NotFound, "Not found"}};
+                    }
                     repository::DataCacheRepository data_cache_repository(
                         catalog, shared_settings->cache);
                     if (data_cache_repository.IsCached(layer_id, handle)) {
@@ -332,22 +330,23 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
         // Inner task only generates successfull result
         if (!response.IsSuccessful()) {
           callback(response.GetError());
+        } else {
+          callback(PrefetchTilesResult());
         }
       });
 
   return token;
-}  // namespace read
+}
 
 client::CancellableFuture<PrefetchTilesResponse>
 VersionedLayerClientImpl::PrefetchTiles(
     PrefetchTilesRequest request, PrefetchStatusCallback status_callback) {
   auto promise = std::make_shared<std::promise<PrefetchTilesResponse>>();
-  auto cancel_token = PrefetchTiles(
-      std::move(request),
-      [promise](PrefetchTilesResponse response) {
-        promise->set_value(std::move(response));
-      },
-      std::move(status_callback));
+  auto cancel_token = PrefetchTiles(std::move(request),
+                                    [promise](PrefetchTilesResponse response) {
+                                      promise->set_value(std::move(response));
+                                    },
+                                    std::move(status_callback));
   return client::CancellableFuture<PrefetchTilesResponse>(cancel_token,
                                                           promise);
 }

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -221,12 +221,6 @@ client::CancellationToken VolatileLayerClientImpl::PrefetchTiles(
             repository::PrefetchTilesRepository::FilterSkippedTiles(
                 request, request_only_input_tiles, sub_tiles.MoveResult());
 
-        if (tiles_result.empty()) {
-          OLP_SDK_LOG_WARNING_F(
-              kLogTag, "PrefetchTiles: subtiles empty, key=%s", key.c_str());
-          return {{ErrorCode::InvalidArgument, "Subquads retrieval failed"}};
-        }
-
         OLP_SDK_LOG_INFO_F(kLogTag, "Prefetch start, key=%s, tiles=%zu",
                            key.c_str(), tiles_result.size());
 
@@ -256,6 +250,10 @@ client::CancellationToken VolatileLayerClientImpl::PrefetchTiles(
           AddTask(
               settings.task_scheduler, pending_requests,
               [=](CancellationContext inner_context) {
+                if (handle.empty()) {
+                  return DataResponse{
+                      {olp::client::ErrorCode::NotFound, "Not found"}};
+                }
                 repository::DataCacheRepository data_cache_repository(
                     catalog, shared_settings->cache);
                 if (data_cache_repository.IsCached(layer_id, handle)) {

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -330,8 +330,8 @@ SubQuadsResponse PrefetchTilesRepository::GetVolatileSubQuads(
 SubQuadsResult PrefetchTilesRepository::FilterSkippedTiles(
     const PrefetchTilesRequest& request, bool request_only_input_tiles,
     SubQuadsResult sub_tiles) {
+  const auto& tile_keys = request.GetTileKeys();
   auto skip_tile = [&](const geo::TileKey& tile_key) {
-    const auto& tile_keys = request.GetTileKeys();
     if (request_only_input_tiles) {
       return std::find(tile_keys.begin(), tile_keys.end(), tile_key) ==
              tile_keys.end();
@@ -356,6 +356,13 @@ SubQuadsResult PrefetchTilesRepository::FilterSkippedTiles(
       sub_quad_it = sub_tiles.erase(sub_quad_it);
     } else {
       ++sub_quad_it;
+    }
+  }
+  if (request_only_input_tiles) {
+    for (const auto& tile : tile_keys) {
+      if (sub_tiles.find(tile) == sub_tiles.end()) {
+        sub_tiles[tile] = "";
+      }
     }
   }
   return sub_tiles;

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -349,9 +349,8 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchWrongLevels) {
 
       ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
       dataservice_read::PrefetchTilesResponse response = future.get();
-      ASSERT_FALSE(response.IsSuccessful());
-      ASSERT_EQ(static_cast<int>(http::ErrorCode::UNKNOWN_ERROR),
-                response.GetError().GetHttpStatusCode());
+      ASSERT_TRUE(response.IsSuccessful());
+      ASSERT_TRUE(response.GetResult().empty());
     }
   }
 }

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -1771,7 +1771,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesEmptyResponse) {
         promise->set_value(std::move(response));
       });
 
- // ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+  ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
   PrefetchTilesResponse response = future.get();
   ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
   ASSERT_TRUE(response.GetResult().empty());

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -1745,6 +1745,75 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesInvalidResponse) {
             response.GetError().GetMessage());
 }
 
+TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesEmptyResponse) {
+  constexpr auto kLayerId = "hype-test-prefetch";
+
+  auto client =
+      read::VersionedLayerClient(kCatalog, kLayerId, boost::none, settings_);
+  std::vector<geo::TileKey> tile_keys = {
+      geo::TileKey::FromHereTile("23618365")};
+
+  auto request = read::PrefetchTilesRequest()
+                     .WithTileKeys(tile_keys)
+                     .WithMinLevel(11)
+                     .WithMaxLevel(12);
+  {
+    EXPECT_CALL(*network_mock_,
+                Send(IsGetRequest(URL_QUADKEYS_92259), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            GetResponse(http::HttpStatusCode::OK),
+            R"jsonString({"subQuads": [],"parentQuads": []})jsonString"));
+  }
+  auto promise = std::make_shared<std::promise<PrefetchTilesResponse>>();
+  auto future = promise->get_future();
+  auto token =
+      client.PrefetchTiles(request, [promise](PrefetchTilesResponse response) {
+        promise->set_value(std::move(response));
+      });
+
+ // ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+  PrefetchTilesResponse response = future.get();
+  ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
+  ASSERT_TRUE(response.GetResult().empty());
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest,
+       PrefetchTilesEmptyResponseDefaultLevels) {
+  constexpr auto kLayerId = "hype-test-prefetch";
+
+  auto client =
+      read::VersionedLayerClient(kCatalog, kLayerId, boost::none, settings_);
+  std::vector<geo::TileKey> tile_keys = {
+      geo::TileKey::FromHereTile("23618365")};
+
+  auto request = read::PrefetchTilesRequest().WithTileKeys(tile_keys);
+  {
+    EXPECT_CALL(*network_mock_,
+                Send(IsGetRequest(URL_QUADKEYS_92259), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            GetResponse(http::HttpStatusCode::OK),
+            R"jsonString({"subQuads": [],"parentQuads": []})jsonString"));
+  }
+  auto promise = std::make_shared<std::promise<PrefetchTilesResponse>>();
+  auto future = promise->get_future();
+  auto token =
+      client.PrefetchTiles(request, [promise](PrefetchTilesResponse response) {
+        promise->set_value(std::move(response));
+      });
+
+  ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+  PrefetchTilesResponse response = future.get();
+  ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
+  ASSERT_FALSE(response.GetResult().empty());
+  for (auto tile_result : response.GetResult()) {
+    std::string str = tile_result->tile_key_.ToHereTile();
+    ASSERT_FALSE(tile_result->IsSuccessful());
+    ASSERT_EQ(olp::client::ErrorCode::NotFound,
+              tile_result->GetError().GetErrorCode());
+    ASSERT_TRUE(tile_result->tile_key_.IsValid());
+  }
+}
+
 TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchSameTiles) {
   constexpr auto kLayerId = "hype-test-prefetch";
 


### PR DESCRIPTION
When requesting tiles we should get success
even with empty vector of tiles result .
If default levels set return tile not found
for each tile from request.
Add tests to check empty tiles result.

Relates-To: OLPEDGE-2204

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>