### PR TITLE
Make cpplint job unblocking again

### DIFF
--- a/scripts/misc/cpplint_ci.sh
+++ b/scripts/misc/cpplint_ci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash +e
 #
 # Copyright (C) 2020 HERE Europe B.V.
 #


### PR DESCRIPTION
Cpplint job was done unblocked without previous research.
Due to many warnings we need to keep cpplint unblocking.

Relates-To: OLPEDGE-1853

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>