### PR TITLE
Fix the gcc warn on maybe uninitialized variable

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -44,11 +44,6 @@
 #include "repositories/PartitionsRepository.h"
 #include "repositories/PrefetchTilesRepository.h"
 
-// Needed to avoid endless warnings from GetVersion/WithVersion
-#include <olp/core/porting/warning_disable.h>
-PORTING_PUSH_WARNINGS()
-PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
-
 namespace olp {
 namespace dataservice {
 namespace read {
@@ -657,7 +652,6 @@ bool VersionedLayerClientImpl::Release(const TileKeys& tiles) {
   return settings_.cache->Release(keys_to_release);
 }
 
-PORTING_POP_WARNINGS()
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -39,11 +39,6 @@
 #include "olp/dataservice/read/PartitionsRequest.h"
 #include "olp/dataservice/read/TileRequest.h"
 
-// Needed to avoid endless warnings from GetVersion/WithVersion
-#include <olp/core/porting/warning_disable.h>
-PORTING_PUSH_WARNINGS()
-PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
-
 namespace olp {
 namespace dataservice {
 namespace read {
@@ -237,7 +232,6 @@ DataResponse DataRepository::GetVolatileData(
   return GetBlobData(layer_id, kVolatileBlobService, blob_request, context);
 }
 
-PORTING_POP_WARNINGS()
 }  // namespace repository
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
@@ -37,11 +37,6 @@
 #include "generated/serializer/JsonSerializer.h"
 // clang-format on
 
-// Needed to avoid endless warnings from GetVersion/WithVersion
-#include <olp/core/porting/warning_disable.h>
-PORTING_PUSH_WARNINGS()
-PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
-
 namespace {
 constexpr auto kLogTag = "PartitionsCacheRepository";
 constexpr auto kChronoSecondsMax = std::chrono::seconds::max();
@@ -338,7 +333,6 @@ bool PartitionsCacheRepository::FindQuadTree(const std::string& layer,
   return false;
 }
 
-PORTING_POP_WARNINGS()
 }  // namespace repository
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -36,11 +36,6 @@
 #include "QuadTreeIndex.h"
 #include "generated/api/QueryApi.h"
 
-// Needed to avoid endless warnings from GetVersion/WithVersion
-#include <olp/core/porting/warning_disable.h>
-PORTING_PUSH_WARNINGS()
-PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
-
 namespace olp {
 namespace dataservice {
 namespace read {
@@ -374,7 +369,6 @@ SubQuadsResult PrefetchTilesRepository::FilterSkippedTiles(
   return sub_tiles;
 }
 
-PORTING_POP_WARNINGS()
 }  // namespace repository
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -37,11 +37,6 @@
 #include <olp/core/generated/parser/JsonParser.h>
 // clang-format on
 
-// Remove after OLPEDGE-1794
-#include <olp/core/porting/warning_disable.h>
-PORTING_PUSH_WARNINGS()
-PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
-
 namespace {
 using olp::client::ApiLookupClient;
 using olp::client::ErrorCode;
@@ -1318,5 +1313,3 @@ TEST_F(PartitionsRepositoryTest, GetTile) {
 }
 
 }  // namespace
-
-PORTING_POP_WARNINGS()

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -49,9 +49,6 @@ using olp::dataservice::read::PrefetchTilesRequest;
 using olp::dataservice::read::PrefetchTilesResponse;
 using testing::_;
 
-// OLPEDGE-1799
-PORTING_PUSH_WARNINGS()
-PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
 namespace {
 
 namespace read = olp::dataservice::read;
@@ -4182,5 +4179,3 @@ TEST_F(DataserviceReadVersionedLayerClientTest, OverlappingQuads) {
 }
 
 }  // namespace
-
-PORTING_POP_WARNINGS()

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
@@ -27,7 +27,6 @@
 #include <olp/core/http/Network.h>
 #include <olp/core/logging/Log.h>
 #include <olp/core/porting/make_unique.h>
-#include <olp/core/porting/warning_disable.h>
 #include <olp/dataservice/read/PartitionsRequest.h>
 #include <olp/dataservice/read/PrefetchTileResult.h>
 #include <olp/dataservice/read/VolatileLayerClient.h>
@@ -204,9 +203,6 @@ TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitions) {
   ASSERT_EQ(4u, partitions_response.GetResult().GetPartitions().size());
 }
 
-PORTING_PUSH_WARNINGS()
-PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
-
 TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsVersionIsIgnored) {
   olp::client::HRN hrn(GetTestCatalog());
 
@@ -216,8 +212,7 @@ TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsVersionIsIgnored) {
   read::VolatileLayerClient client(hrn, "testlayer", settings_);
 
   {
-    SCOPED_TRACE(
-        "Online request.");
+    SCOPED_TRACE("Online request.");
     auto request = read::PartitionsRequest();
     request.WithFetchOption(read::FetchOptions::OnlineIfNotFound);
 
@@ -254,8 +249,6 @@ TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsVersionIsIgnored) {
     ASSERT_EQ(4u, partitions_response.GetResult().GetPartitions().size());
   }
 }
-
-PORTING_POP_WARNINGS()
 
 TEST_F(DataserviceReadVolatileLayerClientTest, GetPartitionsCancellableFuture) {
   olp::client::HRN hrn(GetTestCatalog());


### PR DESCRIPTION
Additionally remove the deprecated usage guards.

Resolves: OLPEDGE-2203

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>