### PR TITLE
Fix crash in DefaultCache::Put with nullptr value

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -205,6 +205,10 @@ bool DefaultCacheImpl::Put(const std::string& key, const boost::any& value,
 bool DefaultCacheImpl::Put(const std::string& key,
                            const KeyValueCache::ValueTypePtr value,
                            time_t expiry) {
+  if (!value) {
+    return false;
+  }
+
   std::lock_guard<std::mutex> lock(cache_lock_);
   if (!is_open_) {
     return false;

--- a/olp-cpp-sdk-core/tests/cache/DefaultCacheTest.cpp
+++ b/olp-cpp-sdk-core/tests/cache/DefaultCacheTest.cpp
@@ -69,6 +69,18 @@ void BasicCacheTestWithSettings(const olp::cache::CacheSettings& settings) {
   }
 
   {
+    SCOPED_TRACE("Put nullptr value");
+
+    olp::cache::DefaultCache cache(settings);
+    ASSERT_EQ(olp::cache::DefaultCache::Success, cache.Open());
+    ASSERT_TRUE(cache.Clear());
+
+    bool put_result =
+        cache.Put("key", nullptr, (std::numeric_limits<time_t>::max)());
+    EXPECT_FALSE(put_result);
+  }
+
+  {
     SCOPED_TRACE("Remove from cache");
 
     std::vector<unsigned char> binary_data = {1, 2, 3};


### PR DESCRIPTION
DefaultCache::Put value is ValueTypePtr. If the value is nullptr the
crash will occur. Adding check for the value and unit test.

Resolves: OLPEDGE-2295

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>