### PR TITLE
Fix MakeDirectoryContentReadonly recursion loop.

### DIFF
--- a/olp-cpp-sdk-core/tests/cache/Helpers.cpp
+++ b/olp-cpp-sdk-core/tests/cache/Helpers.cpp
@@ -39,7 +39,7 @@
 namespace {
 #if defined(_WIN32) && !defined(__MINGW32__)
 
-bool MakeDirectoryContentReadonly(const TCHAR* utfdirPath, bool readonly) {
+bool MakeDirectoryContentReadonlyWin(const TCHAR* utfdirPath, bool readonly) {
   HANDLE hFind;  // file handle
   WIN32_FIND_DATA FindFileData;
 
@@ -72,7 +72,7 @@ bool MakeDirectoryContentReadonly(const TCHAR* utfdirPath, bool readonly) {
       StringCchCat(filename, _countof(filename), FindFileData.cFileName);
       if (FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
         // we have found a directory, recurse
-        if (!MakeDirectoryContentReadonly(filename, readonly)) {
+        if (!MakeDirectoryContentReadonlyWin(filename, readonly)) {
           bSearch = false;
           break;
         }
@@ -141,7 +141,7 @@ bool MakeDirectoryContentReadonly(const std::string& path, bool readonly) {
   const TCHAR* n_path = path.c_str();
 #endif  // _UNICODE
 
-  return MakeDirectoryContentReadonly(n_path, readonly);
+  return MakeDirectoryContentReadonlyWin(n_path, readonly);
 
 #else
 


### PR DESCRIPTION
Helpers.cpp contains overloaded MakeDirectoryContentReadonly function.
1st one translates std::string into TCHAR* and call 2nd one, but at
least on windows compiler translates TCHAR* into std::string again and
infinite recursion occur.

Resolves: OLPEDGE-2270

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>