### PR TITLE
Add a prefetch status callback to volatile layer

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
@@ -214,11 +214,14 @@ class DATASERVICE_READ_API VolatileLayerClient final {
    * @param callback The `PrefetchTilesResponseCallback` object that is invoked
    * if the `PrefetchTilesResult` instance is available or an error is
    * encountered.
+   * @param status_callback The `PrefetchStatusCallback` object that is invoked
+   * every time a tile is fetched.
    *
    * @return A token that can be used to cancel this request.
    */
   client::CancellationToken PrefetchTiles(
-      PrefetchTilesRequest request, PrefetchTilesResponseCallback callback);
+      PrefetchTilesRequest request, PrefetchTilesResponseCallback callback,
+      PrefetchStatusCallback status_callback = nullptr);
 
   /**
    * @brief Prefetches a set of tiles asynchronously.
@@ -235,13 +238,16 @@ class DATASERVICE_READ_API VolatileLayerClient final {
    *
    * @param request The `PrefetchTilesRequest` instance that contains
    * a complete set of request parameters.
+   * @param status_callback The `PrefetchStatusCallback` object that is invoked
+   * every time a tile is fetched.
    *
    * @return `CancellableFuture` that contains the `PrefetchTilesResponse`
    * instance with data or an error. You can also use `CancellableFuture` to
    * cancel this request.
    */
   client::CancellableFuture<PrefetchTilesResponse> PrefetchTiles(
-      PrefetchTilesRequest request);
+      PrefetchTilesRequest request,
+      PrefetchStatusCallback status_callback = nullptr);
 
  private:
   std::unique_ptr<VolatileLayerClientImpl> impl_;

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClient.cpp
@@ -73,13 +73,16 @@ bool VolatileLayerClient::RemoveFromCache(const geo::TileKey& tile) {
 }
 
 client::CancellationToken VolatileLayerClient::PrefetchTiles(
-    PrefetchTilesRequest request, PrefetchTilesResponseCallback callback) {
-  return impl_->PrefetchTiles(std::move(request), std::move(callback));
+    PrefetchTilesRequest request, PrefetchTilesResponseCallback callback,
+    PrefetchStatusCallback status_callback) {
+  return impl_->PrefetchTiles(std::move(request), std::move(callback),
+                              std::move(status_callback));
 }
 
 client::CancellableFuture<PrefetchTilesResponse>
-VolatileLayerClient::PrefetchTiles(PrefetchTilesRequest request) {
-  return impl_->PrefetchTiles(std::move(request));
+VolatileLayerClient::PrefetchTiles(PrefetchTilesRequest request,
+                                   PrefetchStatusCallback status_callback) {
+  return impl_->PrefetchTiles(std::move(request), std::move(status_callback));
 }
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
@@ -66,10 +66,12 @@ class VolatileLayerClientImpl {
   virtual bool RemoveFromCache(const geo::TileKey& tile);
 
   virtual client::CancellationToken PrefetchTiles(
-      PrefetchTilesRequest request, PrefetchTilesResponseCallback callback);
+      PrefetchTilesRequest request, PrefetchTilesResponseCallback callback,
+      PrefetchStatusCallback status_callback = nullptr);
 
   virtual client::CancellableFuture<PrefetchTilesResponse> PrefetchTiles(
-      PrefetchTilesRequest request);
+      PrefetchTilesRequest request,
+      PrefetchStatusCallback status_callback = nullptr);
 
  private:
   client::HRN catalog_;


### PR DESCRIPTION
Adapt volatile layer client to use PrefetchJob.
Prefetch status callback invoked each time a new tile is prefetched.

Relates-To: OLPEDGE-2169

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>