### PR TITLE
Fix reading protected list from cache

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -758,6 +758,9 @@ std::string DefaultCacheImpl::GetExpiryKey(const std::string& key) const {
 
 bool DefaultCacheImpl::Protect(const DefaultCache::KeyListType& keys) {
   std::lock_guard<std::mutex> lock(cache_lock_);
+  if (!mutable_cache_) {
+    return false;
+  }
   auto start = std::chrono::steady_clock::now();
   auto result = protected_keys_.Protect(keys, [&](const std::string& key) {
     if (!RemoveKeyLru(key)) {
@@ -779,6 +782,9 @@ bool DefaultCacheImpl::Protect(const DefaultCache::KeyListType& keys) {
 
 bool DefaultCacheImpl::Release(const DefaultCache::KeyListType& keys) {
   std::lock_guard<std::mutex> lock(cache_lock_);
+  if (!mutable_cache_) {
+    return false;
+  }
   auto start = std::chrono::steady_clock::now();
   auto result = protected_keys_.Release(keys);
 

--- a/olp-cpp-sdk-core/src/cache/ProtectedKeyList.cpp
+++ b/olp-cpp-sdk-core/src/cache/ProtectedKeyList.cpp
@@ -29,6 +29,12 @@
 
 namespace {
 constexpr auto kLogTag = "ProtectedKeyList";
+
+class ReadBuffer : public std::basic_streambuf<char> {
+ public:
+  ReadBuffer(char* p, size_t l) { setg(p, p, p + l); }
+};
+
 }  // namespace
 
 namespace olp {
@@ -41,10 +47,9 @@ bool ProtectedKeyList::Deserialize(KeyValueCache::ValueTypePtr value) {
   if (!value) {
     return false;
   }
-  std::stringbuf string_buf;
-  string_buf.pubsetbuf(reinterpret_cast<char*>(value->data()), value->size());
 
-  std::istream stream(&string_buf);
+  ReadBuffer buf(reinterpret_cast<char*>(value->data()), value->size());
+  std::istream stream(&buf);
 
   for (std::string str; std::getline(stream, str, '\0');) {
     protected_data_.insert(str);

--- a/olp-cpp-sdk-dataservice-read/src/ProtectDependencyResolver.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ProtectDependencyResolver.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "ProtectDependencyResolver.h"
+
+#include <algorithm>
+#include <map>
+#include <string>
+#include <utility>
+
+namespace {
+constexpr auto kQuadTreeDepth = 4;
+}  // namespace
+
+namespace olp {
+namespace dataservice {
+namespace read {
+
+ProtectDependencyResolver::ProtectDependencyResolver(
+    const client::HRN& catalog, const std::string& layer_id, int64_t version,
+    const client::OlpClientSettings& settings)
+    : layer_id_(layer_id),
+      version_(version),
+      data_cache_repository_(catalog, settings.cache),
+      partitions_cache_repository_(catalog, settings.cache),
+      quad_trees_(),
+      keys_to_protect_() {}
+
+const cache::KeyValueCache::KeyListType&
+ProtectDependencyResolver::GetKeysToProtect(const TileKeys& tiles) {
+  keys_to_protect_.clear();
+  for (const auto& tile : tiles) {
+    auto it = FindQuad(tile);
+    if (it != quad_trees_.end()) {
+      // Quad tree for tile found. Get data handle for tile and add to list for
+      // protection
+      AddDataHandle(tile, it->second);
+    } else {
+      // find tile in cache
+      ProcessTileKeyInCache(tile);
+    }
+  }
+  return keys_to_protect_;
+}
+
+ProtectDependencyResolver::QuadsType::iterator
+ProtectDependencyResolver::FindQuad(const geo::TileKey& tile_key) {
+  auto max_depth = std::min<std::int32_t>(tile_key.Level(), kQuadTreeDepth);
+  for (auto i = max_depth; i >= 0; --i) {
+    const auto& quad_root = tile_key.ChangedLevelBy(-i);
+    auto it = quad_trees_.find(quad_root);
+    if (it != quad_trees_.end()) {
+      return it;
+    }
+  }
+  return quad_trees_.end();
+}
+
+bool ProtectDependencyResolver::AddDataHandle(
+    const geo::TileKey& tile, const read::QuadTreeIndex& quad_tree) {
+  auto data = quad_tree.Find(tile, false);
+  if (data) {
+    keys_to_protect_.emplace_back(
+        data_cache_repository_.CreateKey(layer_id_, data->data_handle));
+    return true;
+  }
+  return false;
+}
+
+bool ProtectDependencyResolver::ProcessTileKeyInCache(
+    const geo::TileKey& tile) {
+  read::QuadTreeIndex cached_tree;
+  if (partitions_cache_repository_.FindQuadTree(layer_id_, version_, tile,
+                                                cached_tree) &&
+      AddDataHandle(tile, cached_tree)) {
+    auto root_tile = cached_tree.GetRootTile();
+    // add quad tree to list for protection
+    keys_to_protect_.emplace_back(partitions_cache_repository_.CreateQuadKey(
+        layer_id_, root_tile, kQuadTreeDepth, version_));
+    // save quad tree, because  there is could be more tiles to protect from
+    // this quad
+    quad_trees_[root_tile] = std::move(cached_tree);
+    return true;
+  }
+  return false;
+}
+
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/ProtectDependencyResolver.h
+++ b/olp-cpp-sdk-dataservice-read/src/ProtectDependencyResolver.h
@@ -35,39 +35,35 @@ namespace olp {
 namespace dataservice {
 namespace read {
 
-/// group quad trees and protected tiles. Check if for each quad tree we want
-/// to release all protected keys associated, if true add this quad tree to
-/// released keys
-class ReleaseDependencyResolver {
+/// Find quad trees for protected tiles. Add quad tree to list for protection.
+/// Save downloaded quads for future searches for tiles to protect, if quad tree
+/// not found look it to the cache.
+class ProtectDependencyResolver {
  public:
-  ReleaseDependencyResolver(const client::HRN& catalog,
+  ProtectDependencyResolver(const client::HRN& catalog,
                             const std::string& layer_id, int64_t version,
                             const client::OlpClientSettings& settings);
 
-  const cache::KeyValueCache::KeyListType& GetKeysToRelease(
+  const cache::KeyValueCache::KeyListType& GetKeysToProtect(
       const TileKeys& tiles);
 
  private:
-  using TilesDataKeysType = std::map<geo::TileKey, std::string>;
-  using QuadsType = std::map<geo::TileKey, TilesDataKeysType>;
-
-  bool ProcessTileKey(const geo::TileKey& tile_key);
+  using QuadsType = std::map<geo::TileKey, read::QuadTreeIndex>;
 
   QuadsType::iterator FindQuad(const geo::TileKey& tile_key);
 
-  TilesDataKeysType ProcessQuad(const read::QuadTreeIndex& cached_tree,
-                                const geo::TileKey& tile);
+  bool AddDataHandle(const geo::TileKey& tile,
+                     const read::QuadTreeIndex& quad_tree);
 
-  void ProcessTileKeyInCache(const geo::TileKey& tile);
+  bool ProcessTileKeyInCache(const geo::TileKey& tile);
 
  private:
   const std::string& layer_id_;
   const int64_t version_;
-  std::shared_ptr<cache::KeyValueCache> cache_;
   repository::DataCacheRepository data_cache_repository_;
   repository::PartitionsCacheRepository partitions_cache_repository_;
-  QuadsType quad_trees_with_protected_tiles_;
-  cache::KeyValueCache::KeyListType keys_to_release_;
+  std::map<geo::TileKey, read::QuadTreeIndex> quad_trees_;
+  cache::KeyValueCache::KeyListType keys_to_protect_;
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/ReleaseDependencyResolver.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ReleaseDependencyResolver.cpp
@@ -33,8 +33,8 @@ namespace dataservice {
 namespace read {
 
 ReleaseDependencyResolver::ReleaseDependencyResolver(
-    const client::HRN& catalog, const std::string& layer_id,
-    const int64_t& version, const client::OlpClientSettings& settings)
+    const client::HRN& catalog, const std::string& layer_id, int64_t version,
+    const client::OlpClientSettings& settings)
     : layer_id_(layer_id),
       version_(version),
       cache_(settings.cache),

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -34,6 +34,7 @@
 #include <olp/dataservice/read/CatalogVersionRequest.h>
 #include "Common.h"
 #include "PrefetchJob.h"
+#include "ProtectDependencyResolver.h"
 #include "ReleaseDependencyResolver.h"
 #include "generated/api/QueryApi.h"
 #include "repositories/CatalogRepository.h"
@@ -622,51 +623,11 @@ bool VersionedLayerClientImpl::Protect(const TileKeys& tiles) {
     return false;
   }
   auto version = catalog_version_.load();
-  // could protect keys, which is already in cache
-  // because we don't know quad tree which will contain tiles
-  repository::DataCacheRepository data_cache_repository(catalog_,
-                                                        settings_.cache);
-  repository::PartitionsCacheRepository partitions_cache_repository(
-      catalog_, settings_.cache);
 
-  cache::KeyValueCache::KeyListType keys_to_protect;
-  keys_to_protect.reserve(tiles.size() * 2);
-  auto add_data_handle = [&](const geo::TileKey& tile,
-                             const read::QuadTreeIndex& quad_tree) {
-    auto data = quad_tree.Find(tile, false);
-    if (data) {
-      keys_to_protect.emplace_back(
-          data_cache_repository.CreateKey(layer_id_, data->data_handle));
-      return true;
-    }
-    return false;
-  };
-
-  std::vector<read::QuadTreeIndex> quad_trees;
-  quad_trees.reserve(tiles.size());
-  for (const auto& tile : tiles) {
-    auto it =
-        std::find_if(quad_trees.begin(), quad_trees.end(),
-                     [&tile](const read::QuadTreeIndex& quad) {
-                       auto root = quad.GetRootTile();
-                       return (tile.Level() >= root.Level() &&
-                               tile.Level() - root.Level() <= kQuadTreeDepth &&
-                               root.IsParentOf(tile));
-                     });
-
-    if (it != quad_trees.end()) {
-      add_data_handle(tile, *it);
-    } else {
-      read::QuadTreeIndex cached_tree;
-      if (partitions_cache_repository.FindQuadTree(layer_id_, version, tile,
-                                                   cached_tree) &&
-          add_data_handle(tile, cached_tree)) {
-        keys_to_protect.emplace_back(partitions_cache_repository.CreateQuadKey(
-            layer_id_, cached_tree.GetRootTile(), kQuadTreeDepth, version));
-        quad_trees.emplace_back(std::move(cached_tree));
-      }
-    }
-  }
+  auto tiles_dependency_resolver =
+      ProtectDependencyResolver(catalog_, layer_id_, version, settings_);
+  const auto& keys_to_protect =
+      tiles_dependency_resolver.GetKeysToProtect(tiles);
 
   if (keys_to_protect.empty()) {
     return false;


### PR DESCRIPTION
pubsetbuf is dependent on the library implementation,
so setting buffer for istream changed.
Move Protect implementation from VersionedLayerClient
to ProtectDependencyResolver.
Add tests for cache to check that Protect/Release works
only with mutable cache.

Relates-To: OLPEDGE-2034

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>