### PR TITLE
Minor: Modify the repositories

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/ProtectDependencyResolver.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ProtectDependencyResolver.cpp
@@ -38,7 +38,7 @@ ProtectDependencyResolver::ProtectDependencyResolver(
     : layer_id_(layer_id),
       version_(version),
       data_cache_repository_(catalog, settings.cache),
-      partitions_cache_repository_(catalog, settings.cache),
+      partitions_cache_repository_(catalog, layer_id_, settings.cache),
       quad_trees_(),
       keys_to_protect_() {}
 
@@ -86,13 +86,12 @@ bool ProtectDependencyResolver::AddDataHandle(
 bool ProtectDependencyResolver::ProcessTileKeyInCache(
     const geo::TileKey& tile) {
   read::QuadTreeIndex cached_tree;
-  if (partitions_cache_repository_.FindQuadTree(layer_id_, version_, tile,
-                                                cached_tree) &&
+  if (partitions_cache_repository_.FindQuadTree(version_, tile, cached_tree) &&
       AddDataHandle(tile, cached_tree)) {
     auto root_tile = cached_tree.GetRootTile();
     // add quad tree to list for protection
     keys_to_protect_.emplace_back(partitions_cache_repository_.CreateQuadKey(
-        layer_id_, root_tile, kQuadTreeDepth, version_));
+        root_tile, kQuadTreeDepth, version_));
     // save quad tree, because  there is could be more tiles to protect from
     // this quad
     quad_trees_[root_tile] = std::move(cached_tree);

--- a/olp-cpp-sdk-dataservice-read/src/ReleaseDependencyResolver.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ReleaseDependencyResolver.cpp
@@ -39,7 +39,7 @@ ReleaseDependencyResolver::ReleaseDependencyResolver(
       version_(version),
       cache_(settings.cache),
       data_cache_repository_(catalog, settings.cache),
-      partitions_cache_repository_(catalog, settings.cache),
+      partitions_cache_repository_(catalog, layer_id_, settings.cache),
       quad_trees_with_protected_tiles_(),
       keys_to_release_() {}
 
@@ -77,7 +77,7 @@ void ReleaseDependencyResolver::ProcessTileKey(const geo::TileKey& tile_key) {
         // can add key for quad tree to be released and remove from map
         keys_to_release_.emplace_back(
             partitions_cache_repository_.CreateQuadKey(
-                layer_id_, it->first, kQuadTreeDepth, version_));
+                it->first, kQuadTreeDepth, version_));
       }
       return true;
     }
@@ -128,14 +128,14 @@ void ReleaseDependencyResolver::ProcessQuadTreeCache(
     const geo::TileKey& root_quad_key, const geo::TileKey& tile,
     bool& add_data_handle_key) {
   QuadTreeIndex cached_tree;
-  if (partitions_cache_repository_.Get(layer_id_, root_quad_key, kQuadTreeDepth,
-                                       version_, cached_tree)) {
+  if (partitions_cache_repository_.Get(root_quad_key, kQuadTreeDepth, version_,
+                                       cached_tree)) {
     TilesDataKeysType protected_keys =
         CheckProtectedTilesInQuad(cached_tree, tile, add_data_handle_key);
     if (protected_keys.empty()) {
       // no other tiles are protected, can add quad tree to release list
       keys_to_release_.emplace_back(partitions_cache_repository_.CreateQuadKey(
-          layer_id_, root_quad_key, kQuadTreeDepth, version_));
+          root_quad_key, kQuadTreeDepth, version_));
     }
     // add quad key with other protected keys dependent on this quad to
     // reduce future calls to cache

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -87,9 +87,9 @@ client::CancellationToken VolatileLayerClientImpl::GetPartitions(
 
     auto data_task = [=](client::CancellationContext context) {
       repository::PartitionsRepository repository(
-          std::move(catalog), std::move(settings), std::move(lookup_client));
-      return repository.GetVolatilePartitions(std::move(layer_id), request,
-                                              std::move(context));
+          std::move(catalog), std::move(layer_id), std::move(settings),
+          std::move(lookup_client));
+      return repository.GetVolatilePartitions(request, std::move(context));
     };
 
     return AddTask(settings.task_scheduler, pending_requests_,
@@ -144,11 +144,11 @@ client::CancellableFuture<DataResponse> VolatileLayerClientImpl::GetData(
 }
 
 bool VolatileLayerClientImpl::RemoveFromCache(const std::string& partition_id) {
-  repository::PartitionsCacheRepository cache_repository(catalog_,
+  repository::PartitionsCacheRepository cache_repository(catalog_, layer_id_,
                                                          settings_.cache);
   boost::optional<model::Partition> partition;
-  if (!cache_repository.ClearPartitionMetadata(boost::none, partition_id,
-                                               layer_id_, partition)) {
+  if (!cache_repository.ClearPartitionMetadata(partition_id, boost::none,
+                                               partition)) {
     return false;
   }
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -60,8 +60,9 @@ DataRepository::DataRepository(client::HRN catalog,
 DataResponse DataRepository::GetVersionedTile(
     const std::string& layer_id, const TileRequest& request, int64_t version,
     client::CancellationContext context) {
-  PartitionsRepository repository(catalog_, settings_, lookup_client_);
-  auto response = repository.GetTile(layer_id, request, version, context);
+  PartitionsRepository repository(catalog_, layer_id, settings_,
+                                  lookup_client_);
+  auto response = repository.GetTile(request, version, context);
 
   if (!response.IsSuccessful()) {
     OLP_SDK_LOG_WARNING_F(
@@ -92,9 +93,10 @@ BlobApi::DataResponse DataRepository::GetVersionedData(
   auto blob_request = request;
   if (!request.GetDataHandle()) {
     // get data handle for a partition to be queried
-    PartitionsRepository repository(catalog_, settings_, lookup_client_);
+    PartitionsRepository repository(catalog_, layer_id, settings_,
+                                    lookup_client_);
     auto partitions_response =
-        repository.GetPartitionById(layer_id, version, request, context);
+        repository.GetPartitionById(request, version, context);
 
     if (!partitions_response.IsSuccessful()) {
       return partitions_response.GetError();
@@ -206,9 +208,10 @@ BlobApi::DataResponse DataRepository::GetVolatileData(
 
   auto blob_request = request;
   if (!request.GetDataHandle()) {
-    PartitionsRepository repository(catalog_, settings_, lookup_client_);
+    PartitionsRepository repository(catalog_, layer_id, settings_,
+                                    lookup_client_);
     auto partitions_response =
-        repository.GetPartitionById(layer_id, boost::none, request, context);
+        repository.GetPartitionById(request, boost::none, context);
 
     if (!partitions_response.IsSuccessful()) {
       return partitions_response.GetError();

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
@@ -40,63 +40,59 @@ namespace repository {
 class PartitionsCacheRepository final {
  public:
   PartitionsCacheRepository(
-      const client::HRN& hrn, std::shared_ptr<cache::KeyValueCache> cache,
+      const client::HRN& catalog, const std::string& layer_id,
+      std::shared_ptr<cache::KeyValueCache> cache,
       std::chrono::seconds default_expiry = std::chrono::seconds::max());
 
   ~PartitionsCacheRepository() = default;
 
-  void Put(const model::Partitions& partitions, const std::string& layer_id,
+  void Put(const model::Partitions& partitions,
            const boost::optional<int64_t>& version,
            const boost::optional<time_t>& expiry, bool layer_metadata = false);
 
   model::Partitions Get(const std::vector<std::string>& partition_ids,
-                        const std::string& layer_id,
                         const boost::optional<int64_t>& version);
 
   boost::optional<model::Partitions> Get(
-      const PartitionsRequest& request, const std::string& layer_id,
+      const PartitionsRequest& request,
       const boost::optional<int64_t>& version);
 
   void Put(int64_t catalog_version, const model::LayerVersions& layer_versions);
 
   boost::optional<model::LayerVersions> Get(int64_t catalog_version);
 
-  void Put(const std::string& layer, geo::TileKey tile_key, int32_t depth,
-           const QuadTreeIndex& quad_tree,
+  void Put(geo::TileKey tile_key, int32_t depth, const QuadTreeIndex& quad_tree,
            const boost::optional<int64_t>& version);
 
-  bool Get(const std::string& layer, geo::TileKey tile_key, int32_t depth,
+  bool Get(geo::TileKey tile_key, int32_t depth,
            const boost::optional<int64_t>& version, QuadTreeIndex& tree);
 
-  void Clear(const std::string& layer_id);
+  void Clear();
 
   void ClearPartitions(const std::vector<std::string>& partition_ids,
-                       const std::string& layer_id,
                        const boost::optional<int64_t>& version);
 
-  bool ClearQuadTree(const std::string& layer, geo::TileKey tile_key,
-                     int32_t depth, const boost::optional<int64_t>& version);
+  bool ClearQuadTree(geo::TileKey tile_key, int32_t depth,
+                     const boost::optional<int64_t>& version);
 
-  bool ClearPartitionMetadata(const boost::optional<int64_t>& catalog_version,
-                              const std::string& partition_id,
-                              const std::string& layer_id,
+  bool ClearPartitionMetadata(const std::string& partition_id,
+                              const boost::optional<int64_t>& catalog_version,
                               boost::optional<model::Partition>& out_partition);
 
-  bool GetPartitionHandle(const boost::optional<int64_t>& catalog_version,
-                          const std::string& partition_id,
-                          const std::string& layer_id,
+  bool GetPartitionHandle(const std::string& partition_id,
+                          const boost::optional<int64_t>& catalog_version,
                           std::string& data_handle);
 
-  std::string CreateQuadKey(const std::string& layer, olp::geo::TileKey key,
-                            int32_t depth,
+  std::string CreateQuadKey(olp::geo::TileKey key, int32_t depth,
                             const boost::optional<int64_t>& version) const;
 
-  bool FindQuadTree(const std::string& layer, boost::optional<int64_t> version,
+  bool FindQuadTree(boost::optional<int64_t> version,
                     const olp::geo::TileKey& tile_key,
                     read::QuadTreeIndex& tree);
 
  private:
-  client::HRN hrn_;
+  const std::string catalog_;
+  const std::string layer_id_;
   std::shared_ptr<cache::KeyValueCache> cache_;
   time_t default_expiry_;
 };

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -33,14 +33,15 @@
 #include "olp/dataservice/read/PartitionsRequest.h"
 #include "olp/dataservice/read/Types.h"
 
+#include "PartitionsCacheRepository.h"
+
 namespace olp {
 namespace dataservice {
 namespace read {
+
 class TileRequest;
+
 namespace repository {
-class ApiRepository;
-class CatalogRepository;
-class PartitionsCacheRepository;
 
 /// The partition metadata response type.
 using PartitionResponse = Response<model::Partition>;
@@ -48,49 +49,49 @@ using QuadTreeIndexResponse = Response<QuadTreeIndex>;
 
 class PartitionsRepository {
  public:
-  PartitionsRepository(client::HRN catalog, client::OlpClientSettings settings,
+  PartitionsRepository(client::HRN catalog, std::string layer,
+                       client::OlpClientSettings settings,
                        client::ApiLookupClient client);
 
   PartitionsResponse GetVersionedPartitions(
-      std::string layer, const read::PartitionsRequest& request,
-      std::int64_t version, client::CancellationContext context);
-
-  PartitionsResponse GetVolatilePartitions(
-      std::string layer, const read::PartitionsRequest& request,
+      const read::PartitionsRequest& request, std::int64_t version,
       client::CancellationContext context);
 
-  PartitionsResponse GetPartitionById(const std::string& layer,
-                                      boost::optional<int64_t> version,
-                                      const DataRequest& request,
-                                      client::CancellationContext context);
+  PartitionsResponse GetVolatilePartitions(
+      const read::PartitionsRequest& request,
+      client::CancellationContext context);
 
-  model::Partition PartitionFromSubQuad(const model::SubQuad& sub_quad,
-                                        const std::string& partition);
-
-  PartitionResponse GetAggregatedTile(const std::string& layer,
-                                      TileRequest request,
+  PartitionsResponse GetPartitionById(const DataRequest& request,
                                       boost::optional<int64_t> version,
                                       client::CancellationContext context);
 
-  PartitionResponse GetTile(const std::string& layer,
-                            const TileRequest& request,
+  static model::Partition PartitionFromSubQuad(const model::SubQuad& sub_quad,
+                                               const std::string& partition);
+
+  PartitionResponse GetAggregatedTile(TileRequest request,
+                                      boost::optional<int64_t> version,
+                                      client::CancellationContext context);
+
+  PartitionResponse GetTile(const TileRequest& request,
                             boost::optional<int64_t> version,
                             client::CancellationContext context);
 
  private:
   QuadTreeIndexResponse GetQuadTreeIndexForTile(
-      const std::string& layer, const TileRequest& request,
-      boost::optional<int64_t> version, client::CancellationContext context);
+      const TileRequest& request, boost::optional<int64_t> version,
+      client::CancellationContext context);
 
   PartitionsResponse GetPartitions(
-      std::string layer, const read::PartitionsRequest& request,
+      const read::PartitionsRequest& request,
       boost::optional<std::int64_t> version,
       client::CancellationContext context,
       boost::optional<time_t> expiry = boost::none);
 
-  client::HRN catalog_;
+  const client::HRN catalog_;
+  const std::string layer_id_;
   client::OlpClientSettings settings_;
   client::ApiLookupClient lookup_client_;
+  PartitionsCacheRepository cache_;
 };
 }  // namespace repository
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -106,9 +106,9 @@ class PrefetchTilesRepository {
                                        client::CancellationContext context);
 
  protected:
-  void SplitSubtree(RootTilesForRequest& root_tiles_depth,
-                    RootTilesForRequest::iterator subtree_to_split,
-                    const geo::TileKey& tile_key, std::uint32_t min);
+  static void SplitSubtree(RootTilesForRequest& root_tiles_depth,
+                           RootTilesForRequest::iterator subtree_to_split,
+                           const geo::TileKey& tile_key, std::uint32_t min);
 
  private:
   client::HRN catalog_;

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -173,8 +173,8 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
   settings.retry_settings.timeout = 1;
 
   ApiLookupClient lookup_client(catalog_hrn, settings);
-  repository::PartitionsRepository repository(catalog_hrn, settings,
-                                              lookup_client);
+  repository::PartitionsRepository repository(catalog_hrn, kVersionedLayerId,
+                                              settings, lookup_client);
 
   const DataRequest request{DataRequest().WithPartitionId(kPartitionId)};
   const std::string part_cache_key =
@@ -214,8 +214,8 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
 
     client::CancellationContext context;
     auto response = repository.GetPartitionById(
-        kVersionedLayerId, kVersion,
-        DataRequest(request).WithFetchOption(read::CacheOnly), context);
+        DataRequest(request).WithFetchOption(read::CacheOnly), kVersion,
+        context);
 
     ASSERT_TRUE(response.IsSuccessful());
     const auto& result = response.GetResult();
@@ -237,8 +237,8 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
 
     client::CancellationContext context;
     auto response = repository.GetPartitionById(
-        kVersionedLayerId, kVersion,
-        DataRequest(request).WithFetchOption(read::CacheOnly), context);
+        DataRequest(request).WithFetchOption(read::CacheOnly), kVersion,
+        context);
 
     ASSERT_FALSE(response.IsSuccessful());
     const auto& result = response.GetError();
@@ -251,8 +251,7 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
 
     client::CancellationContext context;
     auto response = repository.GetPartitionById(
-        kVersionedLayerId, kVersion,
-        DataRequest(request).WithPartitionId(boost::none), context);
+        DataRequest(request).WithPartitionId(boost::none), kVersion, context);
 
     ASSERT_FALSE(response.IsSuccessful());
     const auto& result = response.GetError();
@@ -276,8 +275,8 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     EXPECT_CALL(*cache, Put(Eq(cache_key), _, _, _)).Times(0);
 
     auto response = repository.GetPartitionById(
-        kVersionedLayerId, kVersion,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
+        DataRequest(request).WithFetchOption(read::OnlineOnly), kVersion,
+        context);
 
     ASSERT_TRUE(response.IsSuccessful());
     const auto& partitions = response.GetResult().GetPartitions();
@@ -304,8 +303,8 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     EXPECT_CALL(*cache, Put(Eq(cache_key_no_version), _, _, _)).Times(0);
 
     auto response = repository.GetPartitionById(
-        kVersionedLayerId, boost::none,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
+        DataRequest(request).WithFetchOption(read::OnlineOnly), boost::none,
+        context);
 
     ASSERT_TRUE(response.IsSuccessful());
     const auto& partitions = response.GetResult().GetPartitions();
@@ -331,8 +330,8 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
 
     client::CancellationContext context;
     auto response = repository.GetPartitionById(
-        kVersionedLayerId, kVersion,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
+        DataRequest(request).WithFetchOption(read::OnlineOnly), kVersion,
+        context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -353,8 +352,8 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
 
     client::CancellationContext context;
     auto response = repository.GetPartitionById(
-        kVersionedLayerId, kVersion,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
+        DataRequest(request).WithFetchOption(read::OnlineOnly), kVersion,
+        context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -378,8 +377,8 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
 
     client::CancellationContext context;
     auto response = repository.GetPartitionById(
-        kVersionedLayerId, kVersion,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
+        DataRequest(request).WithFetchOption(read::OnlineOnly), kVersion,
+        context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -405,8 +404,8 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         });
 
     auto response = repository.GetPartitionById(
-        kVersionedLayerId, kVersion,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
+        DataRequest(request).WithFetchOption(read::OnlineOnly), kVersion,
+        context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -433,8 +432,8 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         });
 
     auto response = repository.GetPartitionById(
-        kVersionedLayerId, kVersion,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
+        DataRequest(request).WithFetchOption(read::OnlineOnly), kVersion,
+        context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -462,8 +461,8 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
 
     auto response = repository.GetPartitionById(
-        kVersionedLayerId, kVersion,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
+        DataRequest(request).WithFetchOption(read::OnlineOnly), kVersion,
+        context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -493,8 +492,8 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
 
     auto response = repository.GetPartitionById(
-        kVersionedLayerId, kVersion,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
+        DataRequest(request).WithFetchOption(read::OnlineOnly), kVersion,
+        context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -527,8 +526,8 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
 
     auto response = repository.GetPartitionById(
-        kVersionedLayerId, kVersion,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
+        DataRequest(request).WithFetchOption(read::OnlineOnly), kVersion,
+        context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -562,8 +561,8 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
 
     auto response = repository.GetPartitionById(
-        kVersionedLayerId, kVersion,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
+        DataRequest(request).WithFetchOption(read::OnlineOnly), kVersion,
+        context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -578,8 +577,8 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     client::CancellationContext context;
     context.CancelOperation();
     auto response = repository.GetPartitionById(
-        kVersionedLayerId, kVersion,
-        DataRequest(request).WithFetchOption(read::OnlineOnly), context);
+        DataRequest(request).WithFetchOption(read::OnlineOnly), kVersion,
+        context);
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),
@@ -628,15 +627,15 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
 
     client::CancellationContext context;
     olp::client::ApiLookupClient lookup_client(catalog, settings);
-    repository::PartitionsRepository repository(catalog, settings,
-                                                lookup_client);
+    repository::PartitionsRepository repository(catalog, kVersionedLayerId,
+                                                settings, lookup_client);
 
     read::PartitionsRequest request;
     request.WithPartitionIds({kPartitionId, kInvalidPartitionId});
     request.WithFetchOption(read::CacheOnly);
 
-    auto response = repository.GetVersionedPartitions(
-        kVersionedLayerId, request, kVersion, context);
+    auto response =
+        repository.GetVersionedPartitions(request, kVersion, context);
 
     ASSERT_FALSE(response.IsSuccessful());
     EXPECT_TRUE(response.GetResult().GetPartitions().empty());
@@ -663,13 +662,13 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
 
     client::CancellationContext context;
     olp::client::ApiLookupClient lookup_client(catalog, settings);
-    repository::PartitionsRepository repository(catalog, settings,
-                                                lookup_client);
+    repository::PartitionsRepository repository(catalog, kVersionedLayerId,
+                                                settings, lookup_client);
     read::PartitionsRequest request;
     request.WithPartitionIds({kPartitionId});
 
-    auto response = repository.GetVersionedPartitions(
-        kVersionedLayerId, request, kVersion, context);
+    auto response =
+        repository.GetVersionedPartitions(request, kVersion, context);
 
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
     EXPECT_EQ(response.GetResult().GetPartitions().size(), 1);
@@ -696,20 +695,19 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
 
     client::CancellationContext context;
     olp::client::ApiLookupClient lookup_client(catalog, settings);
-    repository::PartitionsRepository repository(catalog, settings,
-                                                lookup_client);
+    repository::PartitionsRepository repository(catalog, kVersionedLayerId,
+                                                settings, lookup_client);
     read::PartitionsRequest request;
 
-    auto response = repository.GetVersionedPartitions(
-        kVersionedLayerId, request, kVersion, context);
+    auto response =
+        repository.GetVersionedPartitions(request, kVersion, context);
 
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
     EXPECT_TRUE(response.GetResult().GetPartitions().empty());
 
     request.WithFetchOption(read::CacheOnly);
 
-    response = repository.GetVersionedPartitions(kVersionedLayerId, request,
-                                                 kVersion, context);
+    response = repository.GetVersionedPartitions(request, kVersion, context);
 
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
     EXPECT_TRUE(response.GetResult().GetPartitions().empty());
@@ -758,12 +756,11 @@ TEST_F(PartitionsRepositoryTest, GetVolatilePartitions) {
 
     client::CancellationContext context;
     olp::client::ApiLookupClient lookup_client(catalog, settings);
-    repository::PartitionsRepository repository(catalog, settings,
-                                                lookup_client);
+    repository::PartitionsRepository repository(catalog, kVolatileLayerId,
+                                                settings, lookup_client);
     read::PartitionsRequest request;
 
-    auto response =
-        repository.GetVolatilePartitions(kVolatileLayerId, request, context);
+    auto response = repository.GetVolatilePartitions(request, context);
 
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
     EXPECT_EQ(response.GetResult().GetPartitions().size(), 4);
@@ -777,14 +774,14 @@ TEST_F(PartitionsRepositoryTest, GetVolatilePartitions) {
     settings.retry_settings.timeout = 0;
 
     olp::client::ApiLookupClient lookup_client(catalog, settings);
-    repository::PartitionsRepository repository(catalog, settings,
-                                                lookup_client);
+    repository::PartitionsRepository repository(catalog, kVolatileLayerId,
+                                                settings, lookup_client);
     client::CancellationContext context;
     read::PartitionsRequest request;
     request.WithFetchOption(read::CacheOnly);
 
     auto cache_only_response =
-        repository.GetVolatilePartitions(kVolatileLayerId, request, context);
+        repository.GetVolatilePartitions(request, context);
 
     ASSERT_TRUE(cache_only_response.IsSuccessful())
         << cache_only_response.GetError().GetMessage();
@@ -818,7 +815,8 @@ TEST_F(PartitionsRepositoryTest, AdditionalFields) {
   settings.network_request_handler = mock_network;
 
   olp::client::ApiLookupClient lookup_client(catalog, settings);
-  repository::PartitionsRepository repository(catalog, settings, lookup_client);
+  repository::PartitionsRepository repository(catalog, kVersionedLayerId,
+                                              settings, lookup_client);
   client::CancellationContext context;
   read::PartitionsRequest request;
 
@@ -828,8 +826,7 @@ TEST_F(PartitionsRepositoryTest, AdditionalFields) {
                                 read::PartitionsRequest::kCrc,
                                 read::PartitionsRequest::kDataSize});
 
-  auto response = repository.GetVersionedPartitions(kVersionedLayerId, request,
-                                                    kVersion, context);
+  auto response = repository.GetVersionedPartitions(request, kVersion, context);
 
   ASSERT_TRUE(response.IsSuccessful());
   auto result = response.GetResult();
@@ -842,8 +839,8 @@ TEST_F(PartitionsRepositoryTest, AdditionalFields) {
 
   request.WithFetchOption(read::CacheOnly);
 
-  auto response_2 = repository.GetVersionedPartitions(
-      kVersionedLayerId, request, kVersion, context);
+  auto response_2 =
+      repository.GetVersionedPartitions(request, kVersion, context);
 
   ASSERT_TRUE(response_2.IsSuccessful());
 
@@ -882,7 +879,8 @@ TEST_F(PartitionsRepositoryTest, CheckCashedPartitions) {
   auto layer = "testlayer";
 
   olp::client::ApiLookupClient lookup_client(hrn, settings);
-  repository::PartitionsRepository repository(hrn, settings, lookup_client);
+  repository::PartitionsRepository repository(hrn, layer, settings,
+                                              lookup_client);
 
   {
     SCOPED_TRACE("query partitions and store to cache");
@@ -890,7 +888,7 @@ TEST_F(PartitionsRepositoryTest, CheckCashedPartitions) {
         olp::geo::TileKey::FromHereTile("5904591"));
     olp::client::CancellationContext context;
 
-    auto response = repository.GetTile(layer, request, version, context);
+    auto response = repository.GetTile(request, version, context);
 
     ASSERT_TRUE(response.IsSuccessful());
     ASSERT_EQ(response.GetResult().GetDataHandle(),
@@ -905,7 +903,7 @@ TEST_F(PartitionsRepositoryTest, CheckCashedPartitions) {
                        .WithTileKey(olp::geo::TileKey::FromHereTile("1476147"))
                        .WithFetchOption(read::CacheOnly);
 
-    auto response = repository.GetTile(layer, request, version, context);
+    auto response = repository.GetTile(request, version, context);
 
     // check if partition was stored to cache
     ASSERT_TRUE(response.IsSuccessful());
@@ -954,9 +952,9 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
 
     olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, settings, lookup_client);
-    auto response =
-        repository.GetAggregatedTile(layer, request, version, context);
+    repository::PartitionsRepository repository(hrn, layer, settings,
+                                                lookup_client);
+    auto response = repository.GetAggregatedTile(request, version, context);
     const auto& result = response.GetResult();
 
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
@@ -984,9 +982,9 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_cache, Get(_)).WillOnce(Return(quad_tree.GetRawData()));
 
     olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, settings, lookup_client);
-    auto response =
-        repository.GetAggregatedTile(layer, request, version, context);
+    repository::PartitionsRepository repository(hrn, layer, settings,
+                                                lookup_client);
+    auto response = repository.GetAggregatedTile(request, version, context);
 
     const auto& result = response.GetResult();
 
@@ -1021,9 +1019,9 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
 
     olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, settings, lookup_client);
-    auto response =
-        repository.GetAggregatedTile(layer, request, version, context);
+    repository::PartitionsRepository repository(hrn, layer, settings,
+                                                lookup_client);
+    auto response = repository.GetAggregatedTile(request, version, context);
 
     const auto& result = response.GetResult();
 
@@ -1062,9 +1060,9 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
 
     olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, settings, lookup_client);
-    auto response =
-        repository.GetAggregatedTile(layer, request, version, context);
+    repository::PartitionsRepository repository(hrn, layer, settings,
+                                                lookup_client);
+    auto response = repository.GetAggregatedTile(request, version, context);
 
     const auto& error = response.GetError();
 
@@ -1092,9 +1090,9 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
     olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, settings, lookup_client);
-    auto response =
-        repository.GetAggregatedTile(layer, request, version, context);
+    repository::PartitionsRepository repository(hrn, layer, settings,
+                                                lookup_client);
+    auto response = repository.GetAggregatedTile(request, version, context);
     const auto& error = response.GetError();
 
     ASSERT_FALSE(response.IsSuccessful());
@@ -1126,9 +1124,9 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
     olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, settings, lookup_client);
-    auto response =
-        repository.GetAggregatedTile(layer, request, version, context);
+    repository::PartitionsRepository repository(hrn, layer, settings,
+                                                lookup_client);
+    auto response = repository.GetAggregatedTile(request, version, context);
 
     const auto& error = response.GetError();
 
@@ -1169,9 +1167,9 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
     olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, settings, lookup_client);
-    auto response =
-        repository.GetAggregatedTile(layer, request, version, context);
+    repository::PartitionsRepository repository(hrn, layer, settings,
+                                                lookup_client);
+    auto response = repository.GetAggregatedTile(request, version, context);
 
     const auto& error = response.GetError();
 
@@ -1211,9 +1209,9 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
     olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, settings, lookup_client);
-    auto response =
-        repository.GetAggregatedTile(layer, request, version, context);
+    repository::PartitionsRepository repository(hrn, layer, settings,
+                                                lookup_client);
+    auto response = repository.GetAggregatedTile(request, version, context);
     const auto& error = response.GetError();
 
     ASSERT_FALSE(response.IsSuccessful());
@@ -1263,8 +1261,9 @@ TEST_F(PartitionsRepositoryTest, GetTile) {
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
 
     olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, settings, lookup_client);
-    auto response = repository.GetTile(layer, request, version, context);
+    repository::PartitionsRepository repository(hrn, layer, settings,
+                                                lookup_client);
+    auto response = repository.GetTile(request, version, context);
 
     ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
   }


### PR DESCRIPTION
Change the PartitionsCacheRepository, PartitionsRepository.
Move layer_id from member function to constructor since it never
changes.
Reorder the arguments to following template: request, version, etc.

Relates-To: OLPEDGE-2312

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>