### PR TITLE
Fix NetworkWinHttp error for pending requests.

### DIFF
--- a/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.h
+++ b/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.h
@@ -141,6 +141,7 @@ class NetworkWinHttp : public Network {
   std::vector<RequestData> http_requests_;
   std::queue<std::shared_ptr<ResultData>> results_;
 
+  bool run_completion_thread_;
   HINTERNET http_session_;
   HANDLE thread_;
   HANDLE event_;


### PR DESCRIPTION
When network destroyed, all pending requests callbacks should receive
OFFLINE_ERROR. To process them correctly, we need to stop
CompletionThread before closing WinHttp handles. Otherwise, it will
treat all pending requests as cancelled.

Resolves: OLPEDGE-2247

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>