### PR TITLE
Destruction network test.

### DIFF
--- a/tests/functional/network/CMakeLists.txt
+++ b/tests/functional/network/CMakeLists.txt
@@ -18,6 +18,7 @@
 
 set(OLP_SDK_NETWORK_TESTS_SOURCES
     ./NetworkTestBase.cpp
+    ./DestructionTest.cpp
 )
 
 set(OLP_SDK_NETWORK_TESTS_HEADERS
@@ -32,8 +33,9 @@ if (ANDROID OR IOS)
         ${OLP_SDK_NETWORK_TESTS_HEADERS})
     target_include_directories(${OLP_SDK_NETWORK_TESTS_LIB}
         PRIVATE
+            ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-dataservice-read/src
             ${PROJECT_SOURCE_DIR}/tests/utils/mock-server-client/
-            utils
+            ${PROJECT_SOURCE_DIR}/tests/functional/utils
     )
     target_link_libraries(${OLP_SDK_NETWORK_TESTS_LIB}
         PRIVATE
@@ -41,6 +43,7 @@ if (ANDROID OR IOS)
             gtest
             olp-cpp-sdk-tests-common
             olp-cpp-sdk-core
+            olp-cpp-sdk-dataservice-read
     )
     if (ANDROID)
         include(${CMAKE_SOURCE_DIR}/cmake/android/gen_android_test.cmake)
@@ -63,8 +66,9 @@ else()
         ${OLP_SDK_NETWORK_TESTS_HEADERS})
     target_include_directories(olp-cpp-sdk-functional-network-tests
     PRIVATE
+        ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-dataservice-read/src
         ${PROJECT_SOURCE_DIR}/tests/utils/mock-server-client/
-        utils
+        ${PROJECT_SOURCE_DIR}/tests/functional/utils
     )
     target_link_libraries(olp-cpp-sdk-functional-network-tests
         PRIVATE
@@ -72,5 +76,6 @@ else()
             gtest_main
             olp-cpp-sdk-tests-common
             olp-cpp-sdk-core
+            olp-cpp-sdk-dataservice-read
     )
 endif()

--- a/tests/functional/network/DestructionTest.cpp
+++ b/tests/functional/network/DestructionTest.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <memory>
+
+#include <gtest/gtest.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/http/Network.h>
+#include <olp/core/http/NetworkSettings.h>
+
+#include "NetworkTestBase.h"
+#include "ReadDefaultResponses.h"
+
+namespace {
+using NetworkRequest = olp::http::NetworkRequest;
+using NetworkResponse = olp::http::NetworkResponse;
+
+using DestructionTest = NetworkTestBase;
+
+TEST_F(DestructionTest, Callback) {
+  const std::string kUrlBase = "https://some-url.com";
+  const std::string kApiBase = "/some-api/";
+  constexpr auto kRequestCount = 10;
+
+  for (int i = 0; i < kRequestCount; ++i) {
+    const auto url = kApiBase + std::to_string(i);
+    // delay needed to be sure network destroyed before any request is complete
+    mock_server_client_->MockResponse(
+        "GET", url, mockserver::ReadDefaultResponses::GenerateData(), 200, true,
+        500);
+  }
+
+  std::vector<std::promise<NetworkResponse>> promises(kRequestCount);
+  for (int i = 0; i < kRequestCount; ++i) {
+    const auto url = kUrlBase + kApiBase + std::to_string(i);
+    const auto request = NetworkRequest(url).WithSettings(settings_).WithVerb(
+        olp::http::NetworkRequest::HttpVerb::GET);
+    const auto outcome = network_->Send(
+        request, nullptr, [&promises, i](NetworkResponse response) {
+          promises[i].set_value(std::move(response));
+        });
+
+    ASSERT_TRUE(outcome.IsSuccessful());
+  }
+
+  mock_server_client_.reset();
+  network_.reset();
+
+  for (int i = 0; i < kRequestCount; ++i) {
+    auto future = promises[i].get_future();
+    const auto response = future.get();
+
+    EXPECT_EQ(response.GetStatus(),
+              static_cast<int>(olp::http::ErrorCode::OFFLINE_ERROR))
+        << response.GetError();
+  }
+}
+
+}  // namespace

--- a/tests/functional/network/NetworkTestBase.cpp
+++ b/tests/functional/network/NetworkTestBase.cpp
@@ -37,4 +37,9 @@ void NetworkTestBase::SetUp() {
   settings_ = olp::http::NetworkSettings().WithProxySettings(proxy_settings);
   network_ = olp::client::OlpClientSettingsFactory::
       CreateDefaultNetworkRequestHandler();
+
+  olp::client::OlpClientSettings client_settings;
+  client_settings.network_request_handler = network_;
+  mock_server_client_ = std::make_shared<mockserver::Client>(client_settings);
+  mock_server_client_->Reset();
 }

