### PR TITLE
Enable the prefetching of aggregated tiles

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
@@ -150,6 +150,36 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
   }
 
   /**
+   * @brief Changes the prefetch behavior when prefetching a list of tiles.
+   *
+   * In case a tile does not exist, the prefetch algorithm searches for the
+   * nearest parent and prefetches it.
+   *
+   * @param data_aggregation_enabled The boolean parameter that enables or
+   * disables the aggregation.
+   *
+   * @note Experimental. API may change.
+   * 
+   * @return A reference to the updated `PrefetchTilesRequest` instance.
+   */
+  inline PrefetchTilesRequest& WithDataAggregationEnabled(
+      bool data_aggregation_enabled) {
+    data_aggregation_enabled_ = data_aggregation_enabled;
+    return *this;
+  }
+
+  /**
+   * @brief Gets the data aggregation flag.
+   *
+   * @note Experimental. API may change.
+   *
+   * @return The data aggregation flag as a boolean value.
+   */
+  inline bool GetDataAggregationEnabled() const {
+    return data_aggregation_enabled_;
+  }
+
+  /**
    * @brief Creates a readable format for the request.
    *
    * @param layer_id The ID of the layer that is used for the request.
@@ -160,9 +190,6 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
     std::stringstream out;
     out << layer_id << "[" << GetMinLevel() << "/" << GetMaxLevel() << "]"
         << "(" << GetTileKeys().size() << ")";
-    if (catalog_version_) {
-      out << "@" << catalog_version_.get();
-    }
     if (GetBillingTag()) {
       out << "$" << GetBillingTag().get();
     }
@@ -174,8 +201,8 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
   std::vector<geo::TileKey> tile_keys_;
   unsigned int min_level_{geo::TileKey::LevelCount};
   unsigned int max_level_{geo::TileKey::LevelCount};
-  boost::optional<int64_t> catalog_version_;
   boost::optional<std::string> billing_tag_;
+  bool data_aggregation_enabled_{false};
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -270,8 +270,11 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
         };
 
         auto filter = [=](QueryResult tiles) mutable {
-          return repository.FilterSkippedTiles(
-              request, request_only_input_tiles, std::move(tiles));
+          if (request_only_input_tiles) {
+            return repository.FilterTilesByList(request, std::move(tiles));
+          } else {
+            return repository.FilterTilesByLevel(request, std::move(tiles));
+          }
         };
 
         auto billing_tag = request.GetBillingTag();

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -230,8 +230,11 @@ client::CancellationToken VolatileLayerClientImpl::PrefetchTiles(
         };
 
         auto filter = [=](QueryResult tiles) mutable {
-          return repository.FilterSkippedTiles(
-              request, request_only_input_tiles, std::move(tiles));
+          if (request_only_input_tiles) {
+            return repository.FilterTilesByList(request, std::move(tiles));
+          } else {
+            return repository.FilterTilesByLevel(request, std::move(tiles));
+          }
         };
 
         auto billing_tag = request.GetBillingTag();

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -69,10 +69,34 @@ class PrefetchTilesRepository {
   RootTilesForRequest GetSlicedTiles(const std::vector<geo::TileKey>& tile_keys,
                                      std::uint32_t min, std::uint32_t max);
 
+  /**
+   * @brief Filters the input tiles according to the request.
+   *
+   * Removes tiles that do not belong to the minimum and maximum levels.
+   * Removes tiles that are not a child or a parent of the requested tiles.
+   * 
+   * @param request Your request.
+   * @param tiles The input tiles.
+   *
+   * @returns The modified tiles.
+   */
+  SubQuadsResult FilterTilesByLevel(const PrefetchTilesRequest& request,
+                                    SubQuadsResult tiles);
 
-  SubQuadsResult FilterSkippedTiles(const PrefetchTilesRequest& request,
-                                    bool request_only_input_tiles,
-                                    SubQuadsResult sub_tiles);
+  /**
+   * @brief Filters the input tiles according to the request.
+   *
+   * Removes tiles that are not requested.
+   * Adds tiles that are missing (to notify you that they are not found).
+   * If you requested aggregated tiles, `FilterTilesByList` scans for parents.
+   * 
+   * @param request Your request.
+   * @param tiles The input tiles.
+   *
+   * @returns The modified tiles.
+   */
+  SubQuadsResult FilterTilesByList(const PrefetchTilesRequest& request,
+                                   SubQuadsResult tiles);
 
   SubQuadsResponse GetVersionedSubQuads(geo::TileKey tile, int32_t depth,
                                         std::int64_t version,


### PR DESCRIPTION
Enable the user to prefetch a list of aggregated tiles.
When the tile does not exists, the prefetch algorithm scans the tree
to find the nearest parent.

Resolves: OLPEDGE-2245

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>