### PR TITLE
Add timestamp to default logging

### DIFF
--- a/olp-cpp-sdk-core/src/logging/MessageFormatter.cpp
+++ b/olp-cpp-sdk-core/src/logging/MessageFormatter.cpp
@@ -32,20 +32,25 @@ static const char* limitString(std::string& tempStr, const char* str,
   if (limit < 0) {
     int length = static_cast<int>(std::strlen(str));
     int start = std::max(length + limit, 0);
-    if (start == 0) return str;
+    if (start == 0) {
+      return str;
+    }
 
     if (length - start > 3) {
       tempStr = "...";
       start += 3;
-    } else
+    } else {
       tempStr.clear();
+    }
 
     tempStr.append(str, start, length - start);
     return tempStr.c_str();
   } else if (limit > 0) {
     std::size_t strLen = std::strlen(str);
     std::size_t finalLength = std::min(strLen, static_cast<std::size_t>(limit));
-    if (finalLength == strLen) return str;
+    if (finalLength == strLen) {
+      return str;
+    }
 
     bool addElipses = false;
     if (finalLength > 3) {
@@ -54,10 +59,13 @@ static const char* limitString(std::string& tempStr, const char* str,
     }
 
     tempStr.assign(str, finalLength);
-    if (addElipses) tempStr += "...";
+    if (addElipses) {
+      tempStr += "...";
+    }
     return tempStr.c_str();
-  } else
+  } else {
     return str;
+  }
 }
 
 MessageFormatter::Element::Element(ElementType type_) : type(type_), limit(0) {
@@ -95,9 +103,10 @@ const MessageFormatter::LevelNameMap& MessageFormatter::defaultLevelNameMap() {
 }
 
 MessageFormatter MessageFormatter::createDefault() {
-  return MessageFormatter({Element(ElementType::Level, "%s "),
-                           Element(ElementType::Tag, "%s - "),
-                           Element(ElementType::Message)});
+  return MessageFormatter(
+      {Element(ElementType::Time, "%T"), Element(ElementType::TimeMs, ".%.3u "),
+       Element(ElementType::Level, "%s "), Element(ElementType::Tag, "%s - "),
+       Element(ElementType::Message)});
 }
 
 std::string MessageFormatter::format(const LogMessage& message) const {
@@ -118,7 +127,9 @@ std::string MessageFormatter::format(const LogMessage& message) const {
             m_levelNameMap[static_cast<std::size_t>(message.level)].c_str());
         break;
       case ElementType::Tag:
-        if (!message.tag || !*message.tag) continue;
+        if (!message.tag || !*message.tag) {
+          continue;
+        }
 
         curElement = curElementBuffer.format(
             element.format.c_str(),

--- a/olp-cpp-sdk-core/tests/logging/FileAppenderTest.cpp
+++ b/olp-cpp-sdk-core/tests/logging/FileAppenderTest.cpp
@@ -36,25 +36,33 @@
 
 namespace {
 
-using namespace olp::logging;
-using namespace testing;
+namespace logging = olp::logging;
 
 TEST(FileAppenderTest, Default) {
   {
+    logging::MessageFormatter formatter(
+        {logging::MessageFormatter::Element(
+             logging::MessageFormatter::ElementType::Level, "%s "),
+         logging::MessageFormatter::Element(
+             logging::MessageFormatter::ElementType::Tag, "%s - "),
+         logging::MessageFormatter::Element(
+             logging::MessageFormatter::ElementType::Message)});
+
     SCOPED_TRACE("Create appender");
-    auto appender = std::make_shared<FileAppender>("test.txt");
+    auto appender =
+        std::make_shared<logging::FileAppender>("test.txt", false, formatter);
     ASSERT_TRUE(appender->isValid());
     EXPECT_EQ("test.txt", appender->getFileName());
 
-    Configuration configuration{};
+    logging::Configuration configuration{};
     configuration.addAppender(appender);
-    Log::configure(configuration);
-    Log::setLevel(Level::Info);
+    logging::Log::configure(configuration);
+    logging::Log::setLevel(logging::Level::Info);
 
     OLP_SDK_LOG_INFO("test", "test 1");
     OLP_SDK_LOG_WARNING("test", "test 2");
 
-    Log::configure(Configuration::createDefault());
+    logging::Log::configure(logging::Configuration::createDefault());
   }
 
   {
@@ -82,42 +90,52 @@ TEST(FileAppenderTest, Default) {
 }
 
 TEST(FileAppenderTest, NonExistingFile) {
-  auto appender = std::make_shared<FileAppender>("asdf/foo/bar");
+  auto appender = std::make_shared<logging::FileAppender>("asdf/foo/bar");
   EXPECT_FALSE(appender->isValid());
 }
 
 TEST(FileAppenderTest, Append) {
+  logging::MessageFormatter formatter(
+      {logging::MessageFormatter::Element(
+           logging::MessageFormatter::ElementType::Level, "%s "),
+       logging::MessageFormatter::Element(
+           logging::MessageFormatter::ElementType::Tag, "%s - "),
+       logging::MessageFormatter::Element(
+           logging::MessageFormatter::ElementType::Message)});
+
   {
     SCOPED_TRACE("Create appender");
-    auto appender = std::make_shared<FileAppender>("test.txt", true);
+    auto appender =
+        std::make_shared<logging::FileAppender>("test.txt", true, formatter);
     ASSERT_TRUE(appender->isValid());
     EXPECT_EQ("test.txt", appender->getFileName());
     EXPECT_TRUE(appender->getAppendFile());
 
-    Configuration configuration{};
+    logging::Configuration configuration{};
     configuration.addAppender(appender);
-    Log::configure(configuration);
-    Log::setLevel(Level::Info);
+    logging::Log::configure(configuration);
+    logging::Log::setLevel(logging::Level::Info);
 
     OLP_SDK_LOG_INFO("test", "test 1");
     OLP_SDK_LOG_WARNING("test", "test 2");
 
-    Log::configure(Configuration::createDefault());
+    logging::Log::configure(logging::Configuration::createDefault());
   }
 
   {
     SCOPED_TRACE("Re-create appender");
-    auto appender = std::make_shared<FileAppender>("test.txt", true);
+    auto appender =
+        std::make_shared<logging::FileAppender>("test.txt", true, formatter);
     EXPECT_TRUE(appender->isValid());
 
-    Configuration configuration{};
+    logging::Configuration configuration{};
     configuration.addAppender(appender);
-    Log::configure(configuration);
+    logging::Log::configure(configuration);
 
     OLP_SDK_LOG_ERROR("test", "test 3");
     OLP_SDK_LOG_FATAL("test", "test 4");
 
-    Log::configure(Configuration::createDefault());
+    logging::Log::configure(logging::Configuration::createDefault());
   }
 
   {

--- a/olp-cpp-sdk-core/tests/logging/LogTest.cpp
+++ b/olp-cpp-sdk-core/tests/logging/LogTest.cpp
@@ -31,8 +31,6 @@
 
 namespace {
 
-using namespace testing;
-
 TEST(LogTest, Levels) {
   EXPECT_TRUE(olp::logging::Log::configure(
       olp::logging::Configuration::createDefault()));
@@ -126,8 +124,18 @@ TEST(LogTest, DifferentLevelsForDifferentAppenders) {
 }
 
 TEST(LogTest, DifferentLevelsForConsoleAndFileLogging) {
-  auto console_appender = std::make_shared<olp::logging::ConsoleAppender>();
-  auto file_appender = std::make_shared<olp::logging::FileAppender>("test.txt");
+  olp::logging::MessageFormatter formatter(
+      {olp::logging::MessageFormatter::Element(
+           olp::logging::MessageFormatter::ElementType::Level, "%s "),
+       olp::logging::MessageFormatter::Element(
+           olp::logging::MessageFormatter::ElementType::Tag, "%s - "),
+       olp::logging::MessageFormatter::Element(
+           olp::logging::MessageFormatter::ElementType::Message)});
+
+  auto console_appender =
+      std::make_shared<olp::logging::ConsoleAppender>(formatter);
+  auto file_appender = std::make_shared<olp::logging::FileAppender>(
+      "test.txt", false, formatter);
 
   ASSERT_TRUE(file_appender->isValid());
   EXPECT_EQ("test.txt", file_appender->getFileName());


### PR DESCRIPTION
Add timestamp to default logging including miliseconds.
Minor code style changes in MessageFormatter.cpp

Resolves: OLPEDGE-2239

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>