### PR TITLE
Fix windows build

### DIFF
--- a/olp-cpp-sdk-core/tests/cache/Helpers.cpp
+++ b/olp-cpp-sdk-core/tests/cache/Helpers.cpp
@@ -23,6 +23,7 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
+#include <stdlib.h>
 #include <strsafe.h>
 #include <tchar.h>
 #include <windows.h>
@@ -49,17 +50,17 @@ bool MakeDirectoryContentReadonly(const TCHAR* utfdirPath, bool readonly) {
   TCHAR dirPath[MAX_PATH];
   TCHAR filename[MAX_PATH];
 
-  StringCchCopy(dirPath, G_COUNTOF(dirPath), utfdirPath);
-  StringCchCat(dirPath, G_COUNTOF(dirPath),
+  StringCchCopy(dirPath, _countof(dirPath), utfdirPath);
+  StringCchCat(dirPath, _countof(dirPath),
                TEXT("\\*"));  // searching all files
-  StringCchCopy(filename, G_COUNTOF(filename), utfdirPath);
-  StringCchCat(filename, G_COUNTOF(filename), TEXT("\\"));
+  StringCchCopy(filename, _countof(filename), utfdirPath);
+  StringCchCat(filename, _countof(filename), TEXT("\\"));
 
   bool bSearch = true;
 
   hFind = FindFirstFile(dirPath, &FindFileData);  // find the first file
   if (hFind != INVALID_HANDLE_VALUE) {
-    StringCchCopy(dirPath, G_COUNTOF(dirPath), filename);
+    StringCchCopy(dirPath, _countof(dirPath), filename);
 
     do {
       if ((lstrcmp(FindFileData.cFileName, TEXT(".")) == 0) ||
@@ -67,11 +68,11 @@ bool MakeDirectoryContentReadonly(const TCHAR* utfdirPath, bool readonly) {
         continue;
       }
 
-      StringCchCopy(filename, G_COUNTOF(filename), dirPath);
-      StringCchCat(filename, G_COUNTOF(filename), FindFileData.cFileName);
+      StringCchCopy(filename, _countof(filename), dirPath);
+      StringCchCat(filename, _countof(filename), FindFileData.cFileName);
       if (FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
         // we have found a directory, recurse
-        if (!WalkTree(filename, callback)) {
+        if (!MakeDirectoryContentReadonly(filename, readonly)) {
           bSearch = false;
           break;
         }

--- a/scripts/windows/build.sh
+++ b/scripts/windows/build.sh
@@ -21,6 +21,5 @@
 [[ -d "build" ]] && rm -rf build
 mkdir build && cd build
 cmake .. -G "Visual Studio 15 2017 Win64" \
-        -DOLP_SDK_ENABLE_TESTING=NO \
         -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 cmake --build . --config $BUILD_TYPE


### PR DESCRIPTION
Fix broken windows build for Core unittests.
Enable test build on windows.

Resolves: OLPEDGE-2228

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>