### PR TITLE
Add PrefetchPartitions result types

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchPartitionsResult.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchPartitionsResult.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <olp/dataservice/read/DataServiceReadApi.h>
@@ -27,34 +28,24 @@
 namespace olp {
 namespace dataservice {
 namespace read {
-namespace model {
 
 /**
  * @brief Represents the result of a prefetch operation for partitions.
  */
-class DATASERVICE_READ_API PrefetchedPartitions {
+class DATASERVICE_READ_API PrefetchPartitionsResult {
  public:
   /**
    * @brief A parent type of the current `PrefetchedPartitions` class.
    */
-  PrefetchedPartitions() = default;
+  PrefetchPartitionsResult() = default;
 
   /**
    * @brief Adds the partition ID that was successfully downloaded.
    *
    * @param partition The partition ID.
    */
-  void AddPartition(std::string&& partition) {
-    partitions.emplace_back(partition);
-  }
-
-  /**
-   * @brief Adds the partition ID that was successfully downloaded.
-   *
-   * @param partition The partition ID.
-   */
-  void AddPartition(const std::string& partition) {
-    partitions.push_back(partition);
+  void AddPartition(std::string partition) {
+    partitions.emplace_back(std::move(partition));
   }
 
   /**
@@ -75,7 +66,6 @@ class DATASERVICE_READ_API PrefetchedPartitions {
   std::vector<std::string> partitions;
 };
 
-}  // namespace model
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
@@ -27,12 +27,12 @@
 #include <olp/core/client/ApiResponse.h>
 
 #include <olp/dataservice/read/AggregatedDataResult.h>
+#include <olp/dataservice/read/PrefetchPartitionsResult.h>
 #include <olp/dataservice/read/PrefetchStatus.h>
 #include <olp/dataservice/read/model/Catalog.h>
 #include <olp/dataservice/read/model/Data.h>
 #include <olp/dataservice/read/model/Messages.h>
 #include <olp/dataservice/read/model/Partitions.h>
-#include <olp/dataservice/read/model/PrefetchedPartitions.h>
 #include <olp/dataservice/read/model/VersionInfos.h>
 #include <olp/dataservice/read/model/VersionResponse.h>
 
@@ -71,7 +71,7 @@ using PartitionsResponse = Response<PartitionsResult>;
 /// The callback type of the partition metadata response.
 using PartitionsResponseCallback = Callback<PartitionsResult>;
 
-/// The data alias type.
+/// The `Data` alias type.
 using DataResult = model::Data;
 /// The data response alias.
 using DataResponse = Response<DataResult>;
@@ -92,12 +92,10 @@ using PrefetchTilesResponseCallback = Callback<PrefetchTilesResult>;
 /// The callback type for the prefetch status update.
 using PrefetchStatusCallback = std::function<void(PrefetchStatus)>;
 
-/// The `PrefetchedPartitions` alias type.
-using PrefetchedPartitionsResult = model::PrefetchedPartitions;
 /// The prefetch partitions response type.
-using PrefetchPartitionsResponse = Response<PrefetchedPartitionsResult>;
+using PrefetchPartitionsResponse = Response<PrefetchPartitionsResult>;
 /// The callback type of the prefetch completion.
-using PrefetchPartitionsResponseCallback = Callback<PrefetchedPartitionsResult>;
+using PrefetchPartitionsResponseCallback = Callback<PrefetchPartitionsResult>;
 
 /// The subscribe ID type of the stream layer client.
 using SubscriptionId = std::string;

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
@@ -32,6 +32,7 @@
 #include <olp/dataservice/read/model/Data.h>
 #include <olp/dataservice/read/model/Messages.h>
 #include <olp/dataservice/read/model/Partitions.h>
+#include <olp/dataservice/read/model/PrefetchedPartitions.h>
 #include <olp/dataservice/read/model/VersionInfos.h>
 #include <olp/dataservice/read/model/VersionResponse.h>
 
@@ -90,6 +91,13 @@ using PrefetchTilesResponse = Response<PrefetchTilesResult>;
 using PrefetchTilesResponseCallback = Callback<PrefetchTilesResult>;
 /// The callback type for the prefetch status update.
 using PrefetchStatusCallback = std::function<void(PrefetchStatus)>;
+
+/// The `PrefetchedPartitions` alias type.
+using PrefetchedPartitionsResult = model::PrefetchedPartitions;
+/// The prefetch partitions response type.
+using PrefetchPartitionsResponse = Response<PrefetchedPartitionsResult>;
+/// The callback type of the prefetch completion.
+using PrefetchPartitionsResponseCallback = Callback<PrefetchedPartitionsResult>;
 
 /// The subscribe ID type of the stream layer client.
 using SubscriptionId = std::string;

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/model/PrefetchedPartitions.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/model/PrefetchedPartitions.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <olp/dataservice/read/DataServiceReadApi.h>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+namespace model {
+
+/**
+ * @brief Represents the result of a prefetch operation for partitions.
+ */
+class DATASERVICE_READ_API PrefetchedPartitions {
+ public:
+  /**
+   * @brief A parent type of the current `PrefetchedPartitions` class.
+   */
+  PrefetchedPartitions() = default;
+
+  /**
+   * @brief Adds the partition ID that was successfully downloaded.
+   *
+   * @param partition The partition ID.
+   */
+  void AddPartition(std::string&& partition) {
+    partitions.emplace_back(partition);
+  }
+
+  /**
+   * @brief Adds the partition ID that was successfully downloaded.
+   *
+   * @param partition The partition ID.
+   */
+  void AddPartition(const std::string& partition) {
+    partitions.push_back(partition);
+  }
+
+  /**
+   * @brief Gets the list of prefetched partitions.
+   *
+   * @return The list of partitions.
+   */
+  const std::vector<std::string>& GetPartitions() const { return partitions; }
+
+  /**
+   * @brief Moves the list of prefetched partitions.
+   *
+   * @return A forwarding reference to the partitions.
+   */
+  std::vector<std::string>&& MovePartitions() { return std::move(partitions); }
+
+ private:
+  std::vector<std::string> partitions;
+};
+
+}  // namespace model
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp


### PR DESCRIPTION
Add PrefetchPartitions result types

Add PrefetchedPartitions class, which
contains all downloaded partitions.
Add alias for PrefetchPartitionsResponse
and PrefetchPartitionsResponseCallback.

Relates-To: OLPEDGE-1902

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>