### PR TITLE
Adapt read::StreamLayerClient to ApiLookupClient.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/StreamLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/StreamLayerClientImpl.h
@@ -21,6 +21,7 @@
 
 #include <memory>
 
+#include <olp/core/client/ApiLookupClient.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettings.h>
@@ -95,6 +96,7 @@ class StreamLayerClientImpl {
   std::shared_ptr<client::PendingRequests> pending_requests_;
   std::mutex mutex_;
   std::unique_ptr<StreamLayerClientContext> client_context_;
+  client::ApiLookupClient lookup_client_;
 };
 
 }  // namespace read


### PR DESCRIPTION
Repositories already use new ApiLookupClient, but StreamLayerClient
request API directly calling LookupApi. Updating it separately from
other clients.

Resolves: OLPEDGE-1698

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>