--- a/tests/functional/network/NetworkTestBase.h
+++ b/tests/functional/network/NetworkTestBase.h
@@ -26,10 +26,13 @@
 #include <olp/core/http/Network.h>
 #include <olp/core/http/NetworkSettings.h>
 
+#include "Client.h"
+
 class NetworkTestBase : public ::testing::Test {
   void SetUp() override;
 
  protected:
   std::shared_ptr<olp::http::Network> network_;
   olp::http::NetworkSettings settings_;
+  std::shared_ptr<mockserver::Client> mock_server_client_;
 };

--- a/tests/utils/mock-server-client/Client.h
+++ b/tests/utils/mock-server-client/Client.h
@@ -49,7 +49,8 @@ class Client {
                     const std::string& path_matcher,
                     const std::string& response_body,
                     int https_status = olp::http::HttpStatusCode::OK,
-                    bool unlimited = false);
+                    bool unlimited = false,
+                    boost::optional<int32_t> delay_ms = boost::none);
 
   void MockBinaryResponse(const std::string& method_matcher,
                           const std::string& path_matcher,
@@ -79,7 +80,8 @@ inline Client::Client(olp::client::OlpClientSettings settings) {
 inline void Client::MockResponse(const std::string& method_matcher,
                                  const std::string& path_matcher,
                                  const std::string& response_body,
-                                 int https_status, bool unlimited) {
+                                 int https_status, bool unlimited,
+                                 boost::optional<int32_t> delay_ms) {
   auto expectation = Expectation{};
   expectation.request.path = path_matcher;
   expectation.request.method = method_matcher;
@@ -88,6 +90,9 @@ inline void Client::MockResponse(const std::string& method_matcher,
       Expectation::ResponseAction{};
   action->body = response_body;
   action->status_code = static_cast<uint16_t>(https_status);
+  if (delay_ms) {
+    action->delay = {{delay_ms.get(), "MILLISECONDS"}};
+  }
   expectation.action = action;
 
   boost::optional<Expectation::ResponseTimes> times =

--- a/tests/utils/mock-server-client/Expectation.h
+++ b/tests/utils/mock-server-client/Expectation.h
@@ -34,7 +34,13 @@ struct Expectation {
     boost::optional<std::string> method = boost::none;
   };
 
+  struct ResponseDelay {
+    int32_t value;
+    std::string time_unit;
+  };
+
   struct ResponseAction {
+    boost::optional<ResponseDelay> delay = boost::none;
     boost::optional<uint16_t> status_code = boost::none;
 
     /// Any of BinaryResponse, std::string, boost::any
@@ -61,6 +67,8 @@ void to_json(const Expectation& x, rapidjson::Value& value,
 void to_json(const Expectation::RequestMatcher& x, rapidjson::Value& value,
              rapidjson::Document::AllocatorType& allocator);
 void to_json(const Expectation::BinaryResponse& x, rapidjson::Value& value,
+             rapidjson::Document::AllocatorType& allocator);
+void to_json(const Expectation::ResponseDelay& x, rapidjson::Value& value,
              rapidjson::Document::AllocatorType& allocator);
 void to_json(const Expectation::ResponseAction& x, rapidjson::Value& value,
              rapidjson::Document::AllocatorType& allocator);
@@ -98,6 +106,14 @@ inline void to_json(const Expectation::BinaryResponse& x,
   serialize("base64Bytes", x.base64_string, value, allocator);
 }
 
+inline void to_json(const Expectation::ResponseDelay& x,
+                    rapidjson::Value& value,
+                    rapidjson::Document::AllocatorType& allocator) {
+  value.SetObject();
+  serialize("timeUnit", x.time_unit, value, allocator);
+  serialize("value", x.value, value, allocator);
+}
+
 inline void to_json(const Expectation::ResponseAction& x,
                     rapidjson::Value& value,
                     rapidjson::Document::AllocatorType& allocator) {
@@ -109,6 +125,10 @@ inline void to_json(const Expectation::ResponseAction& x,
   } else if (x.body.type() == typeid(Expectation::BinaryResponse)) {
     serialize("body", boost::any_cast<Expectation::BinaryResponse>(x.body),
               value, allocator);
+  }
+
+  if (x.delay) {
+    serialize("delay", x.delay.get(), value, allocator);
   }
 }
 


### PR DESCRIPTION
Adding fv network test. Goal of the test is to check callback is
called if network destroyed. Also added possibility to set response
delay to be sure the requests are not finished before the destruction.

Resolves: OLPEDGE-2061

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>