### PR TITLE
Add metadata network stats to prefetch status.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/PrefetchJob.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/PrefetchJob.cpp
@@ -41,12 +41,14 @@ namespace read {
 
 PrefetchJob::PrefetchJob(PrefetchTilesResponseCallback user_callback,
                          PrefetchStatusCallback status_callback,
-                         uint32_t task_count)
+                         uint32_t task_count,
+                         client::NetworkStatistics initial_network_statistics)
     : user_callback_(std::move(user_callback)),
       status_callback_(std::move(status_callback)),
       task_count_{task_count},
       total_task_count_{task_count},
-      canceled_{false} {
+      canceled_{false},
+      accumulated_statistics_{initial_network_statistics} {
   tasks_contexts_.reserve(task_count_);
   prefetch_result_.reserve(task_count_);
 }

--- a/olp-cpp-sdk-dataservice-read/src/PrefetchJob.h
+++ b/olp-cpp-sdk-dataservice-read/src/PrefetchJob.h
@@ -31,7 +31,8 @@ namespace read {
 class PrefetchJob {
  public:
   PrefetchJob(PrefetchTilesResponseCallback user_callback,
-              PrefetchStatusCallback status_callback, uint32_t task_count);
+              PrefetchStatusCallback status_callback, uint32_t task_count,
+              client::NetworkStatistics initial_network_statistics);
 
   PrefetchJob(const PrefetchJob&) = delete;
   PrefetchJob(PrefetchJob&&) = delete;

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -285,7 +285,7 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
 
         auto prefetch_job = std::make_shared<PrefetchJob>(
             std::move(callback), std::move(status_callback),
-            tiles_result.size());
+            tiles_result.size(), GetNetworkStatistics(sub_tiles));
 
         std::for_each(
             tiles_result.begin(), tiles_result.end(),

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -34,6 +34,8 @@
 #include "PartitionsCacheRepository.h"
 #include "generated/model/Index.h"
 
+#include "ExtendedApiResponse.h"
+
 namespace olp {
 namespace dataservice {
 namespace read {
@@ -41,9 +43,11 @@ namespace repository {
 
 using RootTilesForRequest = std::map<geo::TileKey, uint32_t>;
 using SubQuadsResult = std::map<geo::TileKey, std::string>;
-using SubQuadsResponse = client::ApiResponse<SubQuadsResult, client::ApiError>;
+using SubQuadsResponse = ExtendedApiResponse<SubQuadsResult, client::ApiError,
+                                             client::NetworkStatistics>;
 using SubTilesResult = SubQuadsResult;
-using SubTilesResponse = client::ApiResponse<SubTilesResult, client::ApiError>;
+using SubTilesResponse = ExtendedApiResponse<SubTilesResult, client::ApiError,
+                                             client::NetworkStatistics>;
 
 class PrefetchTilesRepository {
  public:

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -1895,7 +1895,9 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesWithStatus) {
                      .WithMaxLevel(12);
   EXPECT_CALL(*network_mock_,
               Send(IsGetRequest(URL_QUADKEYS_92259), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
+      .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK)
+                                       .WithBytesDownloaded(200)
+                                       .WithBytesUploaded(50),
                                    HTTP_RESPONSE_QUADKEYS_92259));
 
   EXPECT_CALL(*network_mock_,
@@ -1956,7 +1958,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, PrefetchTilesWithStatus) {
     ASSERT_TRUE(tile_result->tile_key_.IsValid());
   }
 
-  EXPECT_GE(bytes_transferred, 150);
+  EXPECT_GE(bytes_transferred, 400);
 
   testing::Mock::VerifyAndClearExpectations(&status_object);
 }


### PR DESCRIPTION
For prefetch method we accumulate bytes uploaded/downloaded during
query tree requests so the users receive a bit more precise numbers.

Relates-To: OLPEDGE-2217

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>