### PR TITLE
Add priority to PrefetchTilesRequest

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchTilesRequest.h
@@ -26,6 +26,7 @@
 
 #include <olp/core/geo/tiling/TileKey.h>
 #include <olp/core/porting/deprecated.h>
+#include <olp/core/thread/TaskScheduler.h>
 #include <olp/dataservice/read/DataServiceReadApi.h>
 #include <boost/optional.hpp>
 
@@ -180,6 +181,27 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
   }
 
   /**
+   * @brief Gets the request priority.
+   *
+   * The default priority is `Priority::LOW`.
+   *
+   * @return The request priority.
+   */
+  inline uint32_t GetPriority() const { return priority_; }
+
+  /**
+   * @brief Sets the priority of the prefetch request.
+   *
+   * @param priority The priority of the request.
+   *
+   * @return A reference to the updated `PrefetchTileRequest` instance.
+   */
+  inline PrefetchTilesRequest& WithPriority(uint32_t priority) {
+    priority_ = priority;
+    return *this;
+  }
+
+  /**
    * @brief Creates a readable format for the request.
    *
    * @param layer_id The ID of the layer that is used for the request.
@@ -203,6 +225,7 @@ class DATASERVICE_READ_API PrefetchTilesRequest final {
   unsigned int max_level_{geo::TileKey::LevelCount};
   boost::optional<std::string> billing_tag_;
   bool data_aggregation_enabled_{false};
+  uint32_t priority_{thread::LOW};
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -201,7 +201,7 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
   auto pending_requests = pending_requests_;
   auto lookup_client = lookup_client_;
 
-  auto token = AddTask(
+  auto token = AddTaskWithPriority(
       settings.task_scheduler, pending_requests,
       [=](CancellationContext context) mutable -> EmptyResponse {
         if (request.GetTileKeys().empty()) {
@@ -327,7 +327,7 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
               std::move(roots), std::move(query), std::move(filter),
               std::move(download), std::move(append_result),
               std::move(callback), std::move(status_callback),
-              settings.task_scheduler, pending_requests);
+              settings.task_scheduler, pending_requests, request.GetPriority());
         });
 
         return EmptyResponse(PrefetchTileNoError());
@@ -342,7 +342,8 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
         if (!response.IsSuccessful()) {
           callback(response.GetError());
         }
-      });
+      },
+      request.GetPriority());
 
   return token;
 }

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -179,7 +179,7 @@ client::CancellationToken VolatileLayerClientImpl::PrefetchTiles(
   auto pending_requests = pending_requests_;
   auto lookup_client = lookup_client_;
 
-  auto token = AddTask(
+  auto token = AddTaskWithPriority(
       settings.task_scheduler, pending_requests,
       [=](CancellationContext context) mutable -> EmptyResponse {
         const auto& tile_keys = request.GetTileKeys();
@@ -287,7 +287,7 @@ client::CancellationToken VolatileLayerClientImpl::PrefetchTiles(
               std::move(roots), std::move(query), std::move(filter),
               std::move(download), std::move(append_result),
               std::move(callback), nullptr, settings.task_scheduler,
-              pending_requests);
+              pending_requests, request.GetPriority());
         });
 
         return EmptyResponse(PrefetchTileNoError());
@@ -302,7 +302,8 @@ client::CancellationToken VolatileLayerClientImpl::PrefetchTiles(
         if (!response.IsSuccessful()) {
           callback(response.GetError());
         }
-      });
+      },
+      request.GetPriority());
 
   return token;
 }


### PR DESCRIPTION
In previous commits we added priority to ScheduleTask(). Adding option
for user to set prefetch priority. Default value is Priority::LOW=100.

Resolves: OLPEDGE-2307

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>