### PR TITLE
Add priority queue class.

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -320,6 +320,7 @@ set(OLP_SDK_LOGGING_SOURCES
 )
 
 set(OLP_SDK_THREAD_SOURCES
+    ./src/thread/PriorityQueueExtended.h
     ./src/thread/ThreadPoolTaskScheduler.cpp
 )
 

--- a/olp-cpp-sdk-core/src/thread/PriorityQueueExtended.h
+++ b/olp-cpp-sdk-core/src/thread/PriorityQueueExtended.h
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <deque>
+
+#include <olp/core/porting/make_unique.h>
+
+namespace olp {
+namespace thread {
+
+/// FIFO aware priority queue with removal support
+template <class T, class COMPARE = std::less<T> >
+class PriorityQueueExtended {
+ public:
+  /// Constructor
+  explicit PriorityQueueExtended(const COMPARE& compare = COMPARE());
+
+  /// Check for queue emptiness
+  bool empty() const;
+
+  /// Push copy of an object in priority queue
+  void push(const T& value);
+
+  /// Push a moveable object in priority queue
+  void push(T&& value);
+
+  /// Getter for front element in queue (with highest priority)
+  T& front();
+
+  /// Const getter for front element in queue (with highest priority)
+  const T& front() const;
+
+  /// Remove top element from queue
+  void pop();
+
+ private:
+  class PriorityQueueExtendedImpl;
+  std::unique_ptr<PriorityQueueExtendedImpl> impl_;
+};
+
+template <class T, class COMPARE>
+class PriorityQueueExtended<T, COMPARE>::PriorityQueueExtendedImpl {
+ public:
+  /// Constructor
+  explicit PriorityQueueExtendedImpl(const COMPARE& compare = COMPARE());
+
+  /// Check for queue emptiness
+  bool Empty() const;
+
+  /// Push copy of an object in priority queue
+  void Push(const T& value);
+
+  /// Push a moveable object in priority queue
+  void Push(T&& value);
+
+  /// Getter for front element in queue (with highest priority)
+  T& Front();
+
+  /// Const getter for front element in queue (with highest priority)
+  const T& Front() const;
+
+  /// Remove top element from queue
+  void Pop();
+
+ private:
+  /// Nested helper class to make an object distinguishable
+  struct DistinguishableObject {
+    template <class... Args>
+    DistinguishableObject(std::uint32_t id, Args... args)
+        : id(id), obj(args...) {}
+    DistinguishableObject(std::uint32_t id, const T& obj) : id(id), obj(obj) {}
+    DistinguishableObject(std::uint32_t id, T&& obj) : id(id), obj(obj) {}
+
+    std::uint32_t id;
+    T obj;
+  };
+
+  /// Comparator for distinguishable objects
+  class Compare {
+   public:
+    Compare(const COMPARE& compare) : compare_(compare) {}
+
+    bool operator()(const DistinguishableObject& lhs,
+                    const DistinguishableObject& rhs) const {
+      return (compare_(lhs.obj, rhs.obj) ||
+              (!compare_(rhs.obj, lhs.obj) && lhs.id > rhs.id));
+    }
+
+   private:
+    COMPARE compare_;
+  };
+
+  /// Getter for next object id. Id is used to keep equal objects FIFO order.
+  std::uint32_t GetNextId();
+
+  /// internal queue container
+  std::deque<DistinguishableObject> container_;
+  /// prorized queue comparator
+  Compare compare_;
+  /// id counter
+  std::uint32_t next_id_ = 0;
+};
+
+template <class T, class COMPARE>
+PriorityQueueExtended<T, COMPARE>::PriorityQueueExtended(const COMPARE& compare)
+    : impl_(std::make_unique<PriorityQueueExtendedImpl>(compare)) {}
+
+template <class T, class COMPARE>
+bool PriorityQueueExtended<T, COMPARE>::empty() const {
+  return impl_->Empty();
+}
+
+template <class T, class COMPARE>
+void PriorityQueueExtended<T, COMPARE>::push(const T& value) {
+  impl_->Push(value);
+}
+
+template <class T, class COMPARE>
+void PriorityQueueExtended<T, COMPARE>::push(T&& value) {
+  impl_->Push(value);
+}
+
+template <class T, class COMPARE>
+T& PriorityQueueExtended<T, COMPARE>::front() {
+  return impl_->Front();
+}
+
+template <class T, class COMPARE>
+const T& PriorityQueueExtended<T, COMPARE>::front() const {
+  return impl_->Front();
+}
+
+template <class T, class COMPARE>
+void PriorityQueueExtended<T, COMPARE>::pop() {
+  impl_->Pop();
+}
+
+template <class T, class COMPARE>
+PriorityQueueExtended<T, COMPARE>::PriorityQueueExtendedImpl::
+    PriorityQueueExtendedImpl(const COMPARE& compare)
+    : compare_(compare) {}
+
+template <class T, class COMPARE>
+bool PriorityQueueExtended<T, COMPARE>::PriorityQueueExtendedImpl::Empty()
+    const {
+  return container_.empty();
+}
+
+template <class T, class COMPARE>
+void PriorityQueueExtended<T, COMPARE>::PriorityQueueExtendedImpl::Push(
+    const T& value) {
+  container_.push_back(DistinguishableObject(GetNextId(), value));
+  std::push_heap(container_.begin(), container_.end(), compare_);
+}
+
+template <class T, class COMPARE>
+void PriorityQueueExtended<T, COMPARE>::PriorityQueueExtendedImpl::Push(
+    T&& value) {
+  container_.push_back(DistinguishableObject(GetNextId(), value));
+  std::push_heap(container_.begin(), container_.end(), compare_);
+}
+
+template <class T, class COMPARE>
+T& PriorityQueueExtended<T, COMPARE>::PriorityQueueExtendedImpl::Front() {
+  return container_.front().obj;
+}
+
+template <class T, class COMPARE>
+const T& PriorityQueueExtended<T, COMPARE>::PriorityQueueExtendedImpl::Front()
+    const {
+  return container_.front().obj;
+}
+
+template <class T, class COMPARE>
+void PriorityQueueExtended<T, COMPARE>::PriorityQueueExtendedImpl::Pop() {
+  if (!container_.empty()) {
+    std::pop_heap(container_.begin(), container_.end(), compare_);
+    container_.pop_back();
+  }
+}
+
+template <class T, class COMPARE>
+std::uint32_t
+PriorityQueueExtended<T, COMPARE>::PriorityQueueExtendedImpl::GetNextId() {
+  if (container_.empty()) {
+    next_id_ = 0;
+  }
+
+  // TODO add renumbering of ids in case of overflow (when next_id_ equal
+  // UMAX_INT)
+  return next_id_++;
+}
+
+}  // namespace thread
+}  // namespace olp

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ set(OLP_CPP_SDK_CORE_TESTS_SOURCES
     ./logging/MessageFormatterTest.cpp
     ./logging/MockAppender.cpp
 
+    ./thread/PriorityQueueExtendedTest.cpp
     ./thread/SyncQueueTest.cpp
     ./thread/ThreadPoolTaskSchedulerTest.cpp
     ./http/NetworkUtils.cpp

--- a/olp-cpp-sdk-core/tests/thread/PriorityQueueExtendedTest.cpp
+++ b/olp-cpp-sdk-core/tests/thread/PriorityQueueExtendedTest.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <queue>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "thread/PriorityQueueExtended.h"
+
+namespace {
+namespace thread = olp::thread;
+
+struct TestObject {
+  int value;
+  int id;
+};
+
+bool operator<(const TestObject& lhs, const TestObject& rhs) {
+  return lhs.value < rhs.value;
+}
+
+TEST(PriorityQueueExtendedTest, BasicFunctionality) {
+  {
+    SCOPED_TRACE("empty");
+
+    thread::PriorityQueueExtended<int> queue;
+
+    EXPECT_TRUE(queue.empty());
+  }
+
+  {
+    SCOPED_TRACE("not empty");
+
+    thread::PriorityQueueExtended<int> queue;
+    queue.push(1);
+
+    EXPECT_FALSE(queue.empty());
+  }
+
+  {
+    SCOPED_TRACE("push lvalue");
+
+    std::string value = "value";
+    thread::PriorityQueueExtended<std::string> queue;
+    queue.push(value);
+
+    EXPECT_FALSE(value.empty());
+    ASSERT_FALSE(queue.empty());
+    EXPECT_FALSE(queue.front().empty());
+    EXPECT_EQ(value, queue.front());
+  }
+
+  {
+    SCOPED_TRACE("push rvalue");
+
+    std::string value = "value";
+    thread::PriorityQueueExtended<std::string> queue;
+    queue.push(std::move(value));
+
+    EXPECT_FALSE(value.empty());
+    ASSERT_FALSE(queue.empty());
+    EXPECT_FALSE(queue.front().empty());
+  }
+
+  {
+    SCOPED_TRACE("front");
+
+    auto value = 100;
+    thread::PriorityQueueExtended<int> queue;
+    queue.push(value);
+
+    ASSERT_FALSE(queue.empty());
+    EXPECT_EQ(queue.front(), value);
+  }
+
+  {
+    SCOPED_TRACE("front const");
+
+    auto value = 100;
+    thread::PriorityQueueExtended<int> queue;
+    queue.push(value);
+
+    auto const& const_queue = queue;
+
+    ASSERT_FALSE(const_queue.empty());
+    EXPECT_EQ(const_queue.front(), value);
+  }
+
+  {
+    SCOPED_TRACE("pop");
+
+    thread::PriorityQueueExtended<int> queue;
+    queue.push(100);
+
+    ASSERT_FALSE(queue.empty());
+    queue.pop();
+    ASSERT_TRUE(queue.empty());
+  }
+
+  {
+    SCOPED_TRACE("pop empty");
+
+    thread::PriorityQueueExtended<int> queue;
+
+    ASSERT_TRUE(queue.empty());
+    queue.pop();
+    ASSERT_TRUE(queue.empty());
+  }
+}
+
+TEST(PriorityQueueExtendedTest, Priority) {
+  thread::PriorityQueueExtended<int> queue;
+  ASSERT_TRUE(queue.empty());
+
+  // fill queue with data
+  std::vector<int> priorities{3, 2, 1, 2};
+  for (auto i : priorities) {
+    queue.push(i);
+    ASSERT_FALSE(queue.empty());
+  }
+  std::sort(priorities.begin(), priorities.end());
+
+  // check queue is sorted
+  for (auto it = priorities.rbegin(); it != priorities.rend(); ++it) {
+    ASSERT_EQ(queue.front(), *it);
+    ASSERT_FALSE(queue.empty());
+    queue.pop();
+  }
+
+  ASSERT_TRUE(queue.empty());
+}
+
+TEST(PriorityQueueExtendedTest, FIFO) {
+  thread::PriorityQueueExtended<TestObject> queue;
+  ASSERT_TRUE(queue.empty());
+
+  // fill queue with data
+  std::vector<int> priorities{3, 2, 1, 2, 1, 3};
+  int id = 0;
+  for (auto i : priorities) {
+    queue.push({i, id});
+    ASSERT_FALSE(queue.empty());
+    ++id;
+  }
+
+  // check objects with same priority stored in FIFO order
+  auto top_obj = queue.front();
+  queue.pop();
+  while (!queue.empty()) {
+    const auto& obj = queue.front();
+
+    ASSERT_TRUE(obj < top_obj ||
+                (obj.value == top_obj.value && obj.id > top_obj.id));
+    ASSERT_FALSE(queue.empty());
+
+    top_obj = obj;
+    queue.pop();
+  }
+
+  ASSERT_TRUE(queue.empty());
+}
+
+}  // namespace


### PR DESCRIPTION
Priority queue is needed for requests priority feature. It will be
used by ThreadPoolTaskScheduler. We could use std::priority_queue
instead, but it's not respect order of requests with same priority.

The class has same complexity and similar API as the stl one and also
values with equal priority follow FIFO logic.

PriorityQueueExtended has API like std::queue, because it should be
used as SyncQueue container. Its conflicting with our code style. Impl
class added to split conflicting part from implementation.

Resolves: OLPEDGE-2305

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>