### PR TITLE
Move tests to mock server

### DIFF
--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -413,28 +413,6 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataWithInvalidHrn) {
             data_response.GetError().GetHttpStatusCode());
 }
 
-TEST_F(DataserviceReadVersionedLayerClientTest, GetDataWithHandle) {
-  olp::client::HRN hrn(GetTestCatalog());
-
-  auto catalog_client =
-      std::make_unique<olp::dataservice::read::VersionedLayerClient>(
-          hrn, "testlayer", boost::none, *settings_);
-
-  auto request = olp::dataservice::read::DataRequest();
-  request.WithDataHandle("d5d73b64-7365-41c3-8faf-aa6ad5bab135");
-  auto data_response = GetExecutionTime<dataservice_read::DataResponse>([&] {
-    auto future = catalog_client->GetData(request);
-    return future.GetFuture().get();
-  });
-
-  EXPECT_SUCCESS(data_response);
-  ASSERT_TRUE(data_response.GetResult() != nullptr);
-  ASSERT_LT(0, data_response.GetResult()->size());
-  std::string data_string(data_response.GetResult()->begin(),
-                          data_response.GetResult()->end());
-  ASSERT_EQ("DT_2_0031", data_string);
-}
-
 TEST_F(DataserviceReadVersionedLayerClientTest, GetDataWithInvalidDataHandle) {
   olp::client::HRN hrn(GetTestCatalog());
 
@@ -479,29 +457,6 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetDataWithPartitionId) {
   auto catalog_client =
       std::make_unique<olp::dataservice::read::VersionedLayerClient>(
           hrn, "testlayer", boost::none, *settings_);
-
-  auto request = olp::dataservice::read::DataRequest();
-  request.WithPartitionId("269");
-  auto data_response = GetExecutionTime<dataservice_read::DataResponse>([&] {
-    auto future = catalog_client->GetData(request);
-    return future.GetFuture().get();
-  });
-
-  EXPECT_SUCCESS(data_response);
-  ASSERT_TRUE(data_response.GetResult() != nullptr);
-  ASSERT_LT(0, data_response.GetResult()->size());
-  std::string data_string(data_response.GetResult()->begin(),
-                          data_response.GetResult()->end());
-  ASSERT_EQ("DT_2_0031", data_string);
-}
-
-TEST_F(DataserviceReadVersionedLayerClientTest,
-       GetDataWithPartitionIdVersion2) {
-  olp::client::HRN hrn(GetTestCatalog());
-
-  auto catalog_client =
-      std::make_unique<olp::dataservice::read::VersionedLayerClient>(
-          hrn, "testlayer", 2, *settings_);
 
   auto request = olp::dataservice::read::DataRequest();
   request.WithPartitionId("269");
@@ -616,25 +571,6 @@ TEST_F(DataserviceReadVersionedLayerClientTest,
 
   EXPECT_FALSE(data_response.IsSuccessful());
   ASSERT_EQ(olp::client::ErrorCode::NotFound,
-            data_response.GetError().GetErrorCode());
-}
-
-TEST_F(DataserviceReadVersionedLayerClientTest, GetDataWithInvalidLayerId) {
-  olp::client::HRN hrn(GetTestCatalog());
-
-  auto catalog_client =
-      std::make_unique<olp::dataservice::read::VersionedLayerClient>(
-          hrn, "invalidLayer", boost::none, *settings_);
-
-  auto request = olp::dataservice::read::DataRequest();
-  request.WithPartitionId("269");
-  auto data_response = GetExecutionTime<dataservice_read::DataResponse>([&] {
-    auto future = catalog_client->GetData(request);
-    return future.GetFuture().get();
-  });
-
-  ASSERT_FALSE(data_response.IsSuccessful());
-  ASSERT_EQ(olp::client::ErrorCode::BadRequest,
             data_response.GetError().GetErrorCode());
 }
 

--- a/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientGetDataTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientGetDataTest.cpp
@@ -37,9 +37,6 @@ const auto kTestHrn = "hrn:here:data::olp-here-test:hereos-internal-test";
 const auto kLayer = "testlayer";
 const auto kVersion = 44;
 constexpr auto kWaitTimeout = std::chrono::seconds(10);
-const auto kPartitionsResponsePath =
-    "/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test/"
-    "layers/testlayer/partitions";
 
 class VersionedLayerClientGetDataTest : public ::testing::Test {
  protected:
@@ -55,6 +52,11 @@ class VersionedLayerClientGetDataTest : public ::testing::Test {
     auto network = std::move(settings_->network_request_handler);
     settings_.reset();
     mock_server_client_.reset();
+  }
+
+  std::string GenerateGetPartitionsPath(const std::string& hrn,
+                                        const std::string& layer) {
+    return "/query/v1/catalogs/" + hrn + "/layers/" + layer + "/partitions";
   }
 
   std::shared_ptr<olp::client::OlpClientSettings> settings_;
@@ -74,7 +76,7 @@ TEST_F(VersionedLayerClientGetDataTest, GetDataFromPartitionSync) {
         mockserver::ReadDefaultResponses::GenerateVersionResponse(kVersion));
     mock_server_client_->MockGetResponse(
         mockserver::ReadDefaultResponses::GeneratePartitionsResponse(1),
-        kPartitionsResponsePath);
+        GenerateGetPartitionsPath(kTestHrn, kLayer));
     mock_server_client_->MockGetResponse(
         kLayer, mockserver::ReadDefaultResponses::GenerateDataHandle(partition),
         data);
@@ -105,7 +107,7 @@ TEST_F(VersionedLayerClientGetDataTest, GetDataFromPartitionAsync) {
         mockserver::ReadDefaultResponses::GenerateVersionResponse(kVersion));
     mock_server_client_->MockGetResponse(
         mockserver::ReadDefaultResponses::GeneratePartitionsResponse(1),
-        kPartitionsResponsePath);
+        GenerateGetPartitionsPath(kTestHrn, kLayer));
     mock_server_client_->MockGetResponse(
         kLayer, mockserver::ReadDefaultResponses::GenerateDataHandle(partition),
         data);
