### PR TITLE
Allow using immutable cache from a read only partition

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -220,6 +220,8 @@ set(OLP_SDK_CACHE_SOURCES
     ./src/cache/ProtectedKeyList.h
     ./src/cache/InMemoryCache.cpp
     ./src/cache/InMemoryCache.h
+    ./src/cache/ReadOnlyEnv.cpp
+    ./src/cache/ReadOnlyEnv.h
 )
 
 set(OLP_SDK_CLIENT_SOURCES
@@ -356,7 +358,7 @@ add_library(${PROJECT_NAME} ${OLP_SDK_CORE_SOURCES} ${OLP_SDK_CORE_HEADERS})
 
 
 if (OLP_SDK_DISABLE_DEBUG_LOGGING)
-    target_compile_definitions(${PROJECT_NAME} 
+    target_compile_definitions(${PROJECT_NAME}
         PUBLIC LOGGING_DISABLE_DEBUG_LEVEL)
 endif()
 

--- a/olp-cpp-sdk-core/src/cache/DiskCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.cpp
@@ -33,6 +33,7 @@
 #include <leveldb/options.h>
 #include <leveldb/write_batch.h>
 #include "DiskCacheSizeLimitEnv.h"
+#include "ReadOnlyEnv.h"
 #include "olp/core/logging/Log.h"
 #include "olp/core/porting/make_unique.h"
 #include "olp/core/utils/Dir.h"
@@ -229,6 +230,10 @@ OpenResult DiskCache::Open(const std::string& data_path,
           settings.enforce_immediate_flush);
       open_options.env = environment_.get();
     }
+  } else {
+    environment_ = std::make_unique<ReadOnlyEnv>(leveldb::Env::Default());
+    open_options.env = environment_.get();
+    open_options.reuse_logs = true;
   }
 
   leveldb::DB* db = nullptr;

--- a/olp-cpp-sdk-core/src/cache/DiskCache.h
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.h
@@ -45,7 +45,7 @@ class DB;
 
 namespace olp {
 namespace cache {
-class DiskCacheSizeLimitEnv;
+class SizeCountingEnv;
 
 /**
  * @brief The OpenResult enum defines the result of the open() operation.
@@ -148,7 +148,7 @@ class DiskCache {
   std::string disk_cache_path_;
   std::unique_ptr<leveldb::DB> database_;
   std::unique_ptr<const leveldb::FilterPolicy> filter_policy_;
-  std::unique_ptr<DiskCacheSizeLimitEnv> environment_;
+  std::unique_ptr<SizeCountingEnv> environment_;
   std::unique_ptr<LevelDBLogger> leveldb_logger_;
   uint64_t max_size_{kSizeMax};
   bool check_crc_{false};

--- a/olp-cpp-sdk-core/src/cache/DiskCacheSizeLimitEnv.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCacheSizeLimitEnv.cpp
@@ -45,7 +45,7 @@ char PathSeparator() {
 DiskCacheSizeLimitEnv::DiskCacheSizeLimitEnv(leveldb::Env* env,
                                              const std::string& base_path,
                                              bool enforce_strict_data_save)
-    : leveldb::EnvWrapper(env),
+    : SizeCountingEnv(env),
       enforce_strict_data_save_(enforce_strict_data_save) {
   std::vector<std::string> children;
   if (target()->GetChildren(base_path, &children).ok()) {

--- a/olp-cpp-sdk-core/src/cache/ReadOnlyEnv.cpp
+++ b/olp-cpp-sdk-core/src/cache/ReadOnlyEnv.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "ReadOnlyEnv.h"
+
+namespace olp {
+namespace cache {
+namespace {
+
+class FakeWritableFile : public leveldb::WritableFile {
+ public:
+  ~FakeWritableFile() override = default;
+
+  leveldb::Status Append(const leveldb::Slice& /* data */) override {
+    return {};
+  }
+
+  leveldb::Status Close() override { return {}; }
+
+  leveldb::Status Flush() override { return {}; }
+
+  leveldb::Status Sync() override { return {}; }
+};
+
+}  // namespace
+
+ReadOnlyEnv::ReadOnlyEnv(leveldb::Env* env) : SizeCountingEnv(env) {}
+
+leveldb::Status ReadOnlyEnv::NewWritableFile(const std::string& /* f */,
+                                             leveldb::WritableFile** r) {
+  *r = new FakeWritableFile();
+  return {};
+}
+
+leveldb::Status ReadOnlyEnv::NewAppendableFile(const std::string& /* f */,
+                                               leveldb::WritableFile** r) {
+  *r = new FakeWritableFile();
+  return {};
+}
+
+leveldb::Status ReadOnlyEnv::LockFile(const std::string& /* f */,
+                                      leveldb::FileLock** /* l */) {
+  return {};
+}
+
+leveldb::Status ReadOnlyEnv::UnlockFile(leveldb::FileLock* /* l */) {
+  return {};
+}
+
+leveldb::Status ReadOnlyEnv::RenameFile(const std::string& /* s */,
+                                        const std::string& /* t */) {
+  return {};
+}
+
+}  // namespace cache
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/cache/ReadOnlyEnv.h
+++ b/olp-cpp-sdk-core/src/cache/ReadOnlyEnv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,34 +19,29 @@
 
 #pragma once
 
