### PR TITLE
DataCallbackTest fv network test.

### DIFF
--- a/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
+++ b/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
@@ -838,7 +838,7 @@ void NetworkWinHttp::RequestCallback(HINTERNET, DWORD_PTR context, DWORD status,
       OLP_SDK_LOG_TRACE(kLogTag, "Received " << data_len << " bytes for id="
                                              << handle->request_id);
       if (data_len) {
-        std::uint64_t total_offset = 0;
+        std::uint64_t total_offset = request_result.count;
 
         if (handle->data_callback) {
           handle->data_callback((const uint8_t*)data_buffer, total_offset,

--- a/tests/common/ReadDefaultResponses.h
+++ b/tests/common/ReadDefaultResponses.h
@@ -71,12 +71,18 @@ class ReadDefaultResponses {
     return partitions;
   }
 
-  static std::string GenerateData() {
-    std::string result =
+  static std::string GenerateData(size_t length = 128u) {
+    std::string letters =
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     std::random_device device;
     std::mt19937 generator(device());
-    std::shuffle(result.begin(), result.end(), generator);
+    std::uniform_int_distribution<unsigned int> dis(0u, letters.length() - 1);
+
+    std::string result;
+    result.resize(length);
+    for (auto i = 0u; i < length; ++i) {
+      result[i] += letters[dis(generator)];
+    }
 
     return result;
   }

--- a/tests/common/ReadDefaultResponses.h
+++ b/tests/common/ReadDefaultResponses.h
@@ -71,7 +71,7 @@ class ReadDefaultResponses {
     return partitions;
   }
 
-  static std::string GenerateData(size_t length = 128u) {
+  static std::string GenerateData(size_t length = 64u) {
     std::string letters =
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     std::random_device device;

--- a/tests/functional/network/CMakeLists.txt
+++ b/tests/functional/network/CMakeLists.txt
@@ -18,6 +18,7 @@
 
 set(OLP_SDK_NETWORK_TESTS_SOURCES
     ./ConcurrencyTest.cpp
+    ./DataCallbackTest.cpp
     ./DestructionTest.cpp
     ./NetworkTestBase.cpp
     ./TimeoutTest.cpp

--- a/tests/functional/network/DataCallbackTest.cpp
+++ b/tests/functional/network/DataCallbackTest.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <memory>
+
+#include <gtest/gtest.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/http/Network.h>
+#include <olp/core/http/NetworkSettings.h>
+
+#include "NetworkTestBase.h"
+#include "ReadDefaultResponses.h"
+
+namespace {
+using NetworkRequest = olp::http::NetworkRequest;
+using NetworkResponse = olp::http::NetworkResponse;
+using NetworkSettings = olp::http::NetworkSettings;
+
+using DataCallbackTest = NetworkTestBase;
+
+TEST_F(DataCallbackTest, DataChunks) {
+  const std::string kUrlBase = "https://some-url.com";
+  const std::string kApiBase = "/some-api";
+
+  // generate 1mb of data
+  constexpr auto data_size = 1u * 1024u * 1024u;
+  auto data = mockserver::ReadDefaultResponses::GenerateData(data_size);
+  auto payload = std::make_shared<std::stringstream>();
+  std::vector<uint8_t> chunk_data(data_size);
+
+  // we expect multiple data chunks are received in the test.
+  int chunk_count = 0;
+
+  mock_server_client_->MockResponse("GET", kApiBase, data);
+
+  const auto url = kUrlBase + kApiBase;
+  const auto request = NetworkRequest(url).WithSettings(settings_).WithVerb(
+      olp::http::NetworkRequest::HttpVerb::GET);
+
+  std::promise<NetworkResponse> promise;
+  const auto outcome = network_->Send(
+      request, payload,
+      [&promise](NetworkResponse response) {
+        promise.set_value(std::move(response));
+      },
+      nullptr,
+      [&chunk_data, &chunk_count](const std::uint8_t* data,
+                                  std::uint64_t offset, std::size_t length) {
+        std::copy(data, data + length, &chunk_data[offset]);
+        ++chunk_count;
+      });
+  ASSERT_TRUE(outcome.IsSuccessful());
+
+  auto future = promise.get_future();
+  const auto response = future.get();
+  const auto& payload_data = payload->str();
+
+  ASSERT_EQ(response.GetStatus(), olp::http::HttpStatusCode::OK);
+  ASSERT_GT(chunk_count, 2);
+  EXPECT_TRUE(std::equal(data.begin(), data.end(), chunk_data.begin()));
+  EXPECT_EQ(data, payload_data);
+}
+
+}  // namespace


### PR DESCRIPTION
Add new DataCallbackTest network test. Test goal is to download some
big data in chunks and check data_callback works correctly.

For windows, data_callback offset is always 0, so fixing the bug too.

Resolves: OLPEDGE-2065

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>