@@ -130,6 +132,100 @@ TEST_F(VersionedLayerClientGetDataTest, GetDataFromPartitionAsync) {
   ASSERT_TRUE(response.GetResult() != nullptr);
   ASSERT_EQ(response.GetResult()->size(), data.size());
 
+  EXPECT_TRUE(mock_server_client_->Verify());
+}
+
+TEST_F(VersionedLayerClientGetDataTest, GetDataWithHandle) {
+  olp::client::HRN hrn(kTestHrn);
+
+  const auto data_handle =
+      mockserver::ReadDefaultResponses::GenerateDataHandle("test");
+  const auto data = mockserver::ReadDefaultResponses::GenerateData();
+
+  mock_server_client_->MockAuth();
+  mock_server_client_->MockLookupResourceApiResponse(
+      mockserver::ApiDefaultResponses::GenerateResourceApisResponse(kTestHrn));
+
+  mock_server_client_->MockGetResponse(kLayer, data_handle, data);
+
+  auto client = olp::dataservice::read::VersionedLayerClient(
+      hrn, kLayer, boost::none, *settings_);
+
+  auto request = olp::dataservice::read::DataRequest();
+  request.WithDataHandle(data_handle);
+
+  auto future = client.GetData(request);
+  auto data_response = future.GetFuture().get();
+
+  EXPECT_SUCCESS(data_response);
+  ASSERT_TRUE(data_response.GetResult() != nullptr);
+  ASSERT_LT(0, data_response.GetResult()->size());
+  std::string data_string(data_response.GetResult()->begin(),
+                          data_response.GetResult()->end());
+  ASSERT_EQ(data, data_string);
+  EXPECT_TRUE(mock_server_client_->Verify());
+}
+
+TEST_F(VersionedLayerClientGetDataTest, GetDataWithInvalidLayerId) {
+  olp::client::HRN hrn(kTestHrn);
+
+  const auto kInvalidLayer = "InvalidLayer";
+
+  mock_server_client_->MockAuth();
+  mock_server_client_->MockLookupResourceApiResponse(
+      mockserver::ApiDefaultResponses::GenerateResourceApisResponse(kTestHrn));
+  mock_server_client_->MockGetVersionResponse(
+      mockserver::ReadDefaultResponses::GenerateVersionResponse(kVersion));
+  mock_server_client_->MockGetError(
+      olp::client::ApiError(olp::http::HttpStatusCode::BAD_REQUEST),
+      GenerateGetPartitionsPath(kTestHrn, kInvalidLayer));
+
+  auto client = olp::dataservice::read::VersionedLayerClient(
+      hrn, kInvalidLayer, boost::none, *settings_);
+
+  auto request = olp::dataservice::read::DataRequest();
+  request.WithPartitionId("269");
+
+  auto future = client.GetData(request);
+  auto data_response = future.GetFuture().get();
+
+  ASSERT_FALSE(data_response.IsSuccessful());
+  ASSERT_EQ(olp::client::ErrorCode::BadRequest,
+            data_response.GetError().GetErrorCode());
+  EXPECT_TRUE(mock_server_client_->Verify());
+}
+
+TEST_F(VersionedLayerClientGetDataTest, GetDataWithPartitionIdVersion2) {
+  olp::client::HRN hrn(kTestHrn);
+
+  auto partitions_model =
+      mockserver::ReadDefaultResponses::GeneratePartitionsResponse(1);
+  auto data_handle = partitions_model.GetPartitions()[0].GetDataHandle();
+  auto data = mockserver::ReadDefaultResponses::GenerateData();
+
+  mock_server_client_->MockAuth();
+  mock_server_client_->MockLookupResourceApiResponse(
+      mockserver::ApiDefaultResponses::GenerateResourceApisResponse(kTestHrn));
+  mock_server_client_->MockGetResponse(
+      partitions_model, GenerateGetPartitionsPath(kTestHrn, kLayer));
+
+  mock_server_client_->MockGetResponse(kLayer, data_handle, data);
+
+  auto client =
+      olp::dataservice::read::VersionedLayerClient(hrn, kLayer, 2, *settings_);
+
+  auto request = olp::dataservice::read::DataRequest();
+  request.WithPartitionId("269");
+
+  auto future = client.GetData(request);
+  auto data_response = future.GetFuture().get();
+
+  EXPECT_SUCCESS(data_response);
+  ASSERT_TRUE(data_response.GetResult() != nullptr);
+  ASSERT_LT(0, data_response.GetResult()->size());
+  std::string data_string(data_response.GetResult()->begin(),
+                          data_response.GetResult()->end());
+  ASSERT_EQ(data, data_string);
   EXPECT_TRUE(mock_server_client_->Verify());
 }
 


### PR DESCRIPTION
Move following read versioned layer client tests to
use mock server instead of real server to make tests
more reliable.

Moved tests:
* GetDataWithHandle
* GetDataWithInvalidLayerId
* GetDataWithPartitionIdVersion2

Resolves: OLPEDGE-1972, OLPEDGE-1973, OLPEDGE-1974

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>