### PR TITLE
Minimize quad trees requests for prefetch

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/ReleaseDependencyResolver.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ReleaseDependencyResolver.cpp
@@ -55,29 +55,29 @@ ReleaseDependencyResolver::GetKeysToRelease(const TileKeys& tiles) {
 void ReleaseDependencyResolver::ProcessTileKey(const geo::TileKey& tile_key) {
   bool add_key = true;
   auto process_tile = [&](const geo::TileKey& quad_root,
-                          const geo::TileKey& tile_key) {
+                          const geo::TileKey& tile) {
     auto it = quad_trees_with_protected_tiles_.find(quad_root);
     if (it != quad_trees_with_protected_tiles_.end()) {
       // Quad tree for tile found. Get data handle for tile and add to list
       // to release
-      auto tile_it = it->second.find(tile_key);
+      auto tile_it = it->second.find(tile);
       // if tile_key_to_release was not found, this means it is not
       // protected
-      if (tile_it != it->second.end()) {
-        if (add_key) {
-          keys_to_release_.emplace_back(tile_it->second);
-          add_key = false;
-        }
-        // key added, we can remove this tile from map
-        it->second.erase(tile_it);
-        if (it->second.empty()) {
-          // no more protected tiles associated with this quad tree
-          // can add key for quad tree to be released and remove from map
-          keys_to_release_.emplace_back(
-              partitions_cache_repository_.CreateQuadKey(
-                  layer_id_, it->first, kQuadTreeDepth, version_));
-          quad_trees_with_protected_tiles_.erase(it);
-        }
+      if (tile_it == it->second.end()) {
+        return true;
+      }
+      if (add_key) {
+        keys_to_release_.emplace_back(tile_it->second);
+        add_key = false;
+      }
+      // key added, we can remove this tile from map
+      it->second.erase(tile_it);
+      if (it->second.empty()) {
+        // no more protected tiles associated with this quad tree
+        // can add key for quad tree to be released and remove from map
+        keys_to_release_.emplace_back(
+            partitions_cache_repository_.CreateQuadKey(
+                layer_id_, it->first, kQuadTreeDepth, version_));
       }
       return true;
     }

--- a/olp-cpp-sdk-dataservice-read/src/ReleaseDependencyResolver.h
+++ b/olp-cpp-sdk-dataservice-read/src/ReleaseDependencyResolver.h
@@ -51,14 +51,14 @@ class ReleaseDependencyResolver {
   using TilesDataKeysType = std::map<geo::TileKey, std::string>;
   using QuadsType = std::map<geo::TileKey, TilesDataKeysType>;
 
-  bool ProcessTileKey(const geo::TileKey& tile_key);
+  void ProcessTileKey(const geo::TileKey& tile_key);
 
-  QuadsType::iterator FindQuad(const geo::TileKey& tile_key);
+  TilesDataKeysType CheckProtectedTilesInQuad(const read::QuadTreeIndex& cached_tree,
+                                const geo::TileKey& tile,
+                                bool& add_data_handle_key);
 
-  TilesDataKeysType ProcessQuad(const read::QuadTreeIndex& cached_tree,
-                                const geo::TileKey& tile);
-
-  void ProcessTileKeyInCache(const geo::TileKey& tile);
+  void ProcessQuadTreeCache(const geo::TileKey& root, const geo::TileKey& tile,
+                            bool& add_data_handle_key);
 
  private:
   const std::string& layer_id_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -126,10 +126,10 @@ RootTilesForRequest PrefetchTilesRepository::GetSlicedTiles(
       if (min_level > levels_up) {
         min_level = min_level - levels_up;
       } else {
-        // if min_level is less than steps we need to go up, go some steps down
-        auto levels_down = levels_up - min_level;
+        // if min_level is less than steps we need to go up, set min level to
+        // zero. Some quads will overlap, but we will minimize quad tree
+        // requests
         min_level = 0u;
-        max_level = max_level + levels_down;
       }
     }
 
@@ -173,11 +173,11 @@ SubTilesResponse PrefetchTilesRepository::GetSubTiles(
     }
 
     auto& tile = quad.first;
-    auto& depth = quad.second;
-    auto response =
-        version ? GetSubQuads(layer_id, request, version.get(), tile, depth,
-                              context)
-                : GetVolatileSubQuads(layer_id, request, tile, depth, context);
+    auto response = version
+                        ? GetSubQuads(layer_id, request, version.get(), tile,
+                                      kMaxQuadTreeIndexDepth, context)
+                        : GetVolatileSubQuads(layer_id, request, tile,
+                                              kMaxQuadTreeIndexDepth, context);
 
     if (!response.IsSuccessful()) {
       // Just abort if something else then 404 Not Found is returned

--- a/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
@@ -137,7 +137,6 @@ TEST(PrefetchRepositoryTest, GetSlicedTilesWithLevelsSpecified) {
     // 1 tile on each level
     ASSERT_EQ(root_tiles_depth.size(), 3);
   }
-  return;
   {
     SCOPED_TRACE(
         "Get sliced tiles with min level greater than requested root tile "
@@ -242,23 +241,21 @@ TEST(PrefetchRepositoryTest, GetSlicedTilesSiblings) {
 }
 
 TEST(PrefetchRepositoryTest, GetSlicedTilesLowLevels) {
-  auto tile1 = olp::geo::TileKey::FromHereTile("23618366");
+  auto tile = olp::geo::TileKey::FromHereTile("23618366");
   {
-    SCOPED_TRACE(
-        "Get sliced tiles with min/max levels less than requested tiles "
-        "levels");
-    auto root = tile1.ChangedLevelTo(0);
+    SCOPED_TRACE("Get sliced tiles with levels 1, 6, tile level 12");
+    auto root = tile.ChangedLevelTo(0);
 
     PrefetchRepositoryTestable repository;
-    auto root_tiles_depth = repository.GetSlicedTiles({tile1}, 1, 6);
+    auto root_tiles_depth = repository.GetSlicedTiles({tile}, 1, 6);
     ASSERT_EQ(root_tiles_depth.size(), 2);
     ASSERT_EQ(root_tiles_depth.begin()->first, root);
-    ASSERT_EQ((++root_tiles_depth.begin())->first, tile1.ChangedLevelTo(2));
+    ASSERT_EQ((++root_tiles_depth.begin())->first, tile.ChangedLevelTo(2));
     ASSERT_EQ(root_tiles_depth.begin()->second, 1);
   }
   {
     SCOPED_TRACE("Get sliced tiles with 1,6 levels");
-    auto root = tile1.ChangedLevelTo(0);
+    auto root = tile.ChangedLevelTo(0);
 
     PrefetchRepositoryTestable repository;
     auto root_tiles_depth = repository.GetSlicedTiles({root}, 1, 6);
@@ -271,7 +268,7 @@ TEST(PrefetchRepositoryTest, GetSlicedTilesLowLevels) {
   }
   {
     SCOPED_TRACE("Get sliced tiles with 0, 4 levels");
-    auto root = tile1.ChangedLevelTo(0);
+    auto root = tile.ChangedLevelTo(0);
 
     PrefetchRepositoryTestable repository;
     auto root_tiles_depth = repository.GetSlicedTiles({root}, 0, 4);
@@ -281,7 +278,7 @@ TEST(PrefetchRepositoryTest, GetSlicedTilesLowLevels) {
   }
   {
     SCOPED_TRACE("Get sliced tiles with 0, 5 levels");
-    auto root = tile1.ChangedLevelTo(0);
+    auto root = tile.ChangedLevelTo(0);
 
     PrefetchRepositoryTestable repository;
     auto root_tiles_depth = repository.GetSlicedTiles({root}, 0, 5);


### PR DESCRIPTION
While prefetching quad trees we need to slice
tiles for requests from max level to min level
with predefined depth 4. In case if min level
allows to go up, we will request quad tree on
minimum possible level with depth 4. When min
level is to low we will start from 0 level, but
should continue slicing considering max level
and go up.
Changes related to not changing max level,
that we always have minimum requests, even if
some quads overlap.

Relates-To: OLPEDGE-2225
Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>