### PR TITLE
Adding CatalogEndpointProvider.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/ApiLookupClient.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiLookupClient.h
@@ -79,6 +79,12 @@ class CORE_API ApiLookupClient final {
    * @param callback The function callback used to receive the
    * `LookupApiResponse` instance.
    *
+   * @note If the catalog endpoint provider is set and provides a static URL
+   * for this catalog, the method does not trigger any asynchronous download and
+   * provides the synchronous result instead. This means that
+   * the user needs to take special care in case the callback is called within
+   * the same context and avoid locking any mutex twice.
+   *
    * @return The method used to call or to cancel the request.
    */
   CancellationToken LookupApi(const std::string& service,

--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
@@ -29,6 +29,7 @@
 #include <olp/core/client/BackdownStrategy.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/DefaultLookupEndpointProvider.h>
+#include <olp/core/client/HRN.h>
 #include <olp/core/client/HttpResponse.h>
 #include <olp/core/http/Network.h>
 
@@ -249,6 +250,21 @@ struct CORE_API ApiLookupSettings {
   using LookupEndpointProvider = std::function<std::string(const std::string&)>;
 
   /**
+   * @brief The type alias of the catalog endpoint provider function.
+   *
+   * Catalogs that have a static URL or can be accessed through
+   * a proxy service can input the URL provider here. This URL provider is taken
+   * by the `ApiLookupClient` and returned directly to the caller without any
+   * requests to the API Lookup Service.
+   *
+   * @note This call should be synchronous without any tasks scheduled in
+   * `TaskScheduler` as it might result in a dead-lock.
+   *
+   * @return An empty string if the catalog is invalid or unknown.
+   */
+  using CatalogEndpointProvider = std::function<std::string(const HRN&)>;
+
+  /**
    * @brief The provider of endpoint for API lookup requests.
    *
    * The lookup API endpoint provider will be called prior to every API lookup
@@ -259,6 +275,18 @@ struct CORE_API ApiLookupSettings {
    */
   LookupEndpointProvider lookup_endpoint_provider =
       DefaultLookupEndpointProvider();
+
+  /**
+   * @brief The endpoint provider for API requests.
+   *
+   * If some of the catalogs have fixed URLs and do not need the API Lookup
+   * Service, you can provide the static URL via `CatalogEndpointProvider`.
+   * Every request will receive this URL from `ApiLookupClient` without
+   * any HTTP requests to the API Lookup Service. `CatalogEndpointProvider` is
+   * called before `lookup_endpoint_provider`, and if the output is not empty,
+   * `lookup_endpoint_provider` is not called additionally.
+   */
+  CatalogEndpointProvider catalog_endpoint_provider = nullptr;
 };
 
 /**

--- a/olp-cpp-sdk-core/tests/client/ApiLookupClientImplTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/ApiLookupClientImplTest.cpp
@@ -26,6 +26,8 @@
 
 namespace {
 namespace client = olp::client;
+using testing::_;
+using testing::Return;
 
 constexpr auto kConfigBaseUrl =
     "https://config.data.api.platform.in.here.com/config/v1";
@@ -55,9 +57,6 @@ class ApiLookupClientImplTest : public ::testing::Test {
 };
 
 TEST_F(ApiLookupClientImplTest, LookupApi) {
-  using testing::_;
-  using testing::Return;
-
   const std::string catalog =
       "hrn:here:data::olp-here-test:hereos-internal-test-v2";
   const auto catalog_hrn = client::HRN::FromString(catalog);
@@ -352,10 +351,7 @@ TEST_F(ApiLookupClientImplTest, LookupApi) {
   }
 }
 
-TEST_F(ApiLookupClientImplTest, LookupApiCustomProvider) {
-  using testing::_;
-  using testing::Return;
-
+TEST_F(ApiLookupClientImplTest, CustomProvider) {
   const std::string catalog =
       "hrn:here:data::olp-here-test:hereos-internal-test-v2";
   const auto catalog_hrn = client::HRN::FromString(catalog);
@@ -393,10 +389,69 @@ TEST_F(ApiLookupClientImplTest, LookupApiCustomProvider) {
   testing::Mock::VerifyAndClearExpectations(cache_.get());
 }
 
-TEST_F(ApiLookupClientImplTest, LookupApiAsync) {
-  using testing::_;
-  using testing::Return;
+TEST_F(ApiLookupClientImplTest, CustomCatalogProvider) {
+  const std::string catalog =
+      "hrn:here:data::olp-here-test:hereos-internal-test-v2";
+  const auto catalog_hrn = client::HRN::FromString(catalog);
+  const std::string service_name = "random_service";
+  const std::string service_url = "http://random_service.com";
+  const std::string service_version = "v8";
+  const std::string provider_url = "https://some-lookup-url.com/lookup/v1";
+  const std::string static_base_url = provider_url + "/catalogs/" + catalog;
+  const std::string lookup_url =
+      "https://api-lookup.data.api.platform.here.com/lookup/v1/resources/" +
+      catalog + "/apis";
+  {
+    SCOPED_TRACE("Static url catalog");
 
+    EXPECT_CALL(*network_, Send(_, _, _, _, _)).Times(0);
+    EXPECT_CALL(*cache_, Put(_, _, _, _)).Times(0);
+
+    client::ApiLookupSettings lookup_settings;
+    lookup_settings.catalog_endpoint_provider =
+        [&provider_url](const client::HRN&) { return provider_url; };
+    settings_.api_lookup_settings = lookup_settings;
+
+    client::CancellationContext context;
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    auto response = client.LookupApi(service_name, service_version,
+                                     client::OnlineOnly, context);
+
+    EXPECT_TRUE(response.IsSuccessful());
+    EXPECT_EQ(response.GetResult().GetBaseUrl(), static_base_url);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Non-static url catalog");
+
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
+        .Times(1)
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     kResponseLookupResource));
+    EXPECT_CALL(*cache_, Put(_, _, _, _)).Times(0);
+
+    client::ApiLookupSettings lookup_settings;
+    lookup_settings.catalog_endpoint_provider = [](const client::HRN&) {
+      return "";
+    };
+    settings_.api_lookup_settings = lookup_settings;
+
+    client::CancellationContext context;
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    auto response = client.LookupApi(service_name, service_version,
+                                     client::OnlineOnly, context);
+
+    EXPECT_TRUE(response.IsSuccessful());
+    EXPECT_EQ(response.GetResult().GetBaseUrl(), kConfigBaseUrl);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+}
+
+TEST_F(ApiLookupClientImplTest, LookupApiAsync) {
   const std::string catalog =
       "hrn:here:data::olp-here-test:hereos-internal-test-v2";
   const auto catalog_hrn = client::HRN::FromString(catalog);
@@ -667,10 +722,7 @@ TEST_F(ApiLookupClientImplTest, LookupApiAsync) {
   }
 }
 
-TEST_F(ApiLookupClientImplTest, LookupApiCustomProviderAsync) {
-  using testing::_;
-  using testing::Return;
-
+TEST_F(ApiLookupClientImplTest, CustomProviderAsync) {
   const std::string catalog =
       "hrn:here:data::olp-here-test:hereos-internal-test-v2";
   const auto catalog_hrn = client::HRN::FromString(catalog);
@@ -712,6 +764,80 @@ TEST_F(ApiLookupClientImplTest, LookupApiCustomProviderAsync) {
   EXPECT_EQ(response.GetResult().GetBaseUrl(), kConfigBaseUrl);
   testing::Mock::VerifyAndClearExpectations(network_.get());
   testing::Mock::VerifyAndClearExpectations(cache_.get());
+}
+
+TEST_F(ApiLookupClientImplTest, CustomCatalogProviderAsync) {
+  const std::string catalog =
+      "hrn:here:data::olp-here-test:hereos-internal-test-v2";
+  const auto catalog_hrn = client::HRN::FromString(catalog);
+  const std::string service_name = "random_service";
+  const std::string service_url = "http://random_service.com";
+  const std::string service_version = "v8";
+  const std::string provider_url = "https://some-lookup-url.com/lookup/v1";
+  const std::string static_base_url = provider_url + "/catalogs/" + catalog;
+  const std::string lookup_url =
+      "https://api-lookup.data.api.platform.here.com/lookup/v1/resources/" +
+      catalog + "/apis";
+  {
+    SCOPED_TRACE("Static url catalog");
+
+    EXPECT_CALL(*network_, Send(_, _, _, _, _)).Times(0);
+    EXPECT_CALL(*cache_, Put(_, _, _, _)).Times(0);
+
+    client::ApiLookupSettings lookup_settings;
+    lookup_settings.catalog_endpoint_provider =
+        [&provider_url](const client::HRN&) { return provider_url; };
+    settings_.api_lookup_settings = lookup_settings;
+
+    std::promise<client::ApiLookupClient::LookupApiResponse> promise;
+    auto future = promise.get_future();
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    client.LookupApi(
+        service_name, service_version, client::OnlineOnly,
+        [&promise](client::ApiLookupClient::LookupApiResponse response) {
+          promise.set_value(std::move(response));
+        });
+
+    auto response = future.get();
+
+    EXPECT_TRUE(response.IsSuccessful());
+    EXPECT_EQ(response.GetResult().GetBaseUrl(), static_base_url);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
+
+  {
+    SCOPED_TRACE("Non-static url catalog");
+
+    EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
+        .Times(1)
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     kResponseLookupResource));
+    EXPECT_CALL(*cache_, Put(_, _, _, _)).Times(0);
+
+    client::ApiLookupSettings lookup_settings;
+    lookup_settings.catalog_endpoint_provider = [](const client::HRN&) {
+      return "";
+    };
+    settings_.api_lookup_settings = lookup_settings;
+
+    std::promise<client::ApiLookupClient::LookupApiResponse> promise;
+    auto future = promise.get_future();
+    client::ApiLookupClientImpl client(catalog_hrn, settings_);
+    client.LookupApi(
+        service_name, service_version, client::OnlineOnly,
+        [&promise](client::ApiLookupClient::LookupApiResponse response) {
+          promise.set_value(std::move(response));
+        });
+
+    auto response = future.get();
+
+    EXPECT_TRUE(response.IsSuccessful());
+    EXPECT_EQ(response.GetResult().GetBaseUrl(), kConfigBaseUrl);
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+    testing::Mock::VerifyAndClearExpectations(cache_.get());
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
Api url can be static. In such cases we can avoid lookup request and
save some time. For that purpose we are adding CatalogEndpointProvider
to ApiLookupSettings.

ApiLookupClient will try to get url using the provider from settings
instead of making api lookup request. If it can't be done, behavior
of the client is unchanged.

Also adding unit and integration test for ApiLookupClient.

Resolves: OLPEDGE-2187

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>