### PR TITLE
Fix auth with mock server.

### DIFF
--- a/tests/functional/utils/MockServerHelper.cpp
+++ b/tests/functional/utils/MockServerHelper.cpp
@@ -39,13 +39,13 @@ MockServerHelper::MockServerHelper(olp::client::OlpClientSettings settings,
 void MockServerHelper::MockTimestamp(time_t time) {
   mock_server_client_.MockResponse(
       "GET", "/timestamp",
-      R"({"timestamp" : )" + std::to_string(time) + R"(})", true);
+      R"({"timestamp" : )" + std::to_string(time) + R"(})");
 }
 
 void MockServerHelper::MockAuth() {
   mock_server_client_.MockResponse(
       "POST", "/oauth2/token",
-      R"({"access_token": "token","token_type": "bearer"})", true);
+      R"({"accessToken": "token", "tokenType": "bearer", "expiresIn":86399})");
 }
 
 void MockServerHelper::MockGetVersionResponse(


### PR DESCRIPTION
There are two issues cause authentication errors. Auth response was
mocked with "true" as http_status argument. Also response json was
incorrect and incomplete.

MockTimestamp has same problem with http_status, so updating it too.

Resolves: OLPEDGE-2259

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>