### PR TITLE
Add api to prefetch partitions.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -31,6 +31,7 @@
 #include <olp/dataservice/read/DataRequest.h>
 #include <olp/dataservice/read/DataServiceReadApi.h>
 #include <olp/dataservice/read/PartitionsRequest.h>
+#include <olp/dataservice/read/PrefetchPartitionsRequest.h>
 #include <olp/dataservice/read/PrefetchTileResult.h>
 #include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/TileRequest.h>
@@ -350,6 +351,58 @@ class DATASERVICE_READ_API VersionedLayerClient final {
   client::CancellableFuture<PrefetchTilesResponse> PrefetchTiles(
       PrefetchTilesRequest request,
       PrefetchStatusCallback status_callback = nullptr);
+
+  /**
+   * @brief Prefetches a set of partitions asynchronously.
+   *
+   * This method downloads all partitions listed in \c
+   * PrefetchPartitionsRequest. Only partitions will be downloaded which are not
+   * already present in the cache, this helps reduce the network load.
+   *
+   * @note This method does not guarantee that all partitions are available
+   * offline as the cache might overflow, and data might be evicted at any
+   * point. Use GetData(DataRequest) to retrieve partitions loaded by
+   * PrefetchPartitions.
+   *
+   * @param request The `PrefetchPartitionsRequest` instance that contains
+   * a complete set of request parameters.
+   * @param callback The `PrefetchPartitionsResponseCallback` object that is
+   * invoked if the `PrefetchPartitionsResult` instance is available or an error
+   * is encountered.
+   * @param status_callback The `PrefetchPartitionsStatusCallback` object that
+   * is invoked every time a tile is fetched.
+   *
+   * @return A token that can be used to cancel this request.
+   */
+  client::CancellationToken PrefetchPartitions(
+      PrefetchPartitionsRequest request,
+      PrefetchPartitionsResponseCallback callback,
+      PrefetchPartitionsStatusCallback status_callback = nullptr);
+
+  /**
+   * @brief Prefetches a set of partitions asynchronously.
+   *
+   * This method downloads all partitions listed in \c
+   * PrefetchPartitionsRequest. Only partitions will be downloaded which are not
+   * already present in the cache, this helps reduce the network load.
+   *
+   * @note This method does not guarantee that all partitions are available
+   * offline as the cache might overflow, and data might be evicted at any
+   * point. Use GetData(DataRequest) to retrieve partitions loaded by
+   * PrefetchPartitions.
+   *
+   * @param request The `PrefetchPartitionsRequest` instance that contains
+   * a complete set of request parameters.
+   * @param status_callback The `PrefetchPartitionsStatusCallback` object that
+   * is invoked every time a tile is fetched.
+   *
+   * @return `CancellableFuture` that contains the `PrefetchPartitionsResponse`
+   * instance with data or an error. You can also use `CancellableFuture` to
+   * cancel this request.
+   */
+  client::CancellableFuture<PrefetchPartitionsResponse> PrefetchPartitions(
+      PrefetchPartitionsRequest request,
+      PrefetchPartitionsStatusCallback status_callback = nullptr);
 
   /**
    * @brief Removes the partition from the mutable disk cache.

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -355,20 +355,20 @@ class DATASERVICE_READ_API VersionedLayerClient final {
   /**
    * @brief Prefetches a set of partitions asynchronously.
    *
-   * This method downloads all partitions listed in \c
-   * PrefetchPartitionsRequest. Only partitions will be downloaded which are not
-   * already present in the cache, this helps reduce the network load.
+   * This method downloads all partitions listed in
+   * `PrefetchPartitionsRequest`. Only partitions that are not already present
+   * in the cache are downloaded. It helps reduce the network load.
    *
    * @note This method does not guarantee that all partitions are available
    * offline as the cache might overflow, and data might be evicted at any
-   * point. Use GetData(DataRequest) to retrieve partitions loaded by
-   * PrefetchPartitions.
+   * point. Use `GetData(DataRequest)` to retrieve partitions loaded by
+   * `PrefetchPartitions`.
    *
    * @param request The `PrefetchPartitionsRequest` instance that contains
    * a complete set of request parameters.
    * @param callback The `PrefetchPartitionsResponseCallback` object that is
    * invoked if the `PrefetchPartitionsResult` instance is available or an error
-   * is encountered.
+   * occurs.
    * @param status_callback The `PrefetchPartitionsStatusCallback` object that
    * is invoked every time a tile is fetched.
    *
@@ -382,14 +382,14 @@ class DATASERVICE_READ_API VersionedLayerClient final {
   /**
    * @brief Prefetches a set of partitions asynchronously.
    *
-   * This method downloads all partitions listed in \c
-   * PrefetchPartitionsRequest. Only partitions will be downloaded which are not
-   * already present in the cache, this helps reduce the network load.
+   * This method downloads all partitions listed in
+   * `PrefetchPartitionsRequest`. Only partitions that are not already present
+   * in the cache are downloaded. It helps reduce the network load.
    *
    * @note This method does not guarantee that all partitions are available
    * offline as the cache might overflow, and data might be evicted at any
-   * point. Use GetData(DataRequest) to retrieve partitions loaded by
-   * PrefetchPartitions.
+   * point. Use `GetData(DataRequest)` to retrieve partitions loaded by
+   * `PrefetchPartitions`.
    *
    * @param request The `PrefetchPartitionsRequest` instance that contains
    * a complete set of request parameters.

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -370,7 +370,7 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    * invoked if the `PrefetchPartitionsResult` instance is available or an error
    * occurs.
    * @param status_callback The `PrefetchPartitionsStatusCallback` object that
-   * is invoked every time a tile is fetched.
+   * is invoked every time a partition is fetched.
    *
    * @return A token that can be used to cancel this request.
    */
@@ -394,7 +394,7 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    * @param request The `PrefetchPartitionsRequest` instance that contains
    * a complete set of request parameters.
    * @param status_callback The `PrefetchPartitionsStatusCallback` object that
-   * is invoked every time a tile is fetched.
+   * is invoked every time a partition is fetched.
    *
    * @return `CancellableFuture` that contains the `PrefetchPartitionsResponse`
    * instance with data or an error. You can also use `CancellableFuture` to

--- a/olp-cpp-sdk-dataservice-read/src/PrefetchPartitionsHelper.h
+++ b/olp-cpp-sdk-dataservice-read/src/PrefetchPartitionsHelper.h
@@ -33,19 +33,13 @@
 #include "DownloadItemsJob.h"
 #include "ExtendedApiResponse.h"
 #include "ExtendedApiResponseHelpers.h"
-#include "QueryMetadataJob.h"
+#include "QueryPartitionsJob.h"
 #include "TaskSink.h"
 #include "repositories/PartitionsRepository.h"
 
 namespace olp {
 namespace dataservice {
 namespace read {
-
-using PartitionDataHandleResult =
-    std::vector<std::pair<std::string, std::string>>;
-using PartitionsDataHandleExtendedResponse =
-    ExtendedApiResponse<PartitionDataHandleResult, client::ApiError,
-                        client::NetworkStatistics>;
 
 class PrefetchPartitionsHelper {
  public:
@@ -60,9 +54,7 @@ class PrefetchPartitionsHelper {
       TaskSink& task_sink, size_t query_max_size, uint32_t priority) {
     client::CancellationContext execution_context;
 
-    auto query_job = std::make_shared<QueryMetadataJob<
-        std::string, std::vector<std::string>, PrefetchPartitionsResult,
-        PartitionsDataHandleExtendedResponse, PrefetchPartitionsStatus>>(
+    auto query_job = std::make_shared<QueryPartitionsJob>(
         std::move(query), nullptr, download_job, task_sink, execution_context,
         priority);
 

--- a/olp-cpp-sdk-dataservice-read/src/QueryPartitionsJob.h
+++ b/olp-cpp-sdk-dataservice-read/src/QueryPartitionsJob.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <iterator>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <olp/core/client/CancellationContext.h>
+#include <olp/core/logging/Log.h>
+#include <olp/dataservice/read/Types.h>
+#include "Common.h"
+#include "ExtendedApiResponse.h"
+#include "QueryMetadataJob.h"
+#include "TaskSink.h"
+
+namespace olp {
+namespace dataservice {
+namespace read {
+
+using PartitionDataHandleResult =
+    std::vector<std::pair<std::string, std::string>>;
+using PartitionsDataHandleExtendedResponse =
+    ExtendedApiResponse<PartitionDataHandleResult, client::ApiError,
+                        client::NetworkStatistics>;
+
+class QueryPartitionsJob
+    : public QueryMetadataJob<
+          std::string, std::vector<std::string>, PrefetchPartitionsResult,
+          PartitionsDataHandleExtendedResponse, PrefetchPartitionsStatus> {
+ public:
+  QueryPartitionsJob(
+      QueryItemsFunc<std::string, std::vector<std::string>,
+                     PartitionsDataHandleExtendedResponse>
+          query,
+      FilterItemsFunc<PartitionDataHandleResult> filter,
+      std::shared_ptr<DownloadItemsJob<std::string, PrefetchPartitionsResult,
+                                       PrefetchPartitionsStatus>>
+          download_job,
+      TaskSink& task_sink, client::CancellationContext execution_context,
+      uint32_t priority)
+      : QueryMetadataJob(std::move(query), std::move(filter),
+                         std::move(download_job), task_sink, execution_context,
+                         priority) {}
+
+  virtual bool CheckIfFail() {
+    // Return error only if all fails
+    return (query_errors_.size() == query_size_);
+  }
+};
+
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -80,6 +80,22 @@ VersionedLayerClient::PrefetchTiles(PrefetchTilesRequest request,
   return impl_->PrefetchTiles(std::move(request), std::move(status_callback));
 }
 
+client::CancellationToken VersionedLayerClient::PrefetchPartitions(
+    PrefetchPartitionsRequest request,
+    PrefetchPartitionsResponseCallback callback,
+    PrefetchPartitionsStatusCallback status_callback) {
+  return impl_->PrefetchPartitions(std::move(request), std::move(callback),
+                                   std::move(status_callback));
+}
+
+client::CancellableFuture<PrefetchPartitionsResponse>
+VersionedLayerClient::PrefetchPartitions(
+    PrefetchPartitionsRequest request,
+    PrefetchPartitionsStatusCallback status_callback) {
+  return impl_->PrefetchPartitions(std::move(request),
+                                   std::move(status_callback));
+}
+
 client::CancellationToken VersionedLayerClient::GetData(
     TileRequest request, DataResponseCallback callback) {
   return impl_->GetData(std::move(request), std::move(callback));

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -30,6 +30,7 @@ set(OLP_SDK_INTEGRATIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-dataservice-read/HttpResponses.h
     ./olp-cpp-sdk-dataservice-read/StreamLayerClientTest.cpp
     ./olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+    ./olp-cpp-sdk-dataservice-read/VersionedLayerClientPrefetchPartitionsTest.cpp
     ./olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
     ./olp-cpp-sdk-dataservice-write/HttpResponses.h
     ./olp-cpp-sdk-dataservice-write/IndexLayerClientTest.cpp

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientPrefetchPartitionsTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientPrefetchPartitionsTest.cpp
@@ -123,6 +123,30 @@ TEST_F(VersionedLayerClientPrefetchPartitionsTest, PrefetchPartitions) {
 
     auto response = future.get();
     ASSERT_TRUE(response.IsSuccessful());
+    ASSERT_FALSE(response.GetResult()->empty());
+    std::string data_string(response.GetResult()->begin(),
+                            response.GetResult()->end());
+    ASSERT_EQ("data", data_string);
+  }
+  {
+    SCOPED_TRACE("Get prefetched partition from cache");
+    std::promise<read::PrefetchPartitionsResponse> promise;
+
+    auto future =
+        client
+            .GetData(read::DataRequest()
+                         .WithFetchOption(read::FetchOptions::CacheOnly)
+                         .WithPartitionId(partitions.at(1)))
+            .GetFuture();
+    ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),
+              std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_TRUE(response.IsSuccessful());
+    ASSERT_FALSE(response.GetResult()->empty());
+    std::string data_string(response.GetResult()->begin(),
+                            response.GetResult()->end());
+    ASSERT_EQ("data", data_string);
   }
 }
 

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientPrefetchPartitionsTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientPrefetchPartitionsTest.cpp
@@ -1,0 +1,440 @@
+/*
+ * Copyright (C) 2019-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock.h>
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+#include <numeric>
+#include <string>
+
+#include <matchers/NetworkUrlMatchers.h>
+#include <mocks/NetworkMock.h>
+#include <olp/authentication/Settings.h>
+#include <olp/core/cache/CacheSettings.h>
+#include <olp/core/client/OlpClientSettings.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/dataservice/read/VersionedLayerClient.h>
+#include <olp/dataservice/read/model/Partitions.h>
+#include "HttpResponses.h"
+#include "PlatformUrlsGenerator.h"
+#include "ReadDefaultResponses.h"
+#include "ResponseGenerator.h"
+#include "VersionedLayerTestBase.h"
+
+using testing::_;
+
+namespace {
+
+namespace read = olp::dataservice::read;
+namespace client = olp::client;
+namespace http = olp::http;
+
+constexpr auto kTestLayer = "testlayer";
+constexpr auto kTestVersion = 108;
+
+constexpr auto kTimeout = std::chrono::seconds(3);
+
+class VersionedLayerClientPrefetchPartitionsTest
+    : public VersionedLayerTestBase {
+ protected:
+  VersionedLayerClientPrefetchPartitionsTest()
+      : VersionedLayerTestBase(VersionedLayerTestBase::EndpointType::kLookup),
+        api_response_(ResponseGenerator::ResourceApis(kCatalog)),
+        version_(kTestVersion),
+        layer_(kTestLayer),
+        generator_(api_response_, layer_) {}
+
+  std::vector<std::string> GeneratePartitionIds(size_t partitions_count) {
+    std::vector<std::string> partitions;
+    partitions.reserve(partitions_count);
+    for (auto i = 0u; i < partitions_count; i++) {
+      partitions.emplace_back(std::to_string(i));
+    }
+    return partitions;
+  }
+
+  void SetupApiResponse(http::NetworkResponse response,
+                        const std::string& api_response) {
+    EXPECT_CALL(*network_mock_, Send(IsGetRequest(kUrlLookup), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(response, api_response));
+  }
+
+  void SetupVersionResponse(http::NetworkResponse response) {
+    auto version_path = generator_.LatestVersion();
+    ASSERT_FALSE(version_path.empty());
+
+    EXPECT_CALL(*network_mock_, Send(IsGetRequest(version_path), _, _, _, _))
+        .WillOnce(
+            ReturnHttpResponse(response, ResponseGenerator::Version(version_)));
+  }
+
+  void SetupQueryPartitionsResponse(
+      http::NetworkResponse response,
+      const std::vector<std::string>& partitions,
+      const read::model::Partitions& partitions_response) {
+    auto partitions_path = generator_.PartitionsQuery(partitions, version_);
+
+    EXPECT_CALL(*network_mock_, Send(IsGetRequest(partitions_path), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            response, ResponseGenerator::Partitions(partitions_response)));
+  }
+
+  void SetupPertitionResponse(http::NetworkResponse response,
+                              const std::string& data_handle,
+                              const std::string& response_data) {
+    auto partition_path = generator_.DataBlob(data_handle);
+    ASSERT_FALSE(partition_path.empty());
+
+    EXPECT_CALL(*network_mock_, Send(IsGetRequest(partition_path), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(response, response_data));
+  }
+
+ protected:
+  std::string api_response_;
+  uint32_t version_;
+  std::string layer_;
+  PlatformUrlsGenerator generator_;
+};
+
+TEST_F(VersionedLayerClientPrefetchPartitionsTest, PrefetchPartitions) {
+  auto partitions_count = 3u;
+  auto client =
+      read::VersionedLayerClient(kCatalogHrn, layer_, boost::none, settings_);
+  auto partitions = GeneratePartitionIds(partitions_count);
+  auto partitions_response =
+      mockserver::ReadDefaultResponses::GeneratePartitionsResponse(
+          partitions_count);
+  const auto request =
+      read::PrefetchPartitionsRequest().WithPartitionIds(partitions);
+  {
+    SCOPED_TRACE("Prefetch online");
+    SetupApiResponse(
+        http::NetworkResponse().WithStatus(http::HttpStatusCode::OK),
+        api_response_);
+    SetupVersionResponse(
+        http::NetworkResponse().WithStatus(http::HttpStatusCode::OK));
+    SetupQueryPartitionsResponse(
+        http::NetworkResponse().WithStatus(http::HttpStatusCode::OK),
+        partitions, partitions_response);
+    for (const auto& partition : partitions_response.GetPartitions()) {
+      SetupPertitionResponse(
+          http::NetworkResponse().WithStatus(http::HttpStatusCode::OK),
+          partition.GetDataHandle(), "data");
+    }
+
+    auto future = client.PrefetchPartitions(request).GetFuture();
+    ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),
+              std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_TRUE(response.IsSuccessful());
+    const auto result = response.MoveResult();
+    ASSERT_EQ(result.GetPartitions().size(), partitions_count);
+
+    for (const auto& partition : result.GetPartitions()) {
+      ASSERT_TRUE(client.IsCached(partition));
+    }
+  }
+  {
+    SCOPED_TRACE("Prefetch cached");
+    std::promise<olp::dataservice::read::PrefetchPartitionsResponse> promise;
+    auto future = promise.get_future();
+    auto token = client.PrefetchPartitions(
+        request,
+        [&promise](
+            olp::dataservice::read::PrefetchPartitionsResponse response) {
+          promise.set_value(std::move(response));
+        },
+        nullptr);
+    ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),
+              std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_TRUE(response.IsSuccessful());
+  }
+}
+
+TEST_F(VersionedLayerClientPrefetchPartitionsTest, PrefetchPartitionsFails) {
+  auto partitions_count = 3u;
+  auto client =
+      read::VersionedLayerClient(kCatalogHrn, layer_, boost::none, settings_);
+  auto partitions = GeneratePartitionIds(partitions_count);
+  auto partitions_response =
+      mockserver::ReadDefaultResponses::GeneratePartitionsResponse(
+          partitions_count);
+  const auto request =
+      read::PrefetchPartitionsRequest().WithPartitionIds(partitions);
+  {
+    SCOPED_TRACE("Lookup fails");
+    SetupApiResponse(
+        http::NetworkResponse().WithStatus(http::HttpStatusCode::BAD_REQUEST),
+        "error");
+
+    auto future = client.PrefetchPartitions(request).GetFuture();
+    ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),
+              std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_FALSE(response.IsSuccessful());
+  }
+  {
+    SCOPED_TRACE("Get version fails");
+    SetupApiResponse(
+        http::NetworkResponse().WithStatus(http::HttpStatusCode::OK),
+        api_response_);
+    SetupVersionResponse(
+        http::NetworkResponse().WithStatus(http::HttpStatusCode::BAD_REQUEST));
+
+    auto future = client.PrefetchPartitions(request).GetFuture();
+    ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),
+              std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_FALSE(response.IsSuccessful());
+  }
+  {
+    SCOPED_TRACE("Query partitions fails");
+    SetupVersionResponse(
+        http::NetworkResponse().WithStatus(http::HttpStatusCode::OK));
+    SetupQueryPartitionsResponse(
+        http::NetworkResponse().WithStatus(http::HttpStatusCode::BAD_REQUEST),
+        partitions, partitions_response);
+
+    auto future = client.PrefetchPartitions(request).GetFuture();
+    ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),
+              std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_FALSE(response.IsSuccessful());
+  }
+  {
+    SCOPED_TRACE("Get data fails");
+    SetupQueryPartitionsResponse(
+        http::NetworkResponse().WithStatus(http::HttpStatusCode::OK),
+        partitions, partitions_response);
+    for (const auto& partition : partitions_response.GetPartitions()) {
+      SetupPertitionResponse(
+          http::NetworkResponse().WithStatus(http::HttpStatusCode::BAD_REQUEST),
+          partition.GetDataHandle(), "data");
+    }
+
+    auto future = client.PrefetchPartitions(request).GetFuture();
+    ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),
+              std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_FALSE(response.IsSuccessful());
+  }
+}
+
+TEST_F(VersionedLayerClientPrefetchPartitionsTest, PrefetchPartitionsCancel) {
+  auto partitions_count = 1u;
+  auto client =
+      read::VersionedLayerClient(kCatalogHrn, layer_, boost::none, settings_);
+  auto partitions = GeneratePartitionIds(partitions_count);
+  auto partitions_response =
+      mockserver::ReadDefaultResponses::GeneratePartitionsResponse(
+          partitions_count);
+  const auto request =
+      read::PrefetchPartitionsRequest().WithPartitionIds(partitions);
+
+  SCOPED_TRACE("Cancel request");
+  std::promise<void> block_promise;
+  auto block_future = block_promise.get_future();
+  settings_.task_scheduler->ScheduleTask(
+      [&block_future]() { block_future.get(); });
+  auto cancellable = client.PrefetchPartitions(request);
+
+  // cancel the request and unblock queue
+  cancellable.GetCancellationToken().Cancel();
+  block_promise.set_value();
+  auto future = cancellable.GetFuture();
+
+  ASSERT_EQ(future.wait_for(kTimeout), std::future_status::ready);
+
+  auto data_response = future.get();
+
+  EXPECT_FALSE(data_response.IsSuccessful());
+  EXPECT_EQ(data_response.GetError().GetErrorCode(),
+            client::ErrorCode::Cancelled);
+}
+
+TEST_F(VersionedLayerClientPrefetchPartitionsTest, CheckPriority) {
+  auto priority = 300u;
+  // this priority should be less than priority, but greater than LOW
+  auto finish_task_priority = 200u;
+  auto partitions_count = 3u;
+  auto client =
+      read::VersionedLayerClient(kCatalogHrn, layer_, boost::none, settings_);
+  auto partitions = GeneratePartitionIds(partitions_count);
+  auto partitions_response =
+      mockserver::ReadDefaultResponses::GeneratePartitionsResponse(
+          partitions_count);
+  const auto request = read::PrefetchPartitionsRequest()
+                           .WithPartitionIds(partitions)
+                           .WithPriority(priority);
+
+  SetupApiResponse(http::NetworkResponse().WithStatus(http::HttpStatusCode::OK),
+                   api_response_);
+  SetupVersionResponse(
+      http::NetworkResponse().WithStatus(http::HttpStatusCode::OK));
+  SetupQueryPartitionsResponse(
+      http::NetworkResponse().WithStatus(http::HttpStatusCode::OK), partitions,
+      partitions_response);
+  for (const auto& partition : partitions_response.GetPartitions()) {
+    SetupPertitionResponse(
+        http::NetworkResponse().WithStatus(http::HttpStatusCode::OK),
+        partition.GetDataHandle(), "data");
+  }
+
+  auto scheduler = settings_.task_scheduler;
+  std::promise<void> block_promise;
+  std::promise<void> finish_promise;
+  auto block_future = block_promise.get_future();
+  auto finish_future = finish_promise.get_future();
+
+  // block task scheduler
+  scheduler->ScheduleTask([&]() { block_future.wait_for(kTimeout); },
+                          std::numeric_limits<uint32_t>::max());
+
+  auto future = client.PrefetchPartitions(request).GetFuture();
+  scheduler->ScheduleTask(
+      [&]() {
+        EXPECT_EQ(future.wait_for(std::chrono::milliseconds(0)),
+                  std::future_status::ready);
+        finish_promise.set_value();
+      },
+      finish_task_priority);
+
+  // unblock queue
+  block_promise.set_value();
+
+  ASSERT_NE(future.wait_for(kTimeout), std::future_status::timeout);
+  ASSERT_NE(finish_future.wait_for(kTimeout), std::future_status::timeout);
+
+  auto response = future.get();
+  ASSERT_TRUE(response.IsSuccessful());
+  const auto result = response.MoveResult();
+  ASSERT_EQ(result.GetPartitions().size(), partitions_count);
+
+  for (const auto& partition : result.GetPartitions()) {
+    ASSERT_TRUE(client.IsCached(partition));
+  }
+}
+
+TEST_F(VersionedLayerClientPrefetchPartitionsTest, PrefetchProgress) {
+  auto partitions_count = 201u;  // 3 query
+  auto client =
+      read::VersionedLayerClient(kCatalogHrn, layer_, version_, settings_);
+  auto partitions = GeneratePartitionIds(partitions_count);
+
+  auto size1 = 100;
+  auto size2 = 100;
+  auto size3 = 1;
+
+  auto partitions_response1 =
+      mockserver::ReadDefaultResponses::GeneratePartitionsResponse(size1);
+  auto partitions_response2 =
+      mockserver::ReadDefaultResponses::GeneratePartitionsResponse(size2,
+                                                                   size1);
+  auto partitions_response3 =
+      mockserver::ReadDefaultResponses::GeneratePartitionsResponse(
+          size3, size1 + size2);
+  const auto request =
+      read::PrefetchPartitionsRequest().WithPartitionIds(partitions);
+
+  SetupApiResponse(http::NetworkResponse().WithStatus(http::HttpStatusCode::OK),
+                   api_response_);
+  SetupQueryPartitionsResponse(
+      http::NetworkResponse().WithStatus(http::HttpStatusCode::OK),
+      std::vector<std::string>(partitions.begin(), partitions.begin() + size1),
+      partitions_response1);
+  SetupQueryPartitionsResponse(
+      http::NetworkResponse().WithStatus(http::HttpStatusCode::OK),
+      std::vector<std::string>(partitions.begin() + size1,
+                               partitions.begin() + size1 + size2),
+      partitions_response2);
+  SetupQueryPartitionsResponse(
+      http::NetworkResponse().WithStatus(http::HttpStatusCode::OK),
+      std::vector<std::string>(partitions.begin() + size1 + size2,
+                               partitions.begin() + size1 + size2 + size3),
+      partitions_response3);
+
+  auto mock_partitions_response =
+      [&](const read::model::Partitions& partitions) {
+        for (const auto& partition : partitions.GetPartitions()) {
+          SetupPertitionResponse(http::NetworkResponse()
+                                     .WithStatus(http::HttpStatusCode::OK)
+                                     .WithBytesDownloaded(4)
+                                     .WithBytesUploaded(1),
+                                 partition.GetDataHandle(), "data");
+        }
+      };
+  mock_partitions_response(partitions_response1);
+  mock_partitions_response(partitions_response2);
+  mock_partitions_response(partitions_response3);
+
+  struct Status {
+    MOCK_METHOD(void, Op, (read::PrefetchPartitionsStatus));
+  };
+
+  Status status_object;
+
+  size_t bytes_transferred{0};
+
+  {
+    auto matches = [](uint32_t prefetched, uint32_t total) {
+      return [=](read::PrefetchPartitionsStatus status) -> bool {
+        return status.prefetched_partitions == prefetched &&
+               status.total_partitions_to_prefetch == total;
+      };
+    };
+    for (auto i = 0u; i < partitions_count; i++) {
+      EXPECT_CALL(status_object,
+                  Op(testing::Truly(matches(i + 1, partitions_count))))
+          .Times(1);
+    }
+  }
+
+  auto future =
+      client
+          .PrefetchPartitions(request,
+                              [&](read::PrefetchPartitionsStatus status) {
+                                status_object.Op(status);
+                                bytes_transferred = status.bytes_transferred;
+                              })
+          .GetFuture();
+  ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),
+            std::future_status::timeout);
+
+  auto response = future.get();
+  ASSERT_TRUE(response.IsSuccessful());
+  const auto result = response.MoveResult();
+  ASSERT_EQ(result.GetPartitions().size(), partitions_count);
+
+  for (const auto& partition : result.GetPartitions()) {
+    ASSERT_TRUE(client.IsCached(partition));
+  }
+  EXPECT_GE(bytes_transferred, partitions_count * 5);
+  testing::Mock::VerifyAndClearExpectations(&status_object);
+}
+
+}  // namespace

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerTestBase.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerTestBase.cpp
@@ -40,9 +40,10 @@ void VersionedLayerTestBase::SetUp() {
   olp::utils::Dir::remove(kCachePathMutable);
 
   network_mock_ = std::make_shared<NetworkMock>();
-
-  settings_.api_lookup_settings.catalog_endpoint_provider =
-      [=](const olp::client::HRN&) { return kEndpoint; };
+  if (endpoint_ == EndpointType::kDsp) {
+    settings_.api_lookup_settings.catalog_endpoint_provider =
+        [=](const olp::client::HRN&) { return kEndpoint; };
+  }
 
   settings_.network_request_handler = network_mock_;
   settings_.task_scheduler =

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerTestBase.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerTestBase.cpp
@@ -31,6 +31,8 @@ namespace {
 const auto kCachePathMutable = "./tmp_cache";
 }
 
+namespace model = olp::dataservice::read::model;
+namespace http = olp::http;
 using testing::_;
 
 VersionedLayerTestBase::VersionedLayerTestBase()
@@ -40,10 +42,9 @@ void VersionedLayerTestBase::SetUp() {
   olp::utils::Dir::remove(kCachePathMutable);
 
   network_mock_ = std::make_shared<NetworkMock>();
-  if (endpoint_ == EndpointType::kDsp) {
-    settings_.api_lookup_settings.catalog_endpoint_provider =
-        [=](const olp::client::HRN&) { return kEndpoint; };
-  }
+
+  settings_.api_lookup_settings.catalog_endpoint_provider =
+      [=](const olp::client::HRN&) { return kEndpoint; };
 
   settings_.network_request_handler = network_mock_;
   settings_.task_scheduler =
@@ -63,20 +64,39 @@ void VersionedLayerTestBase::TearDown() {
 }
 
 void VersionedLayerTestBase::ExpectQuadTreeRequest(
-    int64_t version, mockserver::QuadTreeBuilder quad_tree) {
+    int64_t version, mockserver::QuadTreeBuilder quad_tree,
+    http::NetworkResponse response) {
   const auto url = url_generator_.VersionedQuadTree(
       quad_tree.Root().ToHereTile(), version, 4);
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(url), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   quad_tree.BuildJson()));
+      .WillOnce(ReturnHttpResponse(response, quad_tree.BuildJson()));
 }
 
 void VersionedLayerTestBase::ExpectBlobRequest(const std::string& data_handle,
-                                               const std::string& data) {
+                                               const std::string& data,
+                                               http::NetworkResponse response) {
   const auto url = url_generator_.DataBlob(data_handle);
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(url), _, _, _, _))
-      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                       olp::http::HttpStatusCode::OK),
-                                   data));
+      .WillOnce(ReturnHttpResponse(response, data));
+}
+
+void VersionedLayerTestBase::ExpectVersionRequest(
+    http::NetworkResponse response) {
+  auto version_path = url_generator_.LatestVersion();
+  ASSERT_FALSE(version_path.empty());
+
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(version_path), _, _, _, _))
+      .WillOnce(
+          ReturnHttpResponse(response, ResponseGenerator::Version(version_)));
+}
+
+void VersionedLayerTestBase::ExpectQueryPartitionsRequest(
+    const std::vector<std::string>& partitions,
+    const model::Partitions& partitions_response,
+    http::NetworkResponse response) {
+  auto partitions_path = url_generator_.PartitionsQuery(partitions, version_);
+
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(partitions_path), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(
+          response, ResponseGenerator::Partitions(partitions_response)));
 }

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerTestBase.h
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerTestBase.h
@@ -36,20 +36,35 @@ class VersionedLayerTestBase : public ::testing::Test {
   void TearDown() override;
 
   void ExpectQuadTreeRequest(int64_t version,
-                             mockserver::QuadTreeBuilder quad_tree);
+                             mockserver::QuadTreeBuilder quad_tree,
+                             olp::http::NetworkResponse response =
+                                 olp::http::NetworkResponse().WithStatus(
+                                     olp::http::HttpStatusCode::OK));
 
   void ExpectBlobRequest(const std::string& data_handle,
-                         const std::string& data);
+                         const std::string& data,
+                         olp::http::NetworkResponse response =
+                             olp::http::NetworkResponse().WithStatus(
+                                 olp::http::HttpStatusCode::OK));
+
+  void ExpectVersionRequest(olp::http::NetworkResponse response =
+                                olp::http::NetworkResponse().WithStatus(
+                                    olp::http::HttpStatusCode::OK));
+  void ExpectQueryPartitionsRequest(
+      const std::vector<std::string>& partitions,
+      const olp::dataservice::read::model::Partitions& partitions_response,
+      olp::http::NetworkResponse response =
+          olp::http::NetworkResponse().WithStatus(
+              olp::http::HttpStatusCode::OK));
 
  protected:
   const std::string kCatalog = "hrn:here:data::olp-here-test:catalog";
   const std::string kLayerName = "testlayer";
   const olp::client::HRN kCatalogHrn = olp::client::HRN::FromString(kCatalog);
   const std::string kEndpoint = "https://localhost";
-  const std::string kUrlLookup =
-      R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data::olp-here-test:catalog/apis)";
 
   olp::client::OlpClientSettings settings_;
   std::shared_ptr<NetworkMock> network_mock_;
   PlatformUrlsGenerator url_generator_;
+  const uint32_t version_ = 4;
 };

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerTestBase.h
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerTestBase.h
@@ -46,6 +46,8 @@ class VersionedLayerTestBase : public ::testing::Test {
   const std::string kLayerName = "testlayer";
   const olp::client::HRN kCatalogHrn = olp::client::HRN::FromString(kCatalog);
   const std::string kEndpoint = "https://localhost";
+  const std::string kUrlLookup =
+      R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data::olp-here-test:catalog/apis)";
 
   olp::client::OlpClientSettings settings_;
   std::shared_ptr<NetworkMock> network_mock_;


### PR DESCRIPTION
Add public api to prefetch partitions
for versioned layer client. Add integration
tests to check prefetching, handling errors,
canceling, request prioritization, request
progress. Change query to return error only if all query
partitions fail. Add test to check
if all possible partitions prefetched,
even if some queries fail, check if
error returned if all queries fails.
    
Relates-To: OLPEDGE-1901

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>