### PR TITLE
Fix the GetAggregatedData behavior

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -68,7 +68,7 @@ class PartitionsRepository {
                                         const std::string& partition);
 
   PartitionResponse GetAggregatedTile(const std::string& layer,
-                                      const TileRequest& request,
+                                      TileRequest request,
                                       boost::optional<int64_t> version,
                                       client::CancellationContext context);
 

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -39,7 +39,7 @@ target_include_directories(olp-cpp-sdk-tests-common PUBLIC
 )
 
 target_link_libraries(olp-cpp-sdk-tests-common
-    PRIVATE
+    PUBLIC
         gmock
         olp-cpp-sdk-core
         olp-cpp-sdk-dataservice-write

--- a/tests/common/ReadDefaultResponses.cpp
+++ b/tests/common/ReadDefaultResponses.cpp
@@ -29,45 +29,45 @@
 #include <rapidjson/writer.h>
 
 namespace {
-void WriteSubquadsToJson(rapidjson::Document& doc,
-                         const olp::geo::TileKey& root_tile,
-                         const std::vector<std::uint16_t>& sub_quads,
-                         rapidjson::Document::AllocatorType& allocator) {
+
+void WriteSubquadsToJson(
+    rapidjson::Document& doc, const olp::geo::TileKey& root_tile,
+    const std::map<std::uint64_t, mockserver::TileMetadata>& sub_quads,
+    rapidjson::Document::AllocatorType& allocator) {
   rapidjson::Value sub_quads_value;
   sub_quads_value.SetArray();
   for (auto quad : sub_quads) {
-    const auto partition = root_tile.AddedSubkey64(quad).ToHereTile();
-    const auto data_handle =
-        mockserver::ReadDefaultResponses::GenerateDataHandle(partition);
+    const auto partition = root_tile.AddedSubkey64(quad.first).ToHereTile();
+    const auto& data_handle = quad.second.data_handle;
+    const auto version = quad.second.version;
 
     rapidjson::Value item_value;
     item_value.SetObject();
-    olp::serializer::serialize("subQuadKey", std::to_string(quad), item_value,
-                               allocator);
-    olp::serializer::serialize("version", 0, item_value, allocator);
+    olp::serializer::serialize("subQuadKey", std::to_string(quad.first),
+                               item_value, allocator);
+    olp::serializer::serialize("version", version, item_value, allocator);
     olp::serializer::serialize("dataHandle", data_handle, item_value,
                                allocator);
-    olp::serializer::serialize("dataSize", 100, item_value, allocator);
     sub_quads_value.PushBack(std::move(item_value), allocator);
   }
   doc.AddMember("subQuads", std::move(sub_quads_value), allocator);
 }
 
-void WriteParentquadsToJson(rapidjson::Document& doc,
-                            const std::vector<std::uint64_t>& parent_quads,
-                            rapidjson::Document::AllocatorType& allocator) {
+void WriteParentquadsToJson(
+    rapidjson::Document& doc,
+    const std::map<std::uint64_t, mockserver::TileMetadata>& parent_quads,
+    rapidjson::Document::AllocatorType& allocator) {
   rapidjson::Value parent_quads_value;
   parent_quads_value.SetArray();
   for (auto parent : parent_quads) {
-    const auto partition = std::to_string(parent);
-    const auto data_handle =
-        mockserver::ReadDefaultResponses::GenerateDataHandle(partition);
+    const auto partition = std::to_string(parent.first);
+    const auto version = parent.second.version;
+    const auto& data_handle = parent.second.data_handle;
 
     rapidjson::Value item_value;
     item_value.SetObject();
-    olp::serializer::serialize("partition", std::to_string(parent), item_value,
-                               allocator);
-    olp::serializer::serialize("version", 0, item_value, allocator);
+    olp::serializer::serialize("partition", partition, item_value, allocator);
+    olp::serializer::serialize("version", version, item_value, allocator);
     olp::serializer::serialize("dataHandle", data_handle, item_value,
                                allocator);
     olp::serializer::serialize("dataSize", 100, item_value, allocator);
@@ -75,36 +75,64 @@ void WriteParentquadsToJson(rapidjson::Document& doc,
   }
   doc.AddMember("parentQuads", std::move(parent_quads_value), allocator);
 }
+
+std::string GenerateRandomString(size_t length) {
+  std::string letters =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  std::random_device device;
+  std::mt19937 generator(device());
+  std::uniform_int_distribution<unsigned int> dis(0u, letters.length() - 1);
+
+  std::string result;
+  result.resize(length);
+  for (auto i = 0u; i < length; ++i) {
+    result[i] += letters[dis(generator)];
+  }
+
+  return result;
+}
+
+void FillSubQuads(std::int32_t depth, std::vector<std::uint16_t>& sub_quads_) {
+  const auto sub_tile = olp::geo::TileKey::FromRowColumnLevel(0, 0, depth);
+  const auto start_level_id = sub_tile.ToQuadKey64();
+  const auto tiles_count = olp::geo::QuadKey64Helper::ChildrenAtLevel(depth);
+
+  std::vector<std::uint64_t> layer_ids(tiles_count);
+  std::iota(layer_ids.begin(), layer_ids.end(), start_level_id);
+  sub_quads_.insert(sub_quads_.end(), layer_ids.begin(), layer_ids.end());
+}
+
 }  // namespace
 
 namespace mockserver {
 
+std::string ReadDefaultResponses::GenerateData(size_t length) {
+  return GenerateRandomString(length);
+}
+
 std::string ReadDefaultResponses::GenerateQuadTreeResponse(
     olp::geo::TileKey root_tile, std::uint32_t depth,
     const std::vector<std::uint32_t>& available_levels) {
-  std::vector<std::uint16_t> sub_quads;
-  std::vector<std::uint64_t> parent_quads;
+  std::map<std::uint64_t, TileMetadata> sub_quads;
+  std::map<std::uint64_t, TileMetadata> parent_quads;
 
   // generate data
   for (auto level : available_levels) {
     if (level < root_tile.Level()) {
-      auto key = root_tile.ChangedLevelTo(level);
-      parent_quads.push_back(key.ToQuadKey64());
+      auto key = root_tile.ChangedLevelTo(level).ToQuadKey64();
+      parent_quads[key] = {GenerateDataHandle(std::to_string(key)), 0};
     } else {
       const auto level_depth = level - root_tile.Level();
       if (level_depth > depth) {
         continue;
       }
 
-      const auto sub_tile =
-          olp::geo::TileKey::FromRowColumnLevel(0, 0, level_depth);
-      const auto start_level_id = sub_tile.ToQuadKey64();
-      const auto tiles_count =
-          olp::geo::QuadKey64Helper::ChildrenAtLevel(level_depth);
+      std::vector<std::uint16_t> sub_quads_vector;
+      FillSubQuads(level_depth, sub_quads_vector);
 
-      std::vector<std::uint64_t> layer_ids(tiles_count);
-      std::iota(layer_ids.begin(), layer_ids.end(), start_level_id);
-      sub_quads.insert(sub_quads.end(), layer_ids.begin(), layer_ids.end());
+      for (const auto& sub_quad : sub_quads_vector) {
+        sub_quads[sub_quad] = {GenerateDataHandle(std::to_string(sub_quad)), 0};
+      }
     }
   }
 
@@ -119,5 +147,90 @@ std::string ReadDefaultResponses::GenerateQuadTreeResponse(
   doc.Accept(writer);
   return buffer.GetString();
 }
+
+QuadTreeBuilder::QuadTreeBuilder(olp::geo::TileKey root_tile,
+                                 boost::optional<int32_t> version)
+    : root_tile_(root_tile), base_version_(version) {}
+
+QuadTreeBuilder& QuadTreeBuilder::WithParent(olp::geo::TileKey parent,
+                                             std::string datahandle,
+                                             boost::optional<int32_t> version) {
+  assert(root_tile_.IsChildOf(parent));
+
+  // Make sure to set version when the base_version is set
+  if (version != boost::none) {
+    assert(base_version_ != boost::none);
+  } else if (base_version_) {
+    version = base_version_;
+  }
+
+  parent_quads_[parent.ToQuadKey64()] = {datahandle, version};
+
+  return *this;
+}
+
+QuadTreeBuilder& QuadTreeBuilder::FillParents() {
+  auto key = root_tile_.Parent();
+  while (key.IsValid()) {
+    auto quad_key = key.ToQuadKey64();
+    if (parent_quads_.find(quad_key) == parent_quads_.end()) {
+      parent_quads_[quad_key] = {GenerateRandomString(32), base_version_};
+    }
+  }
+  return *this;
+}
+
+QuadTreeBuilder& QuadTreeBuilder::WithSubQuad(
+    olp::geo::TileKey tile, std::string datahandle,
+    boost::optional<int32_t> version) {
+  assert(tile.IsChildOf(root_tile_) || tile == root_tile_);
+  assert((tile.Level() - root_tile_.Level()) <= 4);
+  if (version != boost::none) {
+    assert(base_version_ != boost::none);
+  }
+
+  auto origin = root_tile_.ChangedLevelTo(tile.Level());
+  auto sub_quad =
+      olp::geo::TileKey::FromRowColumnLevel(tile.Row() - origin.Row(),
+                                            tile.Column() - origin.Column(),
+                                            tile.Level() - root_tile_.Level())
+          .ToQuadKey64();
+
+  sub_quads_[sub_quad] = {datahandle, version};
+
+  return *this;
+}
+
+QuadTreeBuilder& QuadTreeBuilder::FillSubquads(uint32_t depth) {
+  assert(depth <= 4);
+
+  std::vector<std::uint16_t> sub_quads;
+  for (uint32_t i = 0; i <= depth; i++) {
+    FillSubQuads(i, sub_quads);
+  }
+
+  for (const auto& sub_quad : sub_quads) {
+    if (sub_quads_.find(sub_quad) == sub_quads_.end()) {
+      sub_quads_[sub_quad] = {GenerateRandomString(32), base_version_};
+    }
+  }
+
+  return *this;
+}
+
+std::string QuadTreeBuilder::BuildJson() const {
+  rapidjson::Document doc;
+  auto& allocator = doc.GetAllocator();
+  doc.SetObject();
+  WriteSubquadsToJson(doc, root_tile_, sub_quads_, allocator);
+  WriteParentquadsToJson(doc, parent_quads_, allocator);
+
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  doc.Accept(writer);
+  return buffer.GetString();
+}
+
+olp::geo::TileKey QuadTreeBuilder::Root() const { return root_tile_; }
 
 }  // namespace mockserver

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -22,6 +22,7 @@ set(OLP_SDK_INTEGRATIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
     ./olp-cpp-sdk-dataservice-read/VolatileLayerClientCacheTest.cpp
     ./olp-cpp-sdk-dataservice-read/VersionedLayerClientCacheTest.cpp
+    ./olp-cpp-sdk-dataservice-read/VersionedLayerGetAggregatedDataTest.cpp
     ./olp-cpp-sdk-dataservice-read/CatalogClientTestBase.cpp
     ./olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
     ./olp-cpp-sdk-dataservice-read/HttpResponses.h
@@ -46,7 +47,6 @@ if (ANDROID OR IOS)
     target_link_libraries(${OLP_SDK_INTEGRATION_TESTS_LIB}
         PRIVATE
             gmock
-            olp-cpp-sdk-tests-common
             olp-cpp-sdk-core
             olp-cpp-sdk-authentication
             olp-cpp-sdk-dataservice-read
@@ -79,7 +79,6 @@ else()
     target_link_libraries(olp-cpp-sdk-integration-tests
         PRIVATE
             gmock_main
-            olp-cpp-sdk-tests-common
             olp-cpp-sdk-core
             olp-cpp-sdk-authentication
             olp-cpp-sdk-dataservice-read

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -3343,38 +3343,6 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetAggregatedData) {
     ASSERT_EQ(error.GetErrorCode(), client::ErrorCode::NotFound);
     testing::Mock::VerifyAndClearExpectations(network_mock_.get());
   }
-
-  {
-    SCOPED_TRACE("Parent");
-    EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_API), _, _, _, _))
-        .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
-                                     HTTP_RESPONSE_LOOKUP));
-    EXPECT_CALL(*network_mock_,
-                Send(IsGetRequest(URL_QUADKEYS_AGGREGATE_92259), _, _, _, _))
-        .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
-                                     HTTP_RESPONSE_QUADKEYS_92259_PARENT));
-    EXPECT_CALL(
-        *network_mock_,
-        Send(IsGetRequest(URL_BLOB_AGGREGATE_DATA_23618364), _, _, _, _))
-        .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
-                                     "some_data"));
-
-    auto client = read::VersionedLayerClient(kCatalog, kTestLayer, kTestVersion,
-                                             settings_);
-    auto future =
-        client.GetAggregatedData(read::TileRequest().WithTileKey(tile_key))
-            .GetFuture();
-
-    ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
-    const auto response = future.get();
-    const auto& result = response.GetResult();
-
-    ASSERT_TRUE(response.IsSuccessful());
-    ASSERT_TRUE(result.GetData());
-    ASSERT_EQ(result.GetTile(), tile_key.ChangedLevelTo(2));
-    testing::Mock::VerifyAndClearExpectations(network_mock_.get());
-  }
-
   {
     SCOPED_TRACE("Empty quad tree");
     EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_API), _, _, _, _))

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerGetAggregatedDataTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerGetAggregatedDataTest.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2019-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock.h>
+
+#include <olp/core/cache/CacheSettings.h>
+#include <olp/core/cache/KeyValueCache.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/http/HttpStatusCode.h>
+#include <olp/dataservice/read/VersionedLayerClient.h>
+
+#include <mocks/NetworkMock.h>
+
+#include "matchers/NetworkUrlMatchers.h"
+
+#include "ReadDefaultResponses.h"
+
+namespace {
+
+namespace read = olp::dataservice::read;
+namespace client = olp::client;
+namespace geo = olp::geo;
+namespace http = olp::http;
+
+using testing::_;
+
+const auto kCatalog = "hrn:here:data::olp-here-test:catalog";
+const client::HRN kCatalogHrn = client::HRN::FromString(kCatalog);
+const auto kEndpoint = "https://localhost";
+
+constexpr auto kWaitTimeout = std::chrono::seconds(3);
+
+class VersionedLayerGetAggregatedDataTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    network_mock_ = std::make_shared<NetworkMock>();
+
+    settings_.api_lookup_settings.catalog_endpoint_provider =
+        [](const client::HRN&) { return kEndpoint; };
+
+    settings_.network_request_handler = network_mock_;
+    settings_.task_scheduler =
+        client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1);
+  }
+
+  void TearDown() override {
+    testing::Mock::VerifyAndClearExpectations(network_mock_.get());
+    network_mock_.reset();
+    settings_.task_scheduler.reset();
+  }
+
+  void ExpectQuadTreeRequest(const std::string& layer, int64_t version,
+                             mockserver::QuadTreeBuilder quad_tree) {
+    std::stringstream url;
+    url << kEndpoint << "/catalogs/" << kCatalog << "/layers/" << layer
+        << "/versions/" << version << "/quadkeys/"
+        << quad_tree.Root().ToHereTile() << "/depths/4";
+
+    EXPECT_CALL(*network_mock_, Send(IsGetRequest(url.str()), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            http::NetworkResponse().WithStatus(http::HttpStatusCode::OK),
+            quad_tree.BuildJson()));
+  }
+
+  void ExpectBlobRequest(const std::string& layer,
+                         const std::string& data_handle,
+                         const std::string& data) {
+    std::stringstream url;
+    url << kEndpoint << "/catalogs/" << kCatalog << "/layers/" << layer
+        << "/data/" << data_handle;
+
+    EXPECT_CALL(*network_mock_, Send(IsGetRequest(url.str()), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            http::NetworkResponse().WithStatus(http::HttpStatusCode::OK),
+            data));
+  }
+
+ protected:
+  client::OlpClientSettings settings_;
+  std::shared_ptr<NetworkMock> network_mock_;
+};
+
+TEST_F(VersionedLayerGetAggregatedDataTest, ParentTileFarAway) {
+  const auto layer = "testlayer";
+  const auto ver = 7;
+
+  const auto target_tile =
+      olp::geo::TileKey::FromRowColumnLevel(6481, 8800, 14);
+  const auto aggregated_parent = target_tile.ChangedLevelTo(1);
+
+  // Mock a quad tree that bundles 0-14 levels, and a blob
+  {
+    const auto tree_root = target_tile.ChangedLevelTo(0);
+    const auto aggregated_parent = target_tile.ChangedLevelTo(1);
+
+    mockserver::QuadTreeBuilder tree_10(target_tile.ChangedLevelTo(10), ver);
+    tree_10.WithParent(tree_root, "handle-0")
+        .WithParent(aggregated_parent, "handle-1");
+
+    mockserver::QuadTreeBuilder tree_5(target_tile.ChangedLevelTo(5), ver);
+    tree_5.WithParent(tree_root, "handle-0")
+        .WithParent(aggregated_parent, "handle-1");
+
+    mockserver::QuadTreeBuilder tree_0(target_tile.ChangedLevelTo(0), ver);
+    tree_0.WithSubQuad(tree_root, "handle-0")
+        .WithSubQuad(aggregated_parent, "handle-1");
+
+    ExpectQuadTreeRequest(layer, ver, tree_10);
+    ExpectQuadTreeRequest(layer, ver, tree_5);
+    ExpectQuadTreeRequest(layer, ver, tree_0);
+
+    // Expect to download handle-1
+    ExpectBlobRequest(layer, "handle-1", "A");
+  }
+
+  olp::cache::CacheSettings settings;
+  settings.disk_path_mutable = "./tmp_cache";
+  settings_.cache =
+      olp::client::OlpClientSettingsFactory::CreateDefaultCache(settings);
+
+  read::VersionedLayerClient client(kCatalogHrn, layer, ver, settings_);
+
+  auto api_call_outcome =
+      client.GetAggregatedData(read::TileRequest().WithTileKey(target_tile));
+
+  auto future = api_call_outcome.GetFuture();
+
+  ASSERT_NE(future.wait_for(kWaitTimeout), std::future_status::timeout);
+
+  auto api_result = future.get();
+
+  ASSERT_TRUE(api_result.IsSuccessful());
+
+  const auto& aggregate_result = api_result.GetResult();
+
+  ASSERT_EQ(aggregate_result.GetTile(), aggregated_parent);
+
+  // Validate that all APIs can't handle it.
+  ASSERT_TRUE(client.IsCached(target_tile, true));
+  ASSERT_TRUE(client.IsCached(aggregated_parent));
+  ASSERT_TRUE(client.Protect({aggregated_parent}));
+  ASSERT_TRUE(client.Release({aggregated_parent}));
+  ASSERT_TRUE(client.RemoveFromCache(aggregated_parent));
+
+  testing::Mock::VerifyAndClearExpectations(network_mock_.get());
+}
+
+}  // namespace


### PR DESCRIPTION
Fix the GetAggregatedData behavior when the aggregated
tile root is too far away, for example, the tile on level 14 is
aggregated in tile on level 1, it means that the tile could be found
on levels 10-14, and tiles on levels 1-9 can't be found anymore.
In such a case we iterate up and fetch quadtrees until the aggregated
tile root is found in tree subquads. So it could be found later by
other APIs, ex. Protect, Release, Remove, etc.

Resolves: OLPSUP-11651

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>