### PR TITLE
Make PublishPartitionData sync

### DIFF
--- a/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.h
@@ -105,12 +105,12 @@ class VolatileLayerClientImpl
       std::shared_ptr<client::CancellationContext> cancel_context,
       InitApiClientsCallback callback);
 
-  client::CancellationToken GetDataHandleMap(
+  DataHandleMapResponse GetDataHandleMap(
       const std::string& layerId, const std::vector<std::string>& partitionIds,
       boost::optional<int64_t> version,
       boost::optional<std::vector<std::string>> additionalFields,
       boost::optional<std::string> billingTag,
-      const DataHandleMapCallback& callback);
+      const client::CancellationContext context);
 
  private:
   client::HRN catalog_;
@@ -128,6 +128,7 @@ class VolatileLayerClientImpl
   CancellationTokenList tokenList_;
 
   std::shared_ptr<client::PendingRequests> pending_requests_;
+  std::shared_ptr<thread::TaskScheduler> task_scheduler_;
 
   std::mutex mutex_;
   std::condition_variable cond_var_;

--- a/olp-cpp-sdk-dataservice-write/src/generated/QueryApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/QueryApi.h
@@ -24,6 +24,7 @@
 
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/CancellationContext.h>
 #include <boost/optional.hpp>
 #include "generated/model/Partitions.h"
 
@@ -52,6 +53,14 @@ class QueryApi {
       boost::optional<std::vector<std::string>> additionalFields,
       boost::optional<std::string> billingTag,
       const PartitionsCallback& callback);
+
+  static PartitionsResponse GetPartitionsById(
+      const client::OlpClient& client, const std::string& layerId,
+      const std::vector<std::string>& partition_ids,
+      boost::optional<int64_t> version,
+      boost::optional<std::vector<std::string>> additional_fields,
+      boost::optional<std::string> billing_tag,
+      client::CancellationContext context);
 };
 
 }  // namespace write


### PR DESCRIPTION
Make write VolatileLayerClient::PublishPartitionData()
method use new sync approach

Resolves: OLPEDGE-2301

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>