### PR TITLE
Adapt TaskContext to other types of response

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/TaskContext.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/TaskContext.h
@@ -25,7 +25,6 @@
 #include <utility>
 
 #include <olp/core/client/ApiError.h>
-#include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/Condition.h>
@@ -122,7 +121,7 @@ class CORE_API TaskContext {
    */
   void SetExecutors(Exec execute_func, Callback callback,
                     client::CancellationContext context) {
-    impl_ = std::make_shared<TaskContextImpl<typename ExecResult::ResultType>>(
+    impl_ = std::make_shared<TaskContextImpl<ExecResult>>(
         std::move(execute_func), std::move(callback), std::move(context));
   }
 
@@ -167,11 +166,9 @@ class CORE_API TaskContext {
    *
    * @tparam T The result type.
    */
-  template <typename T>
+  template <typename Response>
   class TaskContextImpl : public Impl {
    public:
-    /// Wraps the `T` typename in the API response.
-    using Response = client::ApiResponse<T, client::ApiError>;
     /// The task that produces the `Response` instance.
     using ExecuteFunc = std::function<Response(client::CancellationContext)>;
     /// Consumes the `Response` instance.

--- a/olp-cpp-sdk-core/tests/client/TaskContextTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/TaskContextTest.cpp
@@ -20,14 +20,21 @@
 #include <olp/core/client/TaskContext.h>
 
 #include <gtest/gtest.h>
+#include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/Condition.h>
 
 namespace {
 
-using namespace olp::client;
+namespace client = olp::client;
+using client::ApiError;
+using client::CancellationContext;
+using client::CancellationToken;
+using client::Condition;
+using client::ErrorCode;
+using client::TaskContext;
 
 using ResponseType = std::string;
-using Response = ApiResponse<ResponseType, ApiError>;
+using Response = client::ApiResponse<ResponseType, client::ApiError>;
 using ExecuteFunc = std::function<Response(CancellationContext)>;
 using Callback = std::function<void(Response)>;
 
@@ -52,9 +59,8 @@ class TaskContextTestable : public TaskContext {
                 Exec(olp::client::CancellationContext)>::type>
   void SetExecutors(Exec execute_func, Callback callback,
                     CancellationContext context) {
-    auto impl =
-        std::make_shared<TaskContextImpl<typename ExecResult::ResultType>>(
-            std::move(execute_func), std::move(callback), std::move(context));
+    auto impl = std::make_shared<TaskContextImpl<ExecResult>>(
+        std::move(execute_func), std::move(callback), std::move(context));
     notify = [=]() { impl->condition_.Notify(); };
     impl_ = impl;
   }

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -293,29 +293,30 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
               const auto& handle = sub_quad.second;
               const auto& biling_tag = request.GetBillingTag();
 
+              using PrefetchDataResponse = BlobApi::DataResponse;
+
               AddTask(settings.task_scheduler, pending_requests,
-                      [=](CancellationContext inner_context) -> EmptyResponse {
+                      [=](CancellationContext inner_context)
+                          -> PrefetchDataResponse {
                         if (handle.empty()) {
-                          prefetch_job->CompleteTask(
-                              tile, {client::ErrorCode::NotFound, "Not found"});
-                          return PrefetchTileNoError{};
+                          return {{client::ErrorCode::NotFound, "Not found"}};
                         }
                         repository::DataCacheRepository data_cache_repository(
                             catalog, shared_settings->cache);
                         if (data_cache_repository.IsCached(layer_id, handle)) {
-                          prefetch_job->CompleteTask(tile);
-                          return PrefetchTileNoError{};
+                          return {nullptr};
                         }
 
                         // Fetch from online
                         repository::DataRepository repository(
                             catalog, *shared_settings, lookup_client);
-                        auto result = repository.GetVersionedData(
+                        return repository.GetVersionedData(
                             layer_id,
                             DataRequest().WithDataHandle(handle).WithBillingTag(
                                 biling_tag),
                             version, inner_context);
-
+                      },
+                      [=](PrefetchDataResponse result) {
                         if (result.IsSuccessful()) {
                           prefetch_job->CompleteTask(
                               tile, GetNetworkStatistics(result));
@@ -324,9 +325,8 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
                               tile, result.GetError(),
                               GetNetworkStatistics(result));
                         }
-                        return PrefetchTileNoError{};
                       },
-                      [=](EmptyResponse) {}, prefetch_job->AddTask());
+                      prefetch_job->AddTask());
             });
 
         context.ExecuteOrCancelled([&]() {


### PR DESCRIPTION
This allows us to use different types of return types, for example to
use ExtendedApiResponse as the output of task Exec function.
Adapt prefetch code to use task result, instead of multiple returns.

Relates-To: OLPEDGE-2169

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>
