### PR TITLE
Add lookup API endpoint provider settings.

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -66,6 +66,7 @@ set(OLP_SDK_CLIENT_HEADERS
     ./include/olp/core/client/CancellationContext.inl
     ./include/olp/core/client/CancellationToken.h
     ./include/olp/core/client/Condition.h
+    ./include/olp/core/client/DefaultLookupEndpointProvider.h
     ./include/olp/core/client/ErrorCode.h
     ./include/olp/core/client/FetchOptions.h
     ./include/olp/core/client/HRN.h

--- a/olp-cpp-sdk-core/include/olp/core/client/ApiLookupClient.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiLookupClient.h
@@ -36,36 +36,6 @@ namespace client {
 class ApiLookupClientImpl;
 
 /**
- * @brief Default implementation of the lookup API endpoint provider.
- *
- * This is returning the default lookup API endpoint URLs based on the HRN
- * partition.
- */
-struct CORE_API DefaultLookupEndpointProvider {
- public:
-  std::string operator()(const std::string& partition) {
-    constexpr struct {
-      const char* partition;
-      const char* url;
-    } kDatastoreServerUrl[4] = {
-        {"here", "https://api-lookup.data.api.platform.here.com/lookup/v1"},
-        {"here-dev",
-         "https://api-lookup.data.api.platform.in.here.com/lookup/v1"},
-        {"here-cn",
-         "https://api-lookup.data.api.platform.hereolp.cn/lookup/v1"},
-        {"here-cn-dev",
-         "https://api-lookup.data.api.platform.in.hereolp.cn/lookup/v1"}};
-
-    for (const auto& it : kDatastoreServerUrl) {
-      if (partition == it.partition)
-        return it.url;
-    }
-
-    return std::string();
-  }
-};
-
-/**
  * @brief Client to API lookup requests
  */
 class CORE_API ApiLookupClient final {

--- a/olp-cpp-sdk-core/include/olp/core/client/DefaultLookupEndpointProvider.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/DefaultLookupEndpointProvider.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+
+#include <olp/core/CoreApi.h>
+
+namespace olp {
+namespace client {
+/**
+ * @brief Default implementation of the lookup API endpoint provider.
+ *
+ * This is returning the default lookup API endpoint URLs based on the HRN
+ * partition.
+ */
+struct CORE_API DefaultLookupEndpointProvider {
+ public:
+  std::string operator()(const std::string& partition) {
+    constexpr struct {
+      const char* partition;
+      const char* url;
+    } kDatastoreServerUrl[4] = {
+        {"here", "https://api-lookup.data.api.platform.here.com/lookup/v1"},
+        {"here-dev",
+         "https://api-lookup.data.api.platform.in.here.com/lookup/v1"},
+        {"here-cn",
+         "https://api-lookup.data.api.platform.hereolp.cn/lookup/v1"},
+        {"here-cn-dev",
+         "https://api-lookup.data.api.platform.in.hereolp.cn/lookup/v1"}};
+
+    for (const auto& it : kDatastoreServerUrl) {
+      if (partition == it.partition)
+        return it.url;
+    }
+
+    return std::string();
+  }
+};
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
@@ -28,6 +28,7 @@
 
 #include <olp/core/client/BackdownStrategy.h>
 #include <olp/core/client/CancellationToken.h>
+#include <olp/core/client/DefaultLookupEndpointProvider.h>
 #include <olp/core/client/HttpResponse.h>
 #include <olp/core/http/Network.h>
 
@@ -231,6 +232,36 @@ struct CORE_API RetrySettings {
 };
 
 /**
+ * @brief Settings to provide URLs for API lookup requests.
+ */
+struct CORE_API ApiLookupSettings {
+  /**
+   * @brief The type alias of the lookup provider function.
+   *
+   * Users of this provider should always return full lookup API path, e.g.
+   * for "here" partition return
+   * "https://api-lookup.data.api.platform.here.com/lookup/v1"
+   *
+   * @note Return empty string in case of an invalid or unknown partition.
+   * @note This call should be synchronous without any tasks scheduled on the
+   * TaskScheduler as this might result in a dead-lock.
+   */
+  using LookupEndpointProvider = std::function<std::string(const std::string&)>;
+
+  /**
+   * @brief The provider of endpoint for API lookup requests.
+   *
+   * The lookup API endpoint provider will be called prior to every API lookup
+   * attempt to get the API Lookup URL which shall be asked for the catalog
+   * URLs.
+   *
+   * By default `DefaultLookupEndpointProvider` is being used.
+   */
+  LookupEndpointProvider lookup_endpoint_provider =
+      DefaultLookupEndpointProvider();
+};
+
+/**
  * @brief Configures the behavior of the `OlpClient` class.
  */
 struct CORE_API OlpClientSettings {
@@ -238,6 +269,11 @@ struct CORE_API OlpClientSettings {
    * @brief The retry settings.
    */
   RetrySettings retry_settings;
+
+  /**
+   * @brief API Lookup settings.
+   */
+  ApiLookupSettings api_lookup_settings;
 
   /**
    * @brief The network proxy settings.

--- a/olp-cpp-sdk-core/src/client/ApiLookupClientImpl.cpp
+++ b/olp-cpp-sdk-core/src/client/ApiLookupClientImpl.cpp
@@ -47,7 +47,7 @@ std::string FindApi(const Apis& apis, const std::string& service,
 ApiLookupClientImpl::ApiLookupClientImpl(const HRN& catalog,
                                          const OlpClientSettings& settings)
     : catalog_(catalog), settings_(settings) {
-  auto provider = DefaultLookupEndpointProvider();
+  auto provider = settings_.api_lookup_settings.lookup_endpoint_provider;
   const auto& base_url = provider(catalog_.GetPartition());
   lookup_client_.SetBaseUrl(base_url);
   lookup_client_.SetSettings(settings_);


### PR DESCRIPTION
User can specify own endpoint provider through OlpClientSettings. The
provider help to specify custom urls for catalog partition.

OlpClientSettings.h needs ApiLookupClient.h for default provider. That
cause include loop. Moving the default provide to sepparate file will
fix the issue and make OlpClientSettings not dependent on clients.

Resolves: OLPEDGE-1696

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>