### PR TITLE
Add Protect/Release tile keys

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -555,12 +555,18 @@ int64_t DefaultCacheImpl::MaybeUpdatedProtectedKeys(
   if (protected_keys_.IsDirty()) {
     auto prev_size = protected_keys_.Size();
     auto value = protected_keys_.Serialize();
+    // calculate key size, as it is be written for the first time
+    auto key_size = (prev_size > 0 ? 0 : strlen(kProtectedKeys));
     if (value->size() > 0) {
       leveldb::Slice slice(reinterpret_cast<const char*>(value->data()),
                            value->size());
       batch.Put(kProtectedKeys, slice);
-    }  // add key size, as it is be written for the first time
-    auto key_size = (prev_size > 0 ? 0 : strlen(kProtectedKeys));
+    } else {
+      // delete key, as protected list is empty
+      batch.Delete(kProtectedKeys);
+      key_size -= strlen(kProtectedKeys);
+    }
+
     return (key_size + protected_keys_.Size() - prev_size);
   }
 

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -382,6 +382,30 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    */
   bool IsCached(const geo::TileKey& tile) const;
 
+  /**
+   * @brief Protects tile keys from eviction.
+   * @note Only tiles which data handled are present in the cache at the time of
+   * the call can be protected
+   *
+   * @param tiles The list of tile keys.
+   *
+   * @return True if some keys were successfully added to the protected list;
+   * false otherwise.
+   */
+  bool Protect(const TileKeys& tiles);
+
+  /**
+   * @brief Removes a list of tiles from protection.
+   * @note Make sure that no Protect function could be called for the same
+   * catalog and layer during Release.
+   *
+   * @param tiles The list of tile keys.
+   *
+   * @return True if some keys were successfully removed from the protected
+   * list; false otherwise.
+   */
+  bool Release(const TileKeys& tiles);
+
  private:
   std::unique_ptr<VersionedLayerClientImpl> impl_;
 };

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -385,10 +385,19 @@ class DATASERVICE_READ_API VersionedLayerClient final {
   /**
    * @brief Protects tile keys from eviction.
    *
-   * @note Only tiles which data handled are present in the cache at the time of
-   * the call can be protected
+   * Protecting tile keys means that its data and corresponding quadtree
+   * keys are added to the protected list and stored in the cache. These keys
+   * are removed from the LRU cache, so they could not be evicted. Also, they do
+   * not expire. The quadtree stays protected if at least one tile key is
+   * protected.
    *
-   * @param tiles The list of tile keys.
+   * @note You can only protect tiles which data handles are present in the
+   * cache at the time of the call.
+   *
+   * @note Please do not call `Protect` while the `Release` call for the same
+   * catalog and layer is in progress.
+   *
+   * @param tiles The list of tile keys to be protected.
    *
    * @return True if some keys were successfully added to the protected list;
    * false otherwise.
@@ -398,10 +407,15 @@ class DATASERVICE_READ_API VersionedLayerClient final {
   /**
    * @brief Removes a list of tiles from protection.
    *
-   * @note Make sure that no Protect function could be called for the same
-   * catalog and layer during Release.
+   * Releasing tile keys removes data and quadtree keys from the protected
+   * list. The keys are added to the LRU cache, so they could be evicted.
+   * Expiration value is restored, and keys can expire. The quadtree can be
+   * removed from the protected list if all tile keys are no longer protected.
    *
-   * @param tiles The list of tile keys.
+   * @note Please make sure that `Protect` will not be called for the same
+   * catalog and layer while the `Release` call is in progress.
+   *
+   * @param tiles The list of tile keys to be removed from protection.
    *
    * @return True if some keys were successfully removed from the protected
    * list; false otherwise.

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -384,6 +384,7 @@ class DATASERVICE_READ_API VersionedLayerClient final {
 
   /**
    * @brief Protects tile keys from eviction.
+   *
    * @note Only tiles which data handled are present in the cache at the time of
    * the call can be protected
    *
@@ -396,6 +397,7 @@ class DATASERVICE_READ_API VersionedLayerClient final {
 
   /**
    * @brief Removes a list of tiles from protection.
+   *
    * @note Make sure that no Protect function could be called for the same
    * catalog and layer during Release.
    *

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -116,6 +116,14 @@ bool VersionedLayerClient::IsCached(const geo::TileKey& tile) const {
   return impl_->IsCached(tile);
 }
 
+bool VersionedLayerClient::Protect(const TileKeys& tiles) {
+  return impl_->Protect(tiles);
+}
+
+bool VersionedLayerClient::Release(const TileKeys& tiles) {
+  return impl_->Release(tiles);
+}
+
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp


### PR DESCRIPTION
Protect adds tile keys to protected list.
If some tile key was marked as protected, it is expected to stay in
cache, that its data can be accessible.
Release keys, which was marked before as protected. After releasing tile
keys associated data in cache could expire or be evicted.

Protect and Release functionality searches for quad tree in cache to get
data handle for each tile. When protecting tiles, at least one tile is
needed to be protected to also add quad to protected list. When
releasing all tiles should be not protected to release quad.

Added integration test with protecting and releasing tiles
keys under common quad tree.

Relates-To: OLPEDGE-2127

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>