### PR TITLE
Prefetch improvement, split the requests to tasks

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/PrefetchJob.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/PrefetchJob.cpp
@@ -22,8 +22,13 @@
 #include <olp/core/logging/Log.h>
 #include <olp/dataservice/read/PrefetchTileResult.h>
 
+#include "Common.h"
+#include "ExtendedApiResponseHelpers.h"
+
 namespace {
 constexpr auto kLogTag = "PrefetchJob";
+
+using VectorOfTokens = std::vector<olp::client::CancellationToken>;
 
 size_t GetAccumulatedBytes(const olp::client::NetworkStatistics& statistics) {
   // This narrow cast is necessary to avoid narrowing compiler errors like
@@ -33,88 +38,207 @@ size_t GetAccumulatedBytes(const olp::client::NetworkStatistics& statistics) {
   return static_cast<size_t>(bytes_transferred &
                              std::numeric_limits<size_t>::max());
 }
+
+olp::client::CancellationToken CreateToken(VectorOfTokens tokens) {
+  return olp::client::CancellationToken(std::bind(
+      [](const VectorOfTokens& tokens) {
+        std::for_each(std::begin(tokens), std::end(tokens),
+                      [](const olp::client::CancellationToken& token) {
+                        token.Cancel();
+                      });
+      },
+      std::move(tokens)));
+}
+
 }  // namespace
 
 namespace olp {
 namespace dataservice {
 namespace read {
 
-PrefetchJob::PrefetchJob(PrefetchTilesResponseCallback user_callback,
-                         PrefetchStatusCallback status_callback,
-                         uint32_t task_count,
-                         client::NetworkStatistics initial_network_statistics)
-    : user_callback_(std::move(user_callback)),
-      status_callback_(std::move(status_callback)),
-      task_count_{task_count},
-      total_task_count_{task_count},
-      canceled_{false},
-      accumulated_statistics_{initial_network_statistics} {
-  tasks_contexts_.reserve(task_count_);
-  prefetch_result_.reserve(task_count_);
+DownloadTilesJob::DownloadTilesJob(DownloadFunc download,
+                                   PrefetchTilesResponseCallback user_callback,
+                                   PrefetchStatusCallback status_callback)
+    : download_(std::move(download)),
+      user_callback_(std::move(user_callback)),
+      status_callback_(std::move(status_callback)) {}
+
+void DownloadTilesJob::Initialize(size_t tiles_count,
+                                  client::NetworkStatistics statistics) {
+  download_task_count_ = total_download_task_count_ = tiles_count;
+  accumulated_statistics_ = statistics;
 }
 
-PrefetchJob::~PrefetchJob() = default;
+ExtendedDataResponse DownloadTilesJob::Download(
+    const std::string& data_handle, client::CancellationContext context) {
+  return download_(data_handle, context);
+}
 
-client::CancellationContext PrefetchJob::AddTask() {
+void DownloadTilesJob::CompleteTile(geo::TileKey tile,
+                                    ExtendedDataResponse response) {
   std::lock_guard<std::mutex> lock(mutex_);
-  tasks_contexts_.emplace_back();
-  return tasks_contexts_.back();
-}
+  accumulated_statistics_ += GetNetworkStatistics(response);
 
-void PrefetchJob::CompleteTask(geo::TileKey tile) {
-  CompleteTask(tile, client::NetworkStatistics{});
-}
-
-void PrefetchJob::CompleteTask(geo::TileKey tile,
-                               const client::ApiError& error) {
-  CompleteTask(tile, error, {});
-}
-
-void PrefetchJob::CompleteTask(geo::TileKey tile,
-                               client::NetworkStatistics statistics) {
-  CompleteTask(
-      std::make_shared<PrefetchTileResult>(tile, PrefetchTileNoError()),
-      statistics);
-}
-
-void PrefetchJob::CompleteTask(geo::TileKey tile, const client::ApiError& error,
-                               client::NetworkStatistics statistics) {
-  CompleteTask(std::make_shared<PrefetchTileResult>(tile, error), statistics);
-}
-
-void PrefetchJob::CancelOperation() {
-  std::lock_guard<std::mutex> lock(mutex_);
-  canceled_ = true;
-
-  for (auto& context : tasks_contexts_) {
-    context.CancelOperation();
+  if (response.IsSuccessful()) {
+    prefetch_result_.push_back(
+        std::make_shared<PrefetchTileResult>(tile, PrefetchTileNoError()));
+    requests_succeeded_++;
+  } else {
+    prefetch_result_.push_back(
+        std::make_shared<PrefetchTileResult>(tile, response.GetError()));
+    requests_failed_++;
   }
-}
-
-void PrefetchJob::CompleteTask(std::shared_ptr<PrefetchTileResult> result,
-                               client::NetworkStatistics statistics) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  prefetch_result_.push_back(std::move(result));
-
-  accumulated_statistics_ += statistics;
 
   if (status_callback_) {
     status_callback_(
-        PrefetchStatus{prefetch_result_.size(), total_task_count_,
+        PrefetchStatus{prefetch_result_.size(), total_download_task_count_,
                        GetAccumulatedBytes(accumulated_statistics_)});
   }
 
-  if (!--task_count_) {
-    OLP_SDK_LOG_INFO_F(kLogTag, "Prefetch done, tiles=%zu",
-                       prefetch_result_.size());
+  if (!--download_task_count_) {
+    OLP_SDK_LOG_DEBUG_F(kLogTag, "Download complete, succeeded=%zu, failed=%zu",
+                        requests_succeeded_, requests_failed_);
 
-    PrefetchTilesResponseCallback user_callback = std::move(user_callback_);
-    if (canceled_) {
-      user_callback({{client::ErrorCode::Cancelled, "Cancelled"}});
+    OnPrefetchCompleted(std::move(prefetch_result_));
+  }
+}
+
+void DownloadTilesJob::OnPrefetchCompleted(PrefetchTilesResponse result) {
+  auto prefetch_callback = std::move(user_callback_);
+  prefetch_callback(std::move(result));
+}
+
+///////////////////////////////////////////////////////////////////////////////////
+
+QueryMetadataJob::QueryMetadataJob(
+    QueryFunc query, FilterFunc filter,
+    std::shared_ptr<DownloadTilesJob> download_job,
+    std::shared_ptr<thread::TaskScheduler> task_scheduler,
+    std::shared_ptr<client::PendingRequests> pending_requests,
+    client::CancellationContext execution_context)
+    : query_(std::move(query)),
+      filter_(std::move(filter)),
+      download_job_(std::move(download_job)),
+      task_scheduler_(std::move(task_scheduler)),
+      pending_requests_(std::move(pending_requests)),
+      execution_context_(execution_context) {}
+
+void QueryMetadataJob::Initialize(size_t query_count) {
+  query_count_ = query_count;
+}
+
+QueryResponse QueryMetadataJob::Query(geo::TileKey root,
+                                      client::CancellationContext context) {
+  return query_(root, context);
+}
+
+void QueryMetadataJob::CompleteQuery(QueryResponse response) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  accumulated_statistics_ += GetNetworkStatistics(response);
+
+  if (response.IsSuccessful()) {
+    auto tiles = response.MoveResult();
+    query_result_.insert(std::make_move_iterator(tiles.begin()),
+                         std::make_move_iterator(tiles.end()));
+  } else {
+    const auto& error = response.GetError();
+    if (error.GetErrorCode() == client::ErrorCode::Cancelled) {
+      canceled_ = true;
     } else {
-      user_callback(std::move(prefetch_result_));
+      // The old behavior: when one of the query requests fails, we fail the
+      // entire prefetch.
+      query_error_ = error;
     }
   }
+
+  if (!--query_count_) {
+    if (query_error_) {
+      download_job_->OnPrefetchCompleted(query_error_.value());
+      return;
+    }
+
+    if (canceled_) {
+      download_job_->OnPrefetchCompleted(
+          {{client::ErrorCode::Cancelled, "Cancelled"}});
+      return;
+    }
+
+    if (filter_) {
+      query_result_ = filter_(std::move(query_result_));
+    }
+
+    if (query_result_.empty()) {
+      download_job_->OnPrefetchCompleted(PrefetchTilesResponse::ResultType());
+      return;
+    }
+
+    OLP_SDK_LOG_DEBUG_F(kLogTag, "Starting download, requests=%zu",
+                        query_result_.size());
+
+    download_job_->Initialize(query_result_.size(), accumulated_statistics_);
+
+    auto download_job = download_job_;
+
+    execution_context_.ExecuteOrCancelled([&]() {
+      VectorOfTokens tokens;
+      std::transform(
+          std::begin(query_result_), std::end(query_result_),
+          std::back_inserter(tokens), [&](const QueryResult::value_type& tile) {
+            const std::string& data_handle = tile.second;
+            const geo::TileKey& tile_key = tile.first;
+            return AddTask(
+                task_scheduler_, pending_requests_,
+                [=](client::CancellationContext context) {
+                  return download_job->Download(data_handle, context);
+                },
+                [=](ExtendedDataResponse response) {
+                  download_job->CompleteTile(tile_key, std::move(response));
+                });
+          });
+      return CreateToken(std::move(tokens));
+    });
+  }
+}
+
+client::CancellationToken PrefetchHelper::Prefetch(
+    const Roots& roots, QueryFunc query, FilterFunc filter,
+    DownloadFunc download, PrefetchTilesResponseCallback user_callback,
+    PrefetchStatusCallback status_callback,
+    std::shared_ptr<thread::TaskScheduler> task_scheduler,
+    std::shared_ptr<client::PendingRequests> pending_requests) {
+  client::CancellationContext execution_context;
+
+  auto download_job = std::make_shared<DownloadTilesJob>(
+      std::move(download), std::move(user_callback),
+      std::move(status_callback));
+
+  auto query_job = std::make_shared<QueryMetadataJob>(
+      std::move(query), std::move(filter), download_job, task_scheduler,
+      pending_requests, execution_context);
+
+  query_job->Initialize(roots.size());
+
+  OLP_SDK_LOG_DEBUG_F(kLogTag, "Starting queries, requests=%zu", roots.size());
+
+  execution_context.ExecuteOrCancelled([&]() {
+    VectorOfTokens tokens;
+    std::transform(std::begin(roots), std::end(roots),
+                   std::back_inserter(tokens), [&](geo::TileKey root) {
+                     return AddTask(
+                         task_scheduler, pending_requests,
+                         [=](client::CancellationContext context) {
+                           return query_job->Query(root, context);
+                         },
+                         [=](QueryResponse response) {
+                           query_job->CompleteQuery(std::move(response));
+                         });
+                   });
+    return CreateToken(std::move(tokens));
+  });
+
+  return client::CancellationToken(
+      [execution_context]() mutable { execution_context.CancelOperation(); });
 }
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -245,8 +245,10 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
                  ? static_cast<unsigned int>(geo::TileKey::LevelCount)
                  : request.GetMaxLevel());
 
-        repository::PrefetchTilesRepository repository(catalog, settings,
-                                                       lookup_client);
+        repository::PrefetchTilesRepository repository(catalog, layer_id,
+                                                       settings, lookup_client,
+                                                       request.GetBillingTag());
+
         auto sliced_tiles = repository.GetSlicedTiles(request.GetTileKeys(),
                                                       min_level, max_level);
 
@@ -260,79 +262,61 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
         OLP_SDK_LOG_DEBUG_F(kLogTag, "PrefetchTiles, subquads=%zu, key=%s",
                             sliced_tiles.size(), key.c_str());
 
-        auto sub_tiles = repository.GetSubTiles(layer_id, request, version,
-                                                sliced_tiles, context);
-        if (!sub_tiles.IsSuccessful()) {
-          return sub_tiles.GetError();
-        }
-
-        auto tiles_result = repository.FilterSkippedTiles(
-            request, request_only_input_tiles, sub_tiles.MoveResult());
-
-        if (tiles_result.empty()) {
-          return EmptyResponse(
-              {olp::client::ErrorCode::NotFound, "No tiles to prefetch"});
-        }
-
-        OLP_SDK_LOG_INFO_F(kLogTag, "Prefetch start, key=%s, tiles=%zu",
-                           key.c_str(), tiles_result.size());
-
         // Settings structure consumes a 536 bytes of heap memory when captured
         // in lambda, shared pointer (16 bytes) saves 520 bytes of heap memory.
         // When users prefetch few hundreds tiles it could save few mb.
         auto shared_settings =
             std::make_shared<client::OlpClientSettings>(settings);
 
-        auto prefetch_job = std::make_shared<PrefetchJob>(
-            std::move(callback), std::move(status_callback),
-            tiles_result.size(), GetNetworkStatistics(sub_tiles));
+        auto query = [=](geo::TileKey root,
+                         client::CancellationContext inner_context) mutable {
+          return repository.GetVersionedSubQuads(root, kQuadTreeDepth, version,
+                                                 inner_context);
+        };
 
-        std::for_each(
-            tiles_result.begin(), tiles_result.end(),
-            [&](const repository::SubQuadsResult::value_type& sub_quad) {
-              const auto& tile = sub_quad.first;
-              const auto& handle = sub_quad.second;
-              const auto& biling_tag = request.GetBillingTag();
+        auto filter = [=](QueryResult tiles) mutable {
+          return repository.FilterSkippedTiles(
+              request, request_only_input_tiles, std::move(tiles));
+        };
 
-              using PrefetchDataResponse = BlobApi::DataResponse;
+        auto billing_tag = request.GetBillingTag();
+        auto download = [=](std::string data_handle,
+                            client::CancellationContext inner_context) mutable {
+          if (data_handle.empty()) {
+            return BlobApi::DataResponse(
+                client::ApiError(client::ErrorCode::NotFound, "Not found"));
+          }
+          repository::DataCacheRepository data_cache_repository(
+              catalog, shared_settings->cache);
+          if (data_cache_repository.IsCached(layer_id, data_handle)) {
+            return BlobApi::DataResponse(nullptr);
+          }
 
-              AddTask(settings.task_scheduler, pending_requests,
-                      [=](CancellationContext inner_context)
-                          -> PrefetchDataResponse {
-                        if (handle.empty()) {
-                          return {{client::ErrorCode::NotFound, "Not found"}};
-                        }
-                        repository::DataCacheRepository data_cache_repository(
-                            catalog, shared_settings->cache);
-                        if (data_cache_repository.IsCached(layer_id, handle)) {
-                          return {nullptr};
-                        }
+          repository::DataRepository repository(catalog, *shared_settings,
+                                                lookup_client);
+          // Fetch from online
+          return repository.GetVersionedData(layer_id,
+                                             DataRequest()
+                                                 .WithDataHandle(data_handle)
+                                                 .WithBillingTag(billing_tag),
+                                             version, inner_context);
+        };
 
-                        // Fetch from online
-                        repository::DataRepository repository(
-                            catalog, *shared_settings, lookup_client);
-                        return repository.GetVersionedData(
-                            layer_id,
-                            DataRequest().WithDataHandle(handle).WithBillingTag(
-                                biling_tag),
-                            version, inner_context);
-                      },
-                      [=](PrefetchDataResponse result) {
-                        if (result.IsSuccessful()) {
-                          prefetch_job->CompleteTask(
-                              tile, GetNetworkStatistics(result));
-                        } else {
-                          prefetch_job->CompleteTask(
-                              tile, result.GetError(),
-                              GetNetworkStatistics(result));
-                        }
-                      },
-                      prefetch_job->AddTask());
+        std::vector<geo::TileKey> roots;
+        roots.reserve(sliced_tiles.size());
+
+        std::transform(
+            sliced_tiles.begin(), sliced_tiles.end(), std::back_inserter(roots),
+            [](const repository::RootTilesForRequest::value_type& root) {
+              return root.first;
             });
 
         context.ExecuteOrCancelled([&]() {
-          return client::CancellationToken(
-              [=]() { prefetch_job->CancelOperation(); });
+          return PrefetchHelper::Prefetch(
+              std::move(roots), std::move(query), std::move(filter),
+              std::move(download), std::move(callback),
+              std::move(status_callback), settings.task_scheduler,
+              pending_requests);
         });
 
         return EmptyResponse(PrefetchTileNoError());
@@ -345,12 +329,7 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
       [callback](EmptyResponse response) {
         // Inner task only generates successfull result
         if (!response.IsSuccessful()) {
-          if (response.GetError().GetErrorCode() ==
-              olp::client::ErrorCode::NotFound) {
-            callback(PrefetchTilesResult());
-          } else {
-            callback(response.GetError());
-          }
+          callback(response.GetError());
         }
       });
 

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/VolatileBlobApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/VolatileBlobApi.cpp
@@ -29,12 +29,12 @@
 namespace olp {
 namespace dataservice {
 namespace read {
-using namespace olp::client;
+namespace client = olp::client;
 
 VolatileBlobApi::DataResponse VolatileBlobApi::GetVolatileBlob(
-    const OlpClient& client, const std::string& layer_id,
+    const client::OlpClient& client, const std::string& layer_id,
     const std::string& data_handle, boost::optional<std::string> billing_tag,
-    const CancellationContext& context) {
+    const client::CancellationContext& context) {
   std::multimap<std::string, std::string> header_params;
   header_params.insert(std::make_pair("Accept", "application/json"));
   std::multimap<std::string, std::string> query_params;
@@ -49,12 +49,13 @@ VolatileBlobApi::DataResponse VolatileBlobApi::GetVolatileBlob(
                      form_params, nullptr, "", context);
 
   if (api_response.status != http::HttpStatusCode::OK) {
-    return ApiError(api_response.status, api_response.response.str());
+    return {{api_response.status, api_response.response.str()},
+            api_response.GetNetworkStatistics()};
   }
 
   auto result = std::make_shared<std::vector<unsigned char>>();
   api_response.GetResponse(*result);
-  return result;
+  return {result, api_response.GetNetworkStatistics()};
 }
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/VolatileBlobApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/VolatileBlobApi.h
@@ -26,6 +26,8 @@
 #include <boost/optional.hpp>
 #include "olp/dataservice/read/model/Data.h"
 
+#include "ExtendedApiResponse.h"
+
 namespace olp {
 namespace client {
 class OlpClient;
@@ -39,7 +41,8 @@ namespace read {
  */
 class VolatileBlobApi {
  public:
-  using DataResponse = client::ApiResponse<model::Data, client::ApiError>;
+  using DataResponse = ExtendedApiResponse<model::Data, client::ApiError,
+                                           client::NetworkStatistics>;
 
   /**
    * @brief Retrieves a volatile data blob for specified handle.

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -201,7 +201,7 @@ BlobApi::DataResponse DataRepository::GetBlobData(
   return storage_response;
 }
 
-DataResponse DataRepository::GetVolatileData(
+BlobApi::DataResponse DataRepository::GetVolatileData(
     const std::string& layer_id, const DataRequest& request,
     client::CancellationContext context) {
   if (request.GetDataHandle() && request.GetPartitionId()) {

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
@@ -49,9 +49,9 @@ class DataRepository final {
                                          int64_t version,
                                          client::CancellationContext context);
 
-  DataResponse GetVolatileData(const std::string& layer_id,
-                               const DataRequest& request,
-                               client::CancellationContext context);
+  BlobApi::DataResponse GetVolatileData(const std::string& layer_id,
+                                        const DataRequest& request,
+                                        client::CancellationContext context);
 
   BlobApi::DataResponse GetBlobData(const std::string& layer,
                                     const std::string& service,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -51,9 +51,10 @@ using SubTilesResponse = ExtendedApiResponse<SubTilesResult, client::ApiError,
 
 class PrefetchTilesRepository {
  public:
-  PrefetchTilesRepository(client::HRN catalog,
-                          client::OlpClientSettings settings,
-                          client::ApiLookupClient client);
+  PrefetchTilesRepository(
+      client::HRN catalog, const std::string& layer_id,
+      client::OlpClientSettings settings, client::ApiLookupClient client,
+      boost::optional<std::string> billing_tag = boost::none);
 
   /**
    * @brief Given tile keys, return all related tile keys that are between
@@ -68,36 +69,30 @@ class PrefetchTilesRepository {
   RootTilesForRequest GetSlicedTiles(const std::vector<geo::TileKey>& tile_keys,
                                      std::uint32_t min, std::uint32_t max);
 
-  SubTilesResponse GetSubTiles(const std::string& layer_id,
-                               const PrefetchTilesRequest& request,
-                               boost::optional<std::int64_t> version,
-                               const RootTilesForRequest& root_tiles,
-                               client::CancellationContext context);
 
   SubQuadsResult FilterSkippedTiles(const PrefetchTilesRequest& request,
                                     bool request_only_input_tiles,
                                     SubQuadsResult sub_tiles);
 
- protected:
-  SubQuadsResponse GetSubQuads(const std::string& layer_id,
-                               const PrefetchTilesRequest& request,
-                               std::int64_t version, geo::TileKey tile,
-                               int32_t depth,
-                               client::CancellationContext context);
+  SubQuadsResponse GetVersionedSubQuads(geo::TileKey tile, int32_t depth,
+                                        std::int64_t version,
+                                        client::CancellationContext context);
 
-  SubQuadsResponse GetVolatileSubQuads(const std::string& layer_id,
-                                       const PrefetchTilesRequest& request,
-                                       geo::TileKey tile, int32_t depth,
+  SubQuadsResponse GetVolatileSubQuads(geo::TileKey tile, int32_t depth,
                                        client::CancellationContext context);
 
+ protected:
   void SplitSubtree(RootTilesForRequest& root_tiles_depth,
                     RootTilesForRequest::iterator subtree_to_split,
                     const geo::TileKey& tile_key, std::uint32_t min);
 
  private:
   client::HRN catalog_;
+  std::string layer_id_;
   client::OlpClientSettings settings_;
   client::ApiLookupClient lookup_client_;
+  PartitionsCacheRepository cache_repository_;
+  boost::optional<std::string> billing_tag_;
 };
 
 }  // namespace repository

--- a/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PrefetchRepositoryTest.cpp
@@ -35,7 +35,7 @@ class PrefetchRepositoryTestable
   using repository::PrefetchTilesRepository::SplitSubtree;
 
   PrefetchRepositoryTestable()
-      : PrefetchTilesRepository(kCatalog, {},
+      : PrefetchTilesRepository(kCatalog, "test_layer", {},
                                 olp::client::ApiLookupClient(kCatalog, {})) {}
 };
 


### PR DESCRIPTION
Improve prefetch by splitting the quadtree requests to tasks, so
all the query requests are performed in parallel.

Remove layer and request from PrefetchTilesRepository methods, move
them to the constructor, request substituted with billing tag.

Prefetch job class takes control over prefetching, clients must
provide functions used to download metadata, filter the tiles to
download (optional), and download method.

Relates-To: OLPEDGE-2217

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>