### PR TITLE
Remove deprecated methods

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
@@ -62,11 +62,6 @@ using NetworkAsyncCallback = std::function<void(HttpResponse)>;
 using NetworkAsyncCancel = std::function<void()>;
 
 /**
- * @brief The default backdown policy that returns the original wait time.
- */
-CORE_API unsigned int DefaultBackdownPolicy(unsigned int milliseconds);
-
-/**
  * @brief The default retry condition that disables retries.
  */
 CORE_API bool DefaultRetryCondition(const olp::client::HttpResponse& response);
@@ -164,14 +159,6 @@ struct CORE_API AuthenticationSettings {
  */
 struct CORE_API RetrySettings {
   /**
-   * @brief Takes the current timeout (in milliseconds) and
-   * returns what should be used for the next timeout.
-   *
-   * Allows an incremental backdown or other strategies to be configured.
-   */
-  using BackdownPolicy = std::function<int(int)>;
-
-  /**
    * @brief Calculates the number of retry timeouts based on
    * the initial backdown duration and retries count.
    */
@@ -204,27 +191,11 @@ struct CORE_API RetrySettings {
   int initial_backdown_period = 200;
 
   /**
-   * @brief The backdown policy that should be used for the retry attempts.
-   *
-   * @deprecated Use \ref backdown_strategy instead. Will be removed by
-   * 06.2020.
-   *
-   * @return The backdown policy.
-   */
-  BackdownPolicy backdown_policy = DefaultBackdownPolicy;
-
-  /**
    * @brief The backdown strategy.
    *
-   * Calculates the number of retry timeouts for failed requests. It is superior
-   * to \ref backdown_policy as it computes the wait time based on the retry
-   * count. By default, `backdown_strategy` is unset, and \ref backdown_policy
-   * is used.
-   *
-   * @note You can use the \ref `ExponentialBackdownStrategy` as the new
-   * backdown strategy.
+   * Calculates the number of retry timeouts for failed requests.
    */
-  BackdownStrategy backdown_strategy = nullptr;
+  BackdownStrategy backdown_strategy = ExponentialBackdownStrategy();
 
   /**
    * @brief Evaluates responses to determine if the retry should be attempted.

--- a/olp-cpp-sdk-core/src/client/OlpClientSettings.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClientSettings.cpp
@@ -26,9 +26,6 @@
 
 namespace olp {
 namespace client {
-unsigned int DefaultBackdownPolicy(unsigned int milliseconds) {
-  return milliseconds;
-}
 
 bool DefaultRetryCondition(const HttpResponse& response) {
   if ((response.status >= http::HttpStatusCode::INTERNAL_SERVER_ERROR &&

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
@@ -106,37 +106,6 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
   }
 
   /**
-   * @brief Sets the catalog version for the request.
-   *
-   * @param version The catalog version of the requested partitions. If no
-   * version is specified, the latest version is retrieved.
-   *
-   * @return A reference to the updated `PrefetchTilesRequest` instance.
-   *
-   * @deprecated The version is now a part of the VersionedLayerClient
-   * constructor.
-   */
-  OLP_SDK_DEPRECATED("Deprecated, to be removed in 06.2020")
-  inline PrefetchTilesRequest& WithVersion(boost::optional<int64_t> version) {
-    catalog_version_ = std::move(version);
-    return *this;
-  }
-
-  /**
-   * @brief Gets the catalog version for the request.
-   *
-   * @return The catalog version or `boost::none` if the catalog version is not
-   * set.
-   *
-   * @deprecated The version is now a part of the VersionedLayerClient
-   * constructor.
-   */
-  OLP_SDK_DEPRECATED("Deprecated, to be removed in 06.2020")
-  inline const boost::optional<std::int64_t>& GetVersion() const {
-    return catalog_version_;
-  }
-
-  /**
    * @brief Gets the billing tag to group billing records together.
    *
    * The billing tag is an optional free-form tag that is used for grouping

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
@@ -23,8 +23,6 @@
 #include <string>
 #include <vector>
 
-#include <olp/core/cache/CacheSettings.h>
-#include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/OlpClientSettings.h>
@@ -46,19 +44,6 @@ class HRN;
 namespace dataservice {
 namespace write {
 class StreamLayerClientImpl;
-
-/**
- * @brief Creates an instance of the default cache with the provided settings.
- * @param settings Cache settings.
- * @return DefaultCache instance.
- * @deprecated Use olp::client::OlpClientSettingsFactory::CreateDefaultCache()
- * instead. Will be remove by 06.2020.
- */
-OLP_SDK_DEPRECATED(
-    "Please use OlpClientSettingsFactory::CreateDefaultCache() instead. "
-    "Will be removed by 06.2020")
-std::shared_ptr<cache::KeyValueCache> CreateDefaultCache(
-    cache::CacheSettings settings = {});
 
 using PublishDataResult = olp::dataservice::write::model::ResponseOkSingle;
 using PublishDataResponse =

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
@@ -19,19 +19,14 @@
 
 #include "olp/dataservice/write/StreamLayerClient.h"
 
-#include <olp/core/cache/DefaultCache.h>
+#include <olp/core/cache/CacheSettings.h>
+#include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
 #include "StreamLayerClientImpl.h"
 
 namespace olp {
 namespace dataservice {
 namespace write {
-
-std::shared_ptr<cache::KeyValueCache> CreateDefaultCache(
-    cache::CacheSettings settings) {
-  return client::OlpClientSettingsFactory::CreateDefaultCache(
-      std::move(settings));
-}
 
 StreamLayerClient::StreamLayerClient(client::HRN catalog,
                                      StreamLayerClientSettings client_settings,

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
@@ -23,6 +23,7 @@
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
+#include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/OlpClient.h>
 #include <olp/core/client/PendingRequests.h>

--- a/olp-cpp-sdk-dataservice-write/tests/StreamLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/StreamLayerClientImplTest.cpp
@@ -21,6 +21,7 @@
 #include <matchers/NetworkUrlMatchers.h>
 #include <mocks/CacheMock.h>
 #include <mocks/NetworkMock.h>
+#include <olp/core/cache/CacheSettings.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
 #include <unordered_set>
 #include "StreamLayerClientImpl.h"


### PR DESCRIPTION
Remove deprecated WithVersion/GetVersion from PrefetchTilesRequest.h
Remove deprecated CreateDefaultCache method from StreamLayerClient.h
Remove deprecated backdown_policy from OlpClientSettings.

Resolves: OLPEDGE-1945, OLPEDGE-2241, OLPEDGE-2242

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>