### PR TITLE
[CI]Switch back to 18.04 Ubuntu

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,7 +68,7 @@ jobs:
 
 - job: Linux_build_clang
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-latest'
   variables:
     LD_PRELOAD: "/lib/x86_64-linux-gnu/libSegFault.so"
     SEGFAULT_SIGNALS: "all"
@@ -77,7 +77,8 @@ jobs:
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
   steps:
   - bash: |
-        sudo apt-get install libcurl4-openssl-dev clang-7 ccache -y --no-install-recommends
+        sudo apt-get update -y
+        sudo apt-get install clang-7 ccache libcurl4-openssl-dev -y --no-install-recommends --fix-missing
         echo "##vso[task.prependpath]/usr/lib/ccache"
         echo week_$(date +%W) > week_number.txt
     displayName: 'Install dependencies'


### PR DESCRIPTION
20.04 and 18.04 have both the same issues.
Due to issues detected on Azure CI we need to switch
back to 18.04 urgently. Issue is related to some temporary
IP reachability error on cloud:
  404  Not Found [IP: 51.104.174.161 80]
Add --fix-missing and apt-get update
I found a fix for this https://github.com/actions/virtual-environments/issues/675#issuecomment-671057659

Relates-To: OLPEDGE-2119

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>