### PR TITLE
Make TashScheduler support requests priority.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/thread/ThreadPoolTaskScheduler.h
+++ b/olp-cpp-sdk-core/include/olp/core/thread/ThreadPoolTaskScheduler.h
@@ -22,7 +22,6 @@
 #include <thread>
 #include <vector>
 
-#include <olp/core/thread/SyncQueue.h>
 #include <olp/core/thread/TaskScheduler.h>
 
 namespace olp {
@@ -61,17 +60,34 @@ class CORE_API ThreadPoolTaskScheduler final : public TaskScheduler {
    * @brief Overrides the base class method to enqueue tasks and execute them on
    * the next free thread from the thread pool.
    *
+   * @note Tasks added with this method has Priority::NORMAL priority.
+   *
    * @param func The rvalue reference of the task that should be enqueued.
    * Move this task into your queue. No internal references are
    * kept. Once this method is called, you own the task.
    */
   void EnqueueTask(TaskScheduler::CallFuncType&& func) override;
 
+  /**
+   * @brief Overrides the base class method to enqueue tasks and execute them on
+   * the next free thread from the thread pool.
+   *
+   * @param func The rvalue reference of the task that should be enqueued.
+   * Move this task into your queue. No internal references are
+   * kept. Once this method is called, you own the task.
+   * @param priority The priority of the task. Tasks with higher priority
+   * executes earlier.
+   */
+  void EnqueueTask(TaskScheduler::CallFuncType&& func,
+                   uint32_t priority) override;
+
  private:
+  class QueueImpl;
+
   /// Thread pool created in constructor.
   std::vector<std::thread> thread_pool_;
   /// SyncQueue used to manage tasks.
-  SyncQueueFifo<TaskScheduler::CallFuncType> sync_queue_;
+  std::unique_ptr<QueueImpl> queue_;
 };
 
 }  // namespace thread

--- a/olp-cpp-sdk-core/src/thread/ThreadPoolTaskScheduler.cpp
+++ b/olp-cpp-sdk-core/src/thread/ThreadPoolTaskScheduler.cpp
@@ -32,8 +32,11 @@
 #include <string>
 
 #include "olp/core/logging/Log.h"
+#include "olp/core/porting/make_unique.h"
 #include "olp/core/porting/platform.h"
+#include "olp/core/thread/SyncQueue.h"
 #include "olp/core/utils/WarningWorkarounds.h"
