### PR TITLE
Remove static from PrefetchTilesRepository methods.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -198,8 +198,9 @@ client::CancellationToken VolatileLayerClientImpl::PrefetchTiles(
             (request_only_input_tiles ? static_cast<unsigned int>(geo::TileKey::LevelCount)
                                       : request.GetMaxLevel());
 
-        auto sliced_tiles = repository::PrefetchTilesRepository::GetSlicedTiles(
-            tile_keys, min_level, max_level);
+        repository::PrefetchTilesRepository repository(catalog, settings);
+        auto sliced_tiles =
+            repository.GetSlicedTiles(tile_keys, min_level, max_level);
 
         if (sliced_tiles.empty()) {
           OLP_SDK_LOG_WARNING_F(kLogTag,
@@ -211,16 +212,14 @@ client::CancellationToken VolatileLayerClientImpl::PrefetchTiles(
         OLP_SDK_LOG_DEBUG_F(kLogTag, "PrefetchTiles, subquads=%zu, key=%s",
                             sliced_tiles.size(), key.c_str());
 
-        auto sub_tiles = repository::PrefetchTilesRepository::GetSubTiles(
-            catalog, layer_id, request, boost::none, sliced_tiles, context,
-            settings);
+        auto sub_tiles = repository.GetSubTiles(layer_id, request, boost::none,
+                                                sliced_tiles, context);
 
         if (!sub_tiles.IsSuccessful()) {
           return sub_tiles.GetError();
         }
-        auto tiles_result =
-            repository::PrefetchTilesRepository::FilterSkippedTiles(
-                request, request_only_input_tiles, sub_tiles.MoveResult());
+        auto tiles_result = repository.FilterSkippedTiles(
+            request, request_only_input_tiles, sub_tiles.MoveResult());
 
         if (tiles_result.empty()) {
           OLP_SDK_LOG_WARNING_F(

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -46,6 +46,9 @@ using SubTilesResponse = client::ApiResponse<SubTilesResult, client::ApiError>;
 
 class PrefetchTilesRepository {
  public:
+  PrefetchTilesRepository(client::HRN catalog,
+                          client::OlpClientSettings settings);
+
   /**
    * @brief Given tile keys, return all related tile keys that are between
    * minLevel and maxLevel, and the depth. This tiles makes possible to cover
@@ -56,40 +59,38 @@ class PrefetchTilesRepository {
    * @param minLevel Minimum level of the resultant tile keys.
    * @param maxLevel Maximum level of the resultant tile keys.
    */
-  static RootTilesForRequest GetSlicedTiles(
-      const std::vector<geo::TileKey>& tile_keys, std::uint32_t min,
-      std::uint32_t max);
+  RootTilesForRequest GetSlicedTiles(const std::vector<geo::TileKey>& tile_keys,
+                                     std::uint32_t min, std::uint32_t max);
 
-  static SubTilesResponse GetSubTiles(
-      const client::HRN& catalog, const std::string& layer_id,
-      const PrefetchTilesRequest& request,
-      boost::optional<std::int64_t> version,
-      const RootTilesForRequest& root_tiles,
-      client::CancellationContext context,
-      const client::OlpClientSettings& settings);
+  SubTilesResponse GetSubTiles(const std::string& layer_id,
+                               const PrefetchTilesRequest& request,
+                               boost::optional<std::int64_t> version,
+                               const RootTilesForRequest& root_tiles,
+                               client::CancellationContext context);
 
-  static SubQuadsResult FilterSkippedTiles(const PrefetchTilesRequest& request,
-                                           bool request_only_input_tiles,
-                                           SubQuadsResult sub_tiles);
+  SubQuadsResult FilterSkippedTiles(const PrefetchTilesRequest& request,
+                                    bool request_only_input_tiles,
+                                    SubQuadsResult sub_tiles);
 
  protected:
-  static SubQuadsResponse GetSubQuads(const client::HRN& catalog,
-                                      const std::string& layer_id,
-                                      const PrefetchTilesRequest& request,
-                                      std::int64_t version, geo::TileKey tile,
-                                      int32_t depth,
-                                      const client::OlpClientSettings& settings,
-                                      client::CancellationContext context);
+  SubQuadsResponse GetSubQuads(const std::string& layer_id,
+                               const PrefetchTilesRequest& request,
+                               std::int64_t version, geo::TileKey tile,
+                               int32_t depth,
+                               client::CancellationContext context);
 
-  static SubQuadsResponse GetVolatileSubQuads(
-      const client::HRN& catalog, const std::string& layer_id,
-      const PrefetchTilesRequest& request, geo::TileKey tile, int32_t depth,
-      const client::OlpClientSettings& settings,
-      client::CancellationContext context);
+  SubQuadsResponse GetVolatileSubQuads(const std::string& layer_id,
+                                       const PrefetchTilesRequest& request,
+                                       geo::TileKey tile, int32_t depth,
+                                       client::CancellationContext context);
 
-  static void SplitSubtree(RootTilesForRequest& root_tiles_depth,
-                           RootTilesForRequest::iterator subtree_to_split,
-                           const geo::TileKey& tile_key, std::uint32_t min);
+  void SplitSubtree(RootTilesForRequest& root_tiles_depth,
+                    RootTilesForRequest::iterator subtree_to_split,
+                    const geo::TileKey& tile_key, std::uint32_t min);
+
+ private:
+  client::HRN catalog_;
+  client::OlpClientSettings settings_;
 };
 
 }  // namespace repository


### PR DESCRIPTION
PrefetchTilesRepository contains only static methods and they all are
taking HRN and OlpClientSettings as args. Moving these args to the
constructor will simplify further extending, e.g. with ApiClientLookup.

Resolves: OLPEDGE-2200

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>