### PR TITLE
Make integration and funcitonal tests async.

### DIFF
--- a/tests/functional/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
@@ -144,6 +144,8 @@ class CatalogClientTest : public ::testing::TestWithParam<CacheType> {
     olp::cache::CacheSettings cache_settings;
     settings_.cache = olp::client::OlpClientSettingsFactory::CreateDefaultCache(
         cache_settings);
+    settings_.task_scheduler =
+        olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
 
     // setup proxy
     settings_.proxy_settings =

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -59,6 +59,8 @@ class DataserviceReadVersionedLayerClientTest : public ::testing::Test {
     settings_ = std::make_shared<olp::client::OlpClientSettings>();
     settings_->network_request_handler = network;
     settings_->authentication_settings = auth_client_settings;
+    settings_->task_scheduler =
+        olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
   }
 
   void TearDown() override {
@@ -88,9 +90,6 @@ class DataserviceReadVersionedLayerClientTest : public ::testing::Test {
 };
 
 TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionAsync) {
-  settings_->task_scheduler =
-      olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1);
-
   auto catalog = olp::client::HRN::FromString(
       CustomParameters::getArgument("dataservice_read_test_versioned_catalog"));
   auto layer =
@@ -121,9 +120,6 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionAsync) {
 
 TEST_F(DataserviceReadVersionedLayerClientTest,
        GetDataFromPartitionLatestVersionAsync) {
-  settings_->task_scheduler =
-      olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1);
-
   auto catalog = olp::client::HRN::FromString(
       CustomParameters::getArgument("dataservice_read_test_versioned_catalog"));
   auto layer =
@@ -153,6 +149,8 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
 }
 
 TEST_F(DataserviceReadVersionedLayerClientTest, GetDataFromPartitionSync) {
+  settings_->task_scheduler.reset();
+
   auto catalog = olp::client::HRN::FromString(
       CustomParameters::getArgument("dataservice_read_test_versioned_catalog"));
   auto layer =

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
@@ -86,6 +86,8 @@ class VolatileLayerClientTest : public ::testing::Test {
     olp::cache::CacheSettings cache_settings;
     settings_.cache = olp::client::OlpClientSettingsFactory::CreateDefaultCache(
         cache_settings);
+    settings_.task_scheduler =
+        olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
 
     // prefetch setup
     auto prefetch_app_id = CustomParameters::getArgument(kPrefetchAppId);

--- a/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientPrefetchTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientPrefetchTest.cpp
@@ -46,6 +46,8 @@ class VersionedLayerClientPrefetchTest : public ::testing::Test {
 
     settings_ = std::make_shared<olp::client::OlpClientSettings>();
     settings_->network_request_handler = network;
+    settings_->task_scheduler =
+        olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
     // setup proxy
     settings_->proxy_settings =
         olp::http::NetworkProxySettings()

--- a/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -76,6 +76,8 @@ class VersionedLayerClientTest : public ::testing::Test {
     settings_ = std::make_shared<olp::client::OlpClientSettings>();
     settings_->network_request_handler = network;
     settings_->authentication_settings = auth_client_settings;
+    settings_->task_scheduler =
+        olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
 
     // setup proxy
     settings_->proxy_settings =

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -241,6 +241,8 @@ TEST_F(AuthenticationClientTest, DefaultTimeSource) {
   auth::AuthenticationSettings settings;
   settings.network_request_handler = network_;
   settings.token_endpoint_url = kTokenEndpointUrl;
+  settings.task_scheduler =
+      client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
   ASSERT_TRUE(settings.use_system_time);
 
   EXPECT_CALL(*network_, Send(IsGetRequest(kTimestampUrl), _, _, _, _))
@@ -274,6 +276,8 @@ TEST_F(AuthenticationClientTest, SignInClientUseLocalTime) {
   settings.network_request_handler = network_;
   settings.use_system_time = true;
   settings.token_endpoint_url = kTokenEndpointUrl;
+  settings.task_scheduler =
+      client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
 
   auto client =
       std::make_unique<auth::AuthenticationClient>(std::move(settings));
@@ -317,6 +321,8 @@ TEST_F(AuthenticationClientTest, SignInClientUseWrongLocalTime) {
   settings.network_request_handler = network_;
   settings.use_system_time = true;
   settings.token_endpoint_url = kTokenEndpointUrl;
+  settings.task_scheduler =
+      client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
 
   auto client =
       std::make_unique<auth::AuthenticationClient>(std::move(settings));


### PR DESCRIPTION
Clients API designed to be used async, so tests should use same
approach too. Adding task scheduler to such tests will do the job.

Resolves: OLPEDGE-2176

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>