### PR TITLE
Add Content-Encoding header to requests

### DIFF
--- a/olp-cpp-sdk-dataservice-write/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-write/CMakeLists.txt
@@ -67,6 +67,8 @@ set(OLP_SDK_DATASERVICE_WRITE_SOURCES
     # ./src/BackgroundTaskCollection.h
     ./src/CancellationTokenList.cpp
     ./src/CancellationTokenList.h
+    ./src/CatalogSettings.cpp
+    ./src/CatalogSettings.h
     # ./src/DefaultFlushEventListener.cpp
     # ./src/DefaultFlushEventListener.h
     # ./src/FlushEventListener.h

--- a/olp-cpp-sdk-dataservice-write/src/CatalogSettings.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/CatalogSettings.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "CatalogSettings.h"
+
+#include <olp/core/cache/CacheSettings.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <boost/format.hpp>
+#include "ApiClientLookup.h"
+#include "generated/ConfigApi.h"
+
+// clang-format off
+#include <generated/serializer/CatalogSerializer.h>
+#include <generated/serializer/JsonSerializer.h>
+#include <generated/parser/CatalogParser.h>
+#include <olp/core/generated/parser/JsonParser.h>
+// clang-format on
+
+namespace olp {
+namespace dataservice {
+namespace write {
+
+CatalogSettings::CatalogSettings(const client::HRN catalog,
+                                 client::OlpClientSettings settings)
+    : catalog_(std::move(catalog)),
+      cache_(settings.cache),
+      settings_(std::move(settings)) {
+  if (!settings_.cache) {
+    settings_.cache = client::OlpClientSettingsFactory::CreateDefaultCache({});
+    cache_ = settings_.cache;
+  }
+}
+
+CatalogSettings::LayerSettingsResult CatalogSettings::GetLayerSettingsFromModel(
+    const model::Catalog& catalog, const std::string& layer_id) {
+  const auto& layers = catalog.GetLayers();
+
+  auto layer_it = std::find_if(
+      layers.begin(), layers.end(),
+      [&](const model::Layer& layer) { return layer.GetId() == layer_id; });
+
+  CatalogSettings::LayerSettings settings;
+  if (layer_it != layers.end()) {
+    return CatalogSettings::LayerSettings{layer_it->GetContentType(),
+                                          layer_it->GetContentEncoding()};
+  }
+
+  return client::ApiError(
+      client::ErrorCode::InvalidArgument,
+      (boost::format("Layer '%1%' not found in catalog '%2%'") % layer_id %
+       catalog_.ToString())
+          .str());
+}
+
+CatalogSettings::LayerSettingsResult CatalogSettings::GetLayerSettings(
+    client::CancellationContext context, BillingTag billing_tag,
+    const std::string& layer_id) {
+  const auto catalog_settings_key = catalog_.ToString() + "::catalog";
+
+  if (!cache_->Contains(catalog_settings_key)) {
+    auto lookup_response = ApiClientLookup::LookupApiClient(
+        catalog_, context, "config", "v1", settings_);
+    if (!lookup_response.IsSuccessful()) {
+      return lookup_response.GetError();
+    }
+
+    client::OlpClient client = lookup_response.GetResult();
+    auto catalog_response = ConfigApi::GetCatalog(client, catalog_.ToString(),
+                                                  billing_tag, context);
+
+    if (!catalog_response.IsSuccessful()) {
+      return catalog_response.GetError();
+    }
+
+    auto catalog_model = catalog_response.MoveResult();
+
+    cache_->Put(
+        catalog_settings_key, catalog_model,
+        [&]() { return serializer::serialize<model::Catalog>(catalog_model); },
+        settings_.default_cache_expiration.count());
+
+    return GetLayerSettingsFromModel(catalog_model, layer_id);
+  }
+
+  LayerSettings settings;
+
+  const auto& cached_catalog =
+      cache_->Get(catalog_settings_key, [](const std::string& model) {
+        return parser::parse<model::Catalog>(model);
+      });
+
+  if (cached_catalog.empty()) {
+    return client::ApiError(
+        client::ErrorCode::Unknown,
+        (boost::format("Cached catalog '%1' is empty") % catalog_.ToString())
+            .str());
+  }
+
+  const auto& catalog = boost::any_cast<const model::Catalog&>(cached_catalog);
+  return GetLayerSettingsFromModel(catalog, layer_id);
+}
+
+}  // namespace write
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/CatalogSettings.h
+++ b/olp-cpp-sdk-dataservice-write/src/CatalogSettings.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+
+#include <olp/core/cache/KeyValueCache.h>
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/CancellationContext.h>
+#include <olp/core/client/HRN.h>
+#include <olp/core/client/OlpClientSettings.h>
+
+namespace olp {
+namespace dataservice {
+namespace write {
+
+namespace model {
+class Catalog;
+}
+
+class CatalogSettings {
+ public:
+  using BillingTag = boost::optional<std::string>;
+
+  struct LayerSettings {
+    std::string content_type;
+    std::string content_encoding;
+  };
+  using LayerSettingsResult =
+      client::ApiResponse<LayerSettings, client::ApiError>;
+
+  CatalogSettings(const client::HRN catalog,
+                  client::OlpClientSettings settings);
+
+  LayerSettingsResult GetLayerSettings(client::CancellationContext context,
+                                       BillingTag billing_tag,
+                                       const std::string& layer_id);
+
+ private:
+  LayerSettingsResult GetLayerSettingsFromModel(const model::Catalog& catalog,
+                                                const std::string& layer_id);
+
+  client::HRN catalog_;
+  std::shared_ptr<cache::KeyValueCache> cache_;
+  client::OlpClientSettings settings_;
+};
+
+}  // namespace write
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.h
@@ -32,6 +32,7 @@
 
 #include <olp/dataservice/write/IndexLayerClient.h>
 #include "generated/model/Catalog.h"
+#include "CatalogSettings.h"
 
 namespace olp {
 namespace dataservice {
@@ -42,8 +43,6 @@ class PublishDataRequest;
 }
 
 using InitApiClientsCallback =
-    std::function<void(boost::optional<client::ApiError>)>;
-using InitCatalogModelCallback =
     std::function<void(boost::optional<client::ApiError>)>;
 
 class IndexLayerClientImpl
@@ -82,15 +81,9 @@ class IndexLayerClientImpl
       std::shared_ptr<client::CancellationContext> cancel_context,
       InitApiClientsCallback callback);
 
-  client::CancellationToken InitCatalogModel(
-      const model::PublishIndexRequest& request,
-      const InitCatalogModelCallback& callback);
-
-  std::string FindContentTypeForLayerId(const std::string& layer_id);
-
  private:
   client::HRN catalog_;
-  model::Catalog catalog_model_;
+  CatalogSettings catalog_settings_;
 
   client::OlpClientSettings settings_;
 

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
@@ -27,6 +27,7 @@
 #include <olp/core/client/OlpClientSettings.h>
 
 #include <olp/dataservice/write/StreamLayerClient.h>
+#include "CatalogSettings.h"
 #include "generated/model/Catalog.h"
 
 namespace olp {
@@ -86,26 +87,13 @@ class StreamLayerClientImpl {
   virtual std::string GenerateUuid() const;
 
  private:
-  using BillingTag = boost::optional<std::string>;
-
-  struct LayerSettings {
-    std::string content_type;
-    std::string content_encoding;
-  };
-
-  using LayerSettingsResult =
-      client::ApiResponse<LayerSettings, client::ApiError>;
-
-  LayerSettingsResult GetLayerSettings(client::CancellationContext context,
-                                       BillingTag billing_tag,
-                                       const std::string& layer_id);
-
   std::string GetUuidListKey() const;
 
  private:
   client::HRN catalog_;
 
   client::OlpClientSettings settings_;
+  CatalogSettings catalog_settings_;
 
   std::shared_ptr<cache::KeyValueCache> cache_;
   mutable std::mutex cache_mutex_;

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.h
@@ -27,6 +27,7 @@
 #include <olp/core/client/OlpClient.h>
 #include <olp/core/client/PendingRequests.h>
 #include "CancellationTokenList.h"
+#include "CatalogSettings.h"
 #include "generated/model/Catalog.h"
 
 #include <condition_variable>
@@ -108,19 +109,17 @@ class VersionedLayerClientImpl
       CheckDataExistsCallback callback);
 
  private:
-  std::string FindContentTypeForLayerId(const std::string& layer_id);
+  using BillingTag = boost::optional<std::string>;
 
   client::CancellationToken InitApiClients(
       std::shared_ptr<client::CancellationContext> cancel_context,
       InitApiClientsCallback callback);
 
-  void InitCatalogModel(
-      std::shared_ptr<client::CancellationContext> cancel_context,
-      const InitCatalogModelCallback& callback);
-
   void UploadBlob(std::string publication_id,
                   std::shared_ptr<model::PublishPartition> partition,
-                  std::string data_handle, std::string layer_id,
+                  std::string data_handle, std::string content_type,
+                  std::string content_encoding, std::string layer_id,
+                  BillingTag billing_tag,
                   std::shared_ptr<client::CancellationContext> cancel_context,
                   const UploadBlobCallback& callback);
 
@@ -133,7 +132,7 @@ class VersionedLayerClientImpl
   client::HRN catalog_;
   client::OlpClientSettings settings_;
 
-  model::Catalog catalog_model_;
+  CatalogSettings catalog_settings_;
 
   std::shared_ptr<client::OlpClient> apiclient_blob_;
   std::shared_ptr<client::OlpClient> apiclient_config_;

--- a/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.h
@@ -30,6 +30,7 @@
 
 #include <olp/dataservice/write/VolatileLayerClient.h>
 #include "CancellationTokenList.h"
+#include "CatalogSettings.h"
 #include "generated/model/Catalog.h"
 
 namespace olp {
@@ -42,8 +43,6 @@ class Partition;
 }  // namespace model
 
 using InitApiClientsCallback =
-    std::function<void(boost::optional<client::ApiError>)>;
-using InitCatalogModelCallback =
     std::function<void(boost::optional<client::ApiError>)>;
 using DataHandleMap = std::map<std::string, std::string>;
 using DataHandleMapResponse =
@@ -106,12 +105,6 @@ class VolatileLayerClientImpl
       std::shared_ptr<client::CancellationContext> cancel_context,
       InitApiClientsCallback callback);
 
-  client::CancellationToken InitCatalogModel(
-      const model::PublishPartitionDataRequest& request,
-      const InitCatalogModelCallback& callback);
-
-  std::string FindContentTypeForLayerId(const std::string& layer_id);
-
   client::CancellationToken GetDataHandleMap(
       const std::string& layerId, const std::vector<std::string>& partitionIds,
       boost::optional<int64_t> version,
@@ -121,9 +114,10 @@ class VolatileLayerClientImpl
 
  private:
   client::HRN catalog_;
-  model::Catalog catalog_model_;
 
   client::OlpClientSettings settings_;
+
+  CatalogSettings catalog_settings_;
 
   std::shared_ptr<client::OlpClient> apiclient_config_;
   std::shared_ptr<client::OlpClient> apiclient_blob_;

--- a/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.cpp
@@ -37,7 +37,8 @@ namespace write {
 
 client::CancellationToken BlobApi::PutBlob(
     const client::OlpClient& client, const std::string& layer_id,
-    const std::string& content_type, const std::string& data_handle,
+    const std::string& content_type, const std::string& content_encoding,
+    const std::string& data_handle,
     const std::shared_ptr<std::vector<unsigned char>>& data,
     const boost::optional<std::string>& billing_tag, PutBlobCallback callback) {
   std::multimap<std::string, std::string> header_params;
@@ -45,6 +46,9 @@ client::CancellationToken BlobApi::PutBlob(
   std::multimap<std::string, std::string> form_params;
 
   header_params.insert(std::make_pair("Accept", "application/json"));
+  if (!content_encoding.empty()) {
+    header_params.insert(std::make_pair("Content-Encoding", content_encoding));
+  }
 
   if (billing_tag) {
     query_params.insert(
@@ -71,7 +75,8 @@ client::CancellationToken BlobApi::PutBlob(
 
 PutBlobResponse BlobApi::PutBlob(
     const client::OlpClient& client, const std::string& layer_id,
-    const std::string& content_type, const std::string& data_handle,
+    const std::string& content_type, const std::string& content_encoding,
+    const std::string& data_handle,
     const std::shared_ptr<std::vector<unsigned char>>& data,
     const boost::optional<std::string>& billing_tag,
     client::CancellationContext cancel_context) {
@@ -80,6 +85,10 @@ PutBlobResponse BlobApi::PutBlob(
   std::multimap<std::string, std::string> form_params;
 
   header_params.insert(std::make_pair("Accept", "application/json"));
+
+  if (!content_encoding.empty()) {
+      header_params.insert(std::make_pair("Content-Encoding", content_encoding));
+  }
 
   if (billing_tag) {
     query_params.insert(

--- a/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.h
@@ -81,7 +81,8 @@ class BlobApi {
    */
   static client::CancellationToken PutBlob(
       const client::OlpClient& client, const std::string& layer_id,
-      const std::string& content_type, const std::string& data_handle,
+      const std::string& content_type, const std::string& content_encoding,
+      const std::string& data_handle,
       const std::shared_ptr<std::vector<unsigned char>>& data,
       const boost::optional<std::string>& billing_tag,
       PutBlobCallback callback);
@@ -91,7 +92,8 @@ class BlobApi {
    */
   static PutBlobResponse PutBlob(
       const client::OlpClient& client, const std::string& layer_id,
-      const std::string& content_type, const std::string& data_handle,
+      const std::string& content_type, const std::string& content_encoding,
+      const std::string& data_handle,
       const std::shared_ptr<std::vector<unsigned char>>& data,
       const boost::optional<std::string>& billing_tag,
       client::CancellationContext cancel_contex);

--- a/tests/integration/olp-cpp-sdk-dataservice-write/IndexLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/IndexLayerClientTest.cpp
@@ -54,7 +54,6 @@ void PublishCancelledAssertions(
             result.GetError().GetHttpStatusCode());
   EXPECT_EQ(olp::client::ErrorCode::Cancelled,
             result.GetError().GetErrorCode());
-  EXPECT_EQ("Cancelled", result.GetError().GetMessage());
 }
 
 class IndexLayerClientTest : public ::testing::Test {
@@ -182,11 +181,11 @@ TEST_F(IndexLayerClientTest, PublishData) {
   {
     testing::InSequence dummy;
 
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
         .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INDEX), _, _, _, _))
+        .Times(1);
+    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
         .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
         .Times(1);
@@ -213,11 +212,11 @@ TEST_F(IndexLayerClientTest, DeleteData) {
   {
     testing::InSequence dummy;
 
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
         .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INDEX), _, _, _, _))
+        .Times(1);
+    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
         .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
         .Times(1);
@@ -260,8 +259,6 @@ TEST_F(IndexLayerClientTest, UpdateIndex) {
   {
     testing::InSequence dummy;
 
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
         .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INDEX), _, _, _, _))
@@ -301,15 +298,15 @@ TEST_F(IndexLayerClientTest, PublishDataCancelConfig) {
   {
     testing::InSequence dummy;
 
+    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
+        .Times(1);
+    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INDEX), _, _, _, _))
+        .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
         .Times(1)
         .WillOnce(testing::Invoke(std::move(send_mock)));
     EXPECT_CALL(*network_, Cancel(request_id))
         .WillOnce(testing::Invoke(std::move(cancel_mock)));
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
-        .Times(0);
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INDEX), _, _, _, _))
-        .Times(0);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
         .Times(0);
     EXPECT_CALL(*network_,
@@ -346,14 +343,14 @@ TEST_F(IndexLayerClientTest, PublishDataCancelBlob) {
   {
     testing::InSequence dummy;
 
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
         .Times(1)
         .WillOnce(testing::Invoke(std::move(send_mock)));
     EXPECT_CALL(*network_, Cancel(request_id))
         .WillOnce(testing::Invoke(std::move(cancel_mock)));
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INDEX), _, _, _, _))
+        .Times(0);
+    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
         .Times(0);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
         .Times(0);
@@ -392,8 +389,6 @@ TEST_F(IndexLayerClientTest, PublishDataCancelIndex) {
   {
     testing::InSequence dummy;
 
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
         .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INDEX), _, _, _, _))
@@ -401,6 +396,8 @@ TEST_F(IndexLayerClientTest, PublishDataCancelIndex) {
         .WillOnce(testing::Invoke(std::move(send_mock)));
     EXPECT_CALL(*network_, Cancel(request_id))
         .WillOnce(testing::Invoke(std::move(cancel_mock)));
+    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
+        .Times(0);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
         .Times(0);
     EXPECT_CALL(*network_,
@@ -438,11 +435,11 @@ TEST_F(IndexLayerClientTest, PublishDataCancelGetCatalog) {
   {
     testing::InSequence dummy;
 
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
         .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INDEX), _, _, _, _))
+        .Times(1);
+    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
         .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
         .Times(1)
@@ -483,11 +480,11 @@ TEST_F(IndexLayerClientTest, PublishDataCancelPutBlob) {
   {
     testing::InSequence dummy;
 
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
         .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INDEX), _, _, _, _))
+        .Times(1);
+    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
         .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
         .Times(1);

--- a/tests/integration/olp-cpp-sdk-dataservice-write/VolatileLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/VolatileLayerClientTest.cpp
@@ -27,6 +27,7 @@
 #include <olp/core/client/OlpClientSettingsFactory.h>
 #include <olp/core/http/HttpStatusCode.h>
 #include <olp/dataservice/write/VolatileLayerClient.h>
+#include <iostream>
 #include "HttpResponses.h"
 
 namespace {
@@ -157,9 +158,6 @@ TEST_F(VolatileLayerClientTest, PublishData) {
   auto new_client = CreateVolatileLayerClient();
   {
     testing::InSequence dummy;
-
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_METADATA), _, _, _, _))
         .Times(1);
     EXPECT_CALL(*network_,
@@ -170,10 +168,12 @@ TEST_F(VolatileLayerClientTest, PublishData) {
     EXPECT_CALL(*network_,
                 Send(IsGetRequest(URL_LOOKUP_PUBLISH_V2), _, _, _, _))
         .Times(1);
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
-        .Times(1);
     EXPECT_CALL(*network_,
                 Send(IsGetRequest(URL_QUERY_PARTITION_1111), _, _, _, _))
+        .Times(1);
+    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
+        .Times(1);
+    EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
         .Times(1);
     EXPECT_CALL(
         *network_,
@@ -192,7 +192,7 @@ TEST_F(VolatileLayerClientTest, PublishData) {
   ASSERT_NO_FATAL_FAILURE(PublishDataSuccessAssertions(response));
 }
 
-TEST_F(VolatileLayerClientTest, PublishDataCancelConfig) {
+TEST_F(VolatileLayerClientTest, PublishDataCancelMetadata) {
   auto wait_for_cancel = std::make_shared<std::promise<void>>();
   auto pause_for_cancel = std::make_shared<std::promise<void>>();
 
@@ -202,12 +202,12 @@ TEST_F(VolatileLayerClientTest, PublishDataCancelConfig) {
 
   std::tie(request_id, send_mock, cancel_mock) = GenerateNetworkMockActions(
       wait_for_cancel, pause_for_cancel,
-      {http::HttpStatusCode::OK, HTTP_RESPONSE_LOOKUP_CONFIG});
+      {http::HttpStatusCode::OK, URL_LOOKUP_METADATA});
 
   {
     testing::InSequence s;
 
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
+    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_METADATA), _, _, _, _))
         .Times(1)
         .WillOnce(testing::Invoke(std::move(send_mock)));
     EXPECT_CALL(*network_, Cancel(request_id))
@@ -251,8 +251,6 @@ TEST_F(VolatileLayerClientTest, PublishDataCancelBlob) {
   {
     testing::InSequence s;
 
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_METADATA), _, _, _, _))
         .Times(1);
     EXPECT_CALL(*network_,
@@ -298,8 +296,6 @@ TEST_F(VolatileLayerClientTest, PublishDataCancelCatalog) {
   {
     testing::InSequence s;
 
-    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
-        .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_METADATA), _, _, _, _))
         .Times(1);
     EXPECT_CALL(*network_,
@@ -309,6 +305,11 @@ TEST_F(VolatileLayerClientTest, PublishDataCancelCatalog) {
         .Times(1);
     EXPECT_CALL(*network_,
                 Send(IsGetRequest(URL_LOOKUP_PUBLISH_V2), _, _, _, _))
+        .Times(1);
+    EXPECT_CALL(*network_,
+                Send(IsGetRequest(URL_QUERY_PARTITION_1111), _, _, _, _))
+        .Times(1);
+    EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
         .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))
         .Times(1)


### PR DESCRIPTION
Add Content-Encoding header to requests in olp::dataservice::write
module. Content-Encoding added based on layer settings received from
OLP Platform.

Resolves: OLPSUP-11354

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>