-#include <atomic>
-#include <cstdint>
-#include <memory>
-
 #include "SizeCountingEnv.h"
 
 namespace olp {
 namespace cache {
 
-class DiskCacheSizeLimitEnv : public SizeCountingEnv {
+class ReadOnlyEnv : public SizeCountingEnv {
  public:
   // Initialize an EnvWrapper that delegates all calls to *t
-  DiskCacheSizeLimitEnv(leveldb::Env* env, const std::string& base_path,
-                        bool enforce_strict_data_save);
-  ~DiskCacheSizeLimitEnv() override = default;
+  explicit ReadOnlyEnv(leveldb::Env* env);
+  ~ReadOnlyEnv() override = default;
 
   leveldb::Status NewWritableFile(const std::string& f,
                                   leveldb::WritableFile** r) override;
 
-  leveldb::Status DeleteFile(const std::string& f) override;
+  leveldb::Status NewAppendableFile(const std::string& f,
+                                    leveldb::WritableFile** r) override;
 
-  void AddSize(size_t size);
+  leveldb::Status LockFile(const std::string& f,
+                           leveldb::FileLock** l) override;
+  leveldb::Status UnlockFile(leveldb::FileLock* l) override;
 
-  uint64_t Size() const override;
-
- private:
-  std::atomic<uint64_t> total_size_{0};
-  bool enforce_strict_data_save_{false};
+  leveldb::Status RenameFile(const std::string& s,
+                             const std::string& t) override;
 };
 
 }  // namespace cache

--- a/olp-cpp-sdk-core/src/cache/SizeCountingEnv.h
+++ b/olp-cpp-sdk-core/src/cache/SizeCountingEnv.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <leveldb/env.h>
+
+namespace olp {
+namespace cache {
+
+class SizeCountingEnv : public leveldb::EnvWrapper {
+ public:
+  SizeCountingEnv(leveldb::Env* env) : leveldb::EnvWrapper(env) {}
+
+  virtual uint64_t Size() const { return 0; }
+};
+
+}  // namespace cache
+}  // namespace olp

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -18,6 +18,8 @@
 set(OLP_CPP_SDK_CORE_TESTS_SOURCES
     ./cache/DefaultCacheImplTest.cpp
     ./cache/DefaultCacheTest.cpp
+    ./cache/Helpers.cpp
+    ./cache/Helpers.h
     ./cache/InMemoryCacheTest.cpp
     ./cache/ProtectedKeyListTest.cpp
 

--- a/olp-cpp-sdk-core/tests/cache/Helpers.cpp
+++ b/olp-cpp-sdk-core/tests/cache/Helpers.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2019-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "Helpers.h"
+
+#if defined(_WIN32) && !defined(__MINGW32__)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <strsafe.h>
+#include <tchar.h>
+#include <windows.h>
+#include <vector>
+#else
+#include <errno.h>
+#include <ftw.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+namespace {
+#if defined(_WIN32) && !defined(__MINGW32__)
+
+bool MakeDirectoryContentReadonly(const TCHAR* utfdirPath, bool readonly) {
+  HANDLE hFind;  // file handle
+  WIN32_FIND_DATA FindFileData;
+
+  if (utfdirPath == 0 || *utfdirPath == '\0') {
+    return false;
+  }
+
+  TCHAR dirPath[MAX_PATH];
+  TCHAR filename[MAX_PATH];
+
+  StringCchCopy(dirPath, G_COUNTOF(dirPath), utfdirPath);
+  StringCchCat(dirPath, G_COUNTOF(dirPath),
+               TEXT("\\*"));  // searching all files
+  StringCchCopy(filename, G_COUNTOF(filename), utfdirPath);
+  StringCchCat(filename, G_COUNTOF(filename), TEXT("\\"));
+
+  bool bSearch = true;
+
+  hFind = FindFirstFile(dirPath, &FindFileData);  // find the first file
+  if (hFind != INVALID_HANDLE_VALUE) {
+    StringCchCopy(dirPath, G_COUNTOF(dirPath), filename);
+
+    do {
+      if ((lstrcmp(FindFileData.cFileName, TEXT(".")) == 0) ||
+          (lstrcmp(FindFileData.cFileName, TEXT("..")) == 0)) {
+        continue;
+      }
+
+      StringCchCopy(filename, G_COUNTOF(filename), dirPath);
+      StringCchCat(filename, G_COUNTOF(filename), FindFileData.cFileName);
+      if (FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+        // we have found a directory, recurse
+        if (!WalkTree(filename, callback)) {
+          bSearch = false;
+          break;
+        }
+      } else {
+        DWORD attribs = GetFileAttributes(filename);
+        if (readonly) {
+          SetFileAttributes(filename, attribs | FILE_ATTRIBUTE_READONLY);
+        } else {
+          SetFileAttributes(filename, attribs & ~FILE_ATTRIBUTE_READONLY);
+        }
+      }
+    } while (bSearch &&
+             FindNextFile(hFind, &FindFileData));  // until we finds an entry
+
+    if (bSearch) {
+      if (GetLastError() != ERROR_NO_MORE_FILES)  // no more files there
+      {
+        bSearch = false;
+      }
+    }
+
+    FindClose(hFind);  // closing file handle
+  } else {  // Because on WinCE, FindFirstFile will fail for empty folder.
+    // Other than that, we should not try to remove the directory then.
+    if (GetLastError() != ERROR_NO_MORE_FILES)  // no more files there
+    {
+      bSearch = false;
+    }
+  }
+
+  return bSearch;
+}
+
+#else
+
+static constexpr mode_t WRITE_PERMISIONS = S_IWUSR | S_IWGRP | S_IWOTH;
+
+int make_readonly_callback(const char* file, const struct stat* stat, int flag,
+                           struct FTW* /*buf*/) {
+  if (flag == FTW_F) {
+    return chmod(file, stat->st_mode & ~WRITE_PERMISIONS);
+  } else {
+    return 0;
+  }
+}
+
+int make_read_write_callback(const char* file, const struct stat* stat,
+                             int flag, struct FTW* /*buf*/) {
+  if (flag == FTW_F) {
+    return chmod(file, stat->st_mode | WRITE_PERMISIONS);
+  } else {
+    return 0;
+  }
+}
+
+#endif
+}  // namespace
+
+namespace helpers {
+bool MakeDirectoryContentReadonly(const std::string& path, bool readonly) {
+#if defined(_WIN32) && !defined(__MINGW32__)
+#ifdef _UNICODE
+  std::wstring wstrPath = ConvertStringToWideString(path);
+  const TCHAR* n_path = wstrPath.c_str();
+#else
+  const TCHAR* n_path = path.c_str();
+#endif  // _UNICODE
+
+  return MakeDirectoryContentReadonly(n_path, readonly);
+
+#else
+
+  auto callback = readonly ? make_readonly_callback : make_read_write_callback;
+  return nftw(path.c_str(), callback, 10, FTW_DEPTH | FTW_PHYS) == 0;
+
+#endif
+}
+}  // namespace helpers

--- a/olp-cpp-sdk-core/tests/cache/Helpers.h
+++ b/olp-cpp-sdk-core/tests/cache/Helpers.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2019-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+
+namespace helpers {
+/**
+ * @brief Makes directories content readonly or read-write
+ *
+ * @param path Path to the directory.
+ * @param readonly Readonly if true, read-write if false
+ *
+ * @return \c true if any file with the given path exists, \c false otherwise.
+ */
+bool MakeDirectoryContentReadonly(const std::string& path, bool readonly);
+}  // namespace helpers


### PR DESCRIPTION
It should be possible to use protected cache from a read-only partition. Level DB writes some metadata when opening existing DB. Add environment overload that does not write anything to disk but reports success.