+#include "thread/PriorityQueueExtended.h"
 
 namespace olp {
 namespace thread {
@@ -49,7 +52,7 @@ void SetCurrentThreadName(const std::string& thread_name) {
   // Note that in Mac based systems the pthread_setname_np takes 1 argument
   // only.
   pthread_setname_np(thread_name.c_str());
-#elif defined(OLP_SDK_HAVE_PTHREAD_SETNAME_NP) // Linux, Android, QNX
+#elif defined(OLP_SDK_HAVE_PTHREAD_SETNAME_NP)  // Linux, Android, QNX
   // QNX allows 100 but Linux only 16 so select min value and apply for both.
   // If maximum length is exceeded on some systems, e.g. Linux, the name is not
   // set at all. So better truncate it to have at least the minimum set.
@@ -59,9 +62,41 @@ void SetCurrentThreadName(const std::string& thread_name) {
 #endif  // OLP_SDK_HAVE_PTHREAD_SETNAME_NP
 }
 
+struct PrioritizedTask {
+  TaskScheduler::CallFuncType function;
+  uint32_t priority;
+};
+
+struct ComparePrioritizedTask {
+  bool operator()(const PrioritizedTask& lhs,
+                  const PrioritizedTask& rhs) const {
+    return lhs.priority < rhs.priority;
+  }
+};
+
 }  // namespace
 
+class ThreadPoolTaskScheduler::QueueImpl {
+ public:
+  using ElementType = PrioritizedTask;
+
+  bool Pull(ElementType& element) { return sync_queue_.Pull(element); }
+
+  void Push(ElementType&& element) {
+    sync_queue_.Push(std::forward<ElementType>(element));
+  }
+
+  void Close() { sync_queue_.Close(); }
+
+ private:
+  using PriorityQueue =
+      PriorityQueueExtended<ElementType, ComparePrioritizedTask>;
+  SyncQueue<ElementType, PriorityQueue> sync_queue_;
+};
+
 ThreadPoolTaskScheduler::ThreadPoolTaskScheduler(size_t thread_count) {
+  queue_ = std::make_unique<QueueImpl>();
+
   thread_pool_.reserve(thread_count);
 
   for (size_t idx = 0; idx < thread_count; ++idx) {
@@ -72,9 +107,11 @@ ThreadPoolTaskScheduler::ThreadPoolTaskScheduler(size_t thread_count) {
       OLP_SDK_LOG_INFO_F(kLogTag, "Starting thread '%s'", thread_name.c_str());
 
       for (;;) {
-        TaskScheduler::CallFuncType task;
-        if (!sync_queue_.Pull(task)) return;
-        task();
+        PrioritizedTask task;
+        if (!queue_->Pull(task)) {
+          return;
+        }
+        task.function();
       }
     });
 
@@ -83,7 +120,7 @@ ThreadPoolTaskScheduler::ThreadPoolTaskScheduler(size_t thread_count) {
 }
 
 ThreadPoolTaskScheduler::~ThreadPoolTaskScheduler() {
-  sync_queue_.Close();
+  queue_->Close();
   for (auto& thread : thread_pool_) {
     thread.join();
   }
@@ -91,7 +128,12 @@ ThreadPoolTaskScheduler::~ThreadPoolTaskScheduler() {
 }
 
 void ThreadPoolTaskScheduler::EnqueueTask(TaskScheduler::CallFuncType&& func) {
-  sync_queue_.Push(std::move(func));
+  queue_->Push({std::move(func), thread::NORMAL});
+}
+
+void ThreadPoolTaskScheduler::EnqueueTask(TaskScheduler::CallFuncType&& func,
+                                          uint32_t priority) {
+  queue_->Push({std::move(func), priority});
 }
 
 }  // namespace thread

--- a/olp-cpp-sdk-dataservice-read/src/Common.h
+++ b/olp-cpp-sdk-dataservice-read/src/Common.h
@@ -71,6 +71,38 @@ inline client::CancellationToken ScheduleFetch(TaskScheduler&& schedule_task,
  * requests.
  * @param task Function that will be executed.
  * @param callback Function that will consume task output.
+ * @param priority Priority of the task.
+ * @param args Additional agrs to pass to TaskContext.
+ * @return CancellationToken used to cancel the operation.
+ */
+template <typename Function, typename Callback, typename... Args>
+inline client::CancellationToken AddTaskWithPriority(
+    const std::shared_ptr<thread::TaskScheduler>& task_scheduler,
+    const std::shared_ptr<client::PendingRequests>& pending_requests,
+    Function task, Callback callback, uint32_t priority, Args&&... args) {
+  auto context = client::TaskContext::Create(
+      std::move(task), std::move(callback), std::forward<Args>(args)...);
+  pending_requests->Insert(context);
+
+  repository::ExecuteOrSchedule(task_scheduler,
+                                [=] {
+                                  context.Execute();
+                                  pending_requests->Remove(context);
+                                },
+                                priority);
+
+  return context.CancelToken();
+}
+
+/*
+ * @brief Common function used to wrap a lambda function and a callback that
+ * consumes the function result with a TaskContext class and schedule this to a
+ * task scheduler with NORMAL priority.
+ * @param task_scheduler Task scheduler instance.
+ * @param pending_requests PendingRequests instance that tracks current
+ * requests.
+ * @param task Function that will be executed.
+ * @param callback Function that will consume task output.
  * @param args Additional agrs to pass to TaskContext.
  * @return CancellationToken used to cancel the operation.
  */
@@ -79,16 +111,8 @@ inline client::CancellationToken AddTask(
     const std::shared_ptr<thread::TaskScheduler>& task_scheduler,
     const std::shared_ptr<client::PendingRequests>& pending_requests,
     Function task, Callback callback, Args&&... args) {
-  auto context = client::TaskContext::Create(
-      std::move(task), std::move(callback), std::forward<Args>(args)...);
-  pending_requests->Insert(context);
-
-  repository::ExecuteOrSchedule(task_scheduler, [=] {
-    context.Execute();
-    pending_requests->Remove(context);
-  });
-
-  return context.CancelToken();
+  return AddTaskWithPriority(task_scheduler, pending_requests, task, callback,
+                             thread::NORMAL, std::forward<Args>(args)...);
 }
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/repositories/ExecuteOrSchedule.inl
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/ExecuteOrSchedule.inl
@@ -28,22 +28,23 @@ namespace read {
 namespace repository {
 
 using CallFuncType = thread::TaskScheduler::CallFuncType;
+using Priority = thread::Priority;
 
 inline void ExecuteOrSchedule(
     const std::shared_ptr<thread::TaskScheduler>& task_scheduler,
-    CallFuncType&& func) {
+    CallFuncType&& func, uint32_t priority) {
   if (!task_scheduler) {
     // User didn't specify a TaskScheduler, execute sync
     func();
   } else {
-    task_scheduler->ScheduleTask(std::move(func));
+    task_scheduler->ScheduleTask(std::move(func), priority);
   }
 }
 
 inline void ExecuteOrSchedule(const client::OlpClientSettings* settings,
-                              CallFuncType&& func) {
+                              CallFuncType&& func, uint32_t priority) {
   ExecuteOrSchedule(settings ? settings->task_scheduler : nullptr,
-                    std::move(func));
+                    std::move(func), priority);
 }
 
 }  // namespace repository


### PR DESCRIPTION
Overloading EnqueueTask() method with priority input. Now enqueued
requests will be executed in priority order. Request with same
priority follow FIFO approach. thread::Priority is a helper enum,
NORMAL=500 is a default priority for tasks.

Resolves: OLPEDGE-2306

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>