### PR TITLE
Move cpplint to separate Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,23 @@ env:
   - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
   - SEGFAULT_SIGNALS=all
   - WORKSPACE=$TRAVIS_BUILD_DIR
-addons:
-  apt:
-    packages:
-    - libboost-all-dev
-    - libssl-dev
-    - libcurl4-openssl-dev
 matrix:
   - compiler: gcc
     cache: ccache
     env: BUILD_TYPE=COVERAGE WORKSPACE=$TRAVIS_BUILD_DIR
     name: Linux Build using gcc & tests & code coverage
-    script: $WORKSPACE/scripts/misc/cpplint_ci.sh && $WORKSPACE/scripts/linux/psv/build_psv.sh && $WORKSPACE/scripts/linux/psv/travis_test_psv.sh
+    script: $WORKSPACE/scripts/linux/psv/build_psv.sh && $WORKSPACE/scripts/linux/psv/travis_test_psv.sh
+    addons:
+        apt:
+            packages:
+            - libboost-all-dev
+            - libssl-dev
+            - libcurl4-openssl-dev
+  - language: minimal
+    name: "C++ Lint checker script"
+    script: $WORKSPACE/scripts/misc/cpplint_ci.sh
+    if: type = pull_request
 branches:
   only:
   - master
+

--- a/scripts/misc/cpplint_ci.sh
+++ b/scripts/misc/cpplint_ci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash +e
+#!/bin/bash -ex
 #
 # Copyright (C) 2020 HERE Europe B.V.
 #
@@ -31,9 +31,11 @@ else
   printf "Currently in %s branch. Running cpplint.\n" "$CURRENT_BRANCH"
 fi
 
+set +e
 # Get affected files and filter source files
 FILES=$(git diff-tree --no-commit-id --name-only -r master "$CURRENT_BRANCH" \
         | grep '\.c\|\.cpp\|\.cxx\|\.h\|\.hpp\|\.hxx')
+set -e
 
 if [ -z "$FILES" ]; then
   printf "No affected files, exiting.\n"


### PR DESCRIPTION
Now cpplint job will run in a parallel instead of consecutively.

Relates-To: OLPEDGE-1853

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>