### PR TITLE
Add Content-Encoding header to StreamLayerClient

### DIFF
--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
@@ -408,8 +408,8 @@ PublishDataResponse StreamLayerClientImpl::PublishDataLessThanTwentyMib(
 
   auto ingest_data_response = IngestApi::IngestData(
       ingest_api_client, request.GetLayerId(), layer_settings.content_type,
-      request.GetData(), request.GetTraceId(), request.GetBillingTag(),
-      request.GetChecksum(), context);
+      layer_settings.content_encoding, request.GetData(), request.GetTraceId(),
+      request.GetBillingTag(), request.GetChecksum(), context);
 
   if (!ingest_data_response.IsSuccessful()) {
     return ingest_data_response;

--- a/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.cpp
@@ -38,6 +38,7 @@
 namespace client = olp::client;
 
 namespace {
+const std::string kHeaderParamEncoding = "Content-Encoding";
 const std::string kHeaderParamChecksum = "X-HERE-Checksum";
 const std::string kHeaderParamTraceId = "X-HERE-TraceId";
 const std::string kQueryParamBillingTag = "billingTag";
@@ -93,7 +94,7 @@ client::CancellationToken IngestApi::IngestData(
 
 IngestDataResponse IngestApi::IngestData(
     const client::OlpClient& client, const std::string& layer_id,
-    const std::string& content_type,
+    const std::string& content_type, const std::string& content_encoding,
     const std::shared_ptr<std::vector<unsigned char>>& data,
     const boost::optional<std::string>& trace_id,
     const boost::optional<std::string>& billing_tag,
@@ -104,9 +105,16 @@ IngestDataResponse IngestApi::IngestData(
   std::multimap<std::string, std::string> header_params;
 
   header_params.insert(std::make_pair("Accept", "application/json"));
+
+  if (!content_encoding.empty()) {
+    header_params.insert(
+        std::make_pair(kHeaderParamEncoding, content_encoding));
+  }
+
   if (trace_id) {
     header_params.insert(std::make_pair(kHeaderParamTraceId, trace_id.get()));
   }
+
   if (checksum) {
     header_params.insert(std::make_pair(kHeaderParamChecksum, checksum.get()));
   }

--- a/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.h
@@ -94,6 +94,7 @@ class IngestApi {
    * @param layer_id Layer of the catalog where you want to store the data. The
    * layer type must be Stream.
    * @param content_type The content type configured for the target layer.
+   * @param content_encoding The content encoding configured for the target layer.
    * @param data Content to be uploaded to OLP.
    * @param trace_id Optional. A unique message ID, such as a UUID. This can be
    * included in the request if you want to use an ID that you define. If you do
@@ -114,7 +115,7 @@ class IngestApi {
    */
   static IngestDataResponse IngestData(
       const client::OlpClient& client, const std::string& layer_id,
-      const std::string& content_type,
+      const std::string& content_type, const std::string& content_encoding,
       const std::shared_ptr<std::vector<unsigned char>>& data,
       const boost::optional<std::string>& trace_id,
       const boost::optional<std::string>& billing_tag,


### PR DESCRIPTION
Automatically add Content-Encoding header to StreamLayerClient,
needed for gzip streams (when the Stream layer is configured as
compressed on the platform). Without this header the server responds
with status 400 Bad Request. Currently user have to manually compress
the payload that he wants to send, however when downloading, the
content is unziped automatically by network libraries.

Resolves: OLPEDGE-11219

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>