### PR TITLE
Setup for network fv tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ if(OLP_SDK_ENABLE_TESTING)
     # Add tests
     add_subdirectory(tests/common)
     add_subdirectory(tests/functional)
+    add_subdirectory(tests/functional/network)
     add_subdirectory(tests/integration)
     add_subdirectory(tests/performance)
 endif()

--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-network-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-network-test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -ex
+#
+# Copyright (C) 2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+# For core dump backtrace
+ulimit -c unlimited
+
+echo ">>> Starting Mock Server... >>>"
+pushd tests/utils/mock-server
+npm install
+node server.js & export SERVER_PID=$!
+popd
+
+# Node can start server in 1 second, but not faster.
+# Add waiter for server to be started. No other way to solve that.
+# Curl returns code 1 - means server still down. Curl returns 0 when server is up
+RC=1
+while [[ ${RC} -ne 0 ]];
+do
+        set +e
+        curl -s http://localhost:1080
+        RC=$?
+        sleep 0.2
+        set -e
+done
+
+echo ">>> Installing mock server SSL certificate into OS... >>>"
+curl https://raw.githubusercontent.com/mock-server/mockserver/master/mockserver-core/src/main/resources/org/mockserver/socket/CertificateAuthorityCertificate.pem --output mock-server-cert.pem
+mv mock-server-cert.pem /usr/share/ca-certificates/
+echo "mock-server-cert.pem" >> /etc/ca-certificates.conf
+update-ca-certificates
+
+echo ">>> Start network tests ... >>>"
+$REPO_HOME/build/tests/functional/network/olp-cpp-sdk-functional-network-tests  \
+    --gtest_output="xml:$REPO_HOME/reports/olp-functional-network-test-report.xml"
+echo ">>> Finished network tests >>>"
+
+# Terminate the mock server
+kill -TERM $SERVER_PID
+
+wait

--- a/tests/functional/network/CMakeLists.txt
+++ b/tests/functional/network/CMakeLists.txt
@@ -1,0 +1,76 @@
+# Copyright (C) 2019 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+
+set(OLP_SDK_NETWORK_TESTS_SOURCES
+    ./NetworkTestBase.cpp
+)
+
+set(OLP_SDK_NETWORK_TESTS_HEADERS
+    ./NetworkTestBase.h
+)
+
+if (ANDROID OR IOS)
+    set(OLP_SDK_NETWORK_TESTS_LIB olp-cpp-sdk-functional-network-tests-lib)
+
+    add_library(${OLP_SDK_NETWORK_TESTS_LIB}
+        ${OLP_SDK_NETWORK_TESTS_SOURCES}
+        ${OLP_SDK_NETWORK_TESTS_HEADERS})
+    target_include_directories(${OLP_SDK_NETWORK_TESTS_LIB}
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/tests/utils/mock-server-client/
+            utils
+    )
+    target_link_libraries(${OLP_SDK_NETWORK_TESTS_LIB}
+        PRIVATE
+            custom-params
+            gtest
+            olp-cpp-sdk-tests-common
+            olp-cpp-sdk-core
+    )
+    if (ANDROID)
+        include(${CMAKE_SOURCE_DIR}/cmake/android/gen_android_test.cmake)
+        gen_android_test_runner(olp-cpp-sdk-functional-network-tests
+            ${OLP_SDK_NETWORK_TESTS_LIB})
+        add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/android
+            ${CMAKE_CURRENT_BINARY_DIR}/android)
+
+    else()
+        include(${CMAKE_SOURCE_DIR}/cmake/ios/gen_ios_test.cmake)
+        gen_ios_test_runner(olp-cpp-sdk-functional-network-tests ${OLP_SDK_NETWORK_TESTS_LIB})
+        add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/ios
+            ${CMAKE_CURRENT_BINARY_DIR}/ios)
+
+    endif()
+
+else()
+    add_executable(olp-cpp-sdk-functional-network-tests
+        ${OLP_SDK_NETWORK_TESTS_SOURCES}
+        ${OLP_SDK_NETWORK_TESTS_HEADERS})
+    target_include_directories(olp-cpp-sdk-functional-network-tests
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/tests/utils/mock-server-client/
+        utils
+    )
+    target_link_libraries(olp-cpp-sdk-functional-network-tests
+        PRIVATE
+            custom-params
+            gtest_main
+            olp-cpp-sdk-tests-common
+            olp-cpp-sdk-core
+    )
+endif()

--- a/tests/functional/network/NetworkTestBase.cpp
+++ b/tests/functional/network/NetworkTestBase.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+#include "NetworkTestBase.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/http/Network.h>
+#include <olp/core/http/NetworkSettings.h>
+
+void NetworkTestBase::SetUp() {
+  auto proxy_settings =
+      olp::http::NetworkProxySettings()
+          .WithHostname("localhost")
+          .WithPort(1080)
+          .WithUsername("test_user")
+          .WithPassword("test_password")
+          .WithType(olp::http::NetworkProxySettings::Type::HTTP);
+
+  settings_ = olp::http::NetworkSettings().WithProxySettings(proxy_settings);
+  network_ = olp::client::OlpClientSettingsFactory::
+      CreateDefaultNetworkRequestHandler();
+}

--- a/tests/functional/network/NetworkTestBase.h
+++ b/tests/functional/network/NetworkTestBase.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include <olp/core/http/Network.h>
+#include <olp/core/http/NetworkSettings.h>
+
+class NetworkTestBase : public ::testing::Test {
+  void SetUp() override;
+
+ protected:
+  std::shared_ptr<olp::http::Network> network_;
+  olp::http::NetworkSettings settings_;
+};


### PR DESCRIPTION
We are going to add bunch of functional network tests. Mock server
will help to simulate corner test cases. Added script will be used to
launch test and server separately from other fv tests.

Resolves: OLPEDGE-2211

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>