### PR TITLE
Change PublishIndex() to be sync

### DIFF
--- a/olp-cpp-sdk-dataservice-write/src/generated/IndexApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/IndexApi.cpp
@@ -87,6 +87,38 @@ client::CancellationToken IndexApi::insertIndexes(
   return cancel_token;
 }
 
+InsertIndexesResponse IndexApi::InsertIndexes(
+    const client::OlpClient& client, const model::Index& indexes,
+    const std::string& layer_id,
+    const boost::optional<std::string>& billing_tag,
+    client::CancellationContext context) {
+  std::multimap<std::string, std::string> header_params;
+  std::multimap<std::string, std::string> query_params;
+  std::multimap<std::string, std::string> form_params;
+
+  header_params.insert(std::make_pair("Accept", "application/json"));
+
+  if (billing_tag) {
+    query_params.insert(
+        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+  }
+
+  std::string insert_indexes_uri = "/layers/" + layer_id;
+
+  auto serialized_indexes = serializer::serialize(indexes);
+  auto data = std::make_shared<std::vector<unsigned char>>(
+      serialized_indexes.begin(), serialized_indexes.end());
+
+  auto http_response =
+      client.CallApi(insert_indexes_uri, "POST", query_params, header_params,
+                     form_params, data, "application/json", context);
+  if (http_response.status > http::HttpStatusCode::CREATED) {
+    return client::ApiError(http_response.status, http_response.response.str());
+  }
+
+  return client::ApiNoResult();
+}
+
 client::CancellableFuture<UpdateIndexesResponse> IndexApi::performUpdate(
     const client::OlpClient& client, const model::UpdateIndexRequest& request,
     const boost::optional<std::string>& billing_tag) {

--- a/olp-cpp-sdk-dataservice-write/src/generated/IndexApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/IndexApi.h
@@ -95,6 +95,16 @@ class IndexApi {
       const std::string& layer_id,
       const boost::optional<std::string>& billing_tag,
       InsertIndexesCallback callback);
+
+  /**
+  * @brief Synchronous version of \c insertIndexes method.
+  */
+  static InsertIndexesResponse InsertIndexes(
+      const client::OlpClient& client, const model::Index& indexes,
+      const std::string& layer_id,
+      const boost::optional<std::string>& billing_tag,
+      client::CancellationContext context);
+
   /**
    * @brief Updates index layer partitions
    * Modifies partitions in an index layer.

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteIndexLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteIndexLayerClientTest.cpp
@@ -83,6 +83,7 @@ class DataserviceWriteIndexLayerClientTest : public ::testing::Test {
     olp::client::OlpClientSettings settings;
     settings.authentication_settings = auth_client_settings;
     settings.network_request_handler = network;
+    settings.task_scheduler = olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
 
     return std::make_shared<write::IndexLayerClient>(
         olp::client::HRN{GetTestCatalog()}, settings);

--- a/tests/integration/olp-cpp-sdk-dataservice-write/IndexLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/IndexLayerClientTest.cpp
@@ -104,6 +104,7 @@ class IndexLayerClientTest : public ::testing::Test {
     olp::client::OlpClientSettings client_settings;
     network_ = std::make_shared<NetworkMock>();
     client_settings.network_request_handler = network_;
+    client_settings.task_scheduler = olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
     SetUpCommonNetworkMockCalls(*network_);
 
     return std::make_shared<write::IndexLayerClient>(
@@ -210,12 +211,10 @@ TEST_F(IndexLayerClientTest, PublishData) {
 
 TEST_F(IndexLayerClientTest, DeleteData) {
   {
-    testing::InSequence dummy;
-
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_BLOB), _, _, _, _))
-        .Times(1);
+        .Times(2);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_INDEX), _, _, _, _))
-        .Times(1);
+        .Times(2);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_LOOKUP_CONFIG), _, _, _, _))
         .Times(1);
     EXPECT_CALL(*network_, Send(IsGetRequest(URL_GET_CATALOG), _, _, _, _))


### PR DESCRIPTION
Change write::IndexLayerClient::PublishIndex() to use sync
method approach. We need to make it similar to
dataservice::read. Making it sync will simplify the code.

Resolves: OLPEDGE-2301

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>