### PR TITLE
Add priority to TileRequest

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/TileRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/TileRequest.h
@@ -24,6 +24,7 @@
 #include <utility>
 
 #include <olp/core/geo/tiling/TileKey.h>
+#include <olp/core/thread/TaskScheduler.h>
 #include <olp/dataservice/read/FetchOptions.h>
 #include <boost/optional.hpp>
 
@@ -128,6 +129,27 @@ class DATASERVICE_READ_API TileRequest final {
   }
 
   /**
+   * @brief Gets the request priority.
+   *
+   * The default priority is `Priority::NORMAL`.
+   *
+   * @return The request priority.
+   */
+  inline uint32_t GetPriority() const { return priority_; }
+
+  /**
+   * @brief Sets the priority of the request.
+   *
+   * @param priority The priority of the request.
+   *
+   * @return A reference to the updated `TileRequest` instance.
+   */
+  inline TileRequest& WithPriority(uint32_t priority) {
+    priority_ = priority;
+    return *this;
+  }
+
+  /**
    * @brief Creates a readable format for the request.
    *
    * @param layer_id The ID of the layer that is used for the request.
@@ -148,6 +170,7 @@ class DATASERVICE_READ_API TileRequest final {
   boost::optional<std::string> billing_tag_;
   geo::TileKey tile_key_;
   FetchOptions fetch_option_{OnlineIfNotFound};
+  uint32_t priority_{thread::NORMAL};
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -394,52 +394,37 @@ CatalogVersionResponse VersionedLayerClientImpl::GetVersion(
 
 client::CancellationToken VersionedLayerClientImpl::GetData(
     TileRequest request, DataResponseCallback callback) {
-  if (request.GetFetchOption() == CacheWithUpdate) {
-    auto task = [](client::CancellationContext) -> DataResponse {
+  auto catalog = catalog_;
+  auto layer_id = layer_id_;
+  auto settings = settings_;
+  auto pending_requests = pending_requests_;
+  auto lookup_client = lookup_client_;
+
+  auto data_task = [=](client::CancellationContext context) -> DataResponse {
+    if (request.GetFetchOption() == CacheWithUpdate) {
       return {{client::ErrorCode::InvalidArgument,
-               "CacheWithUpdate option can not be used for versioned "
-               "layer"}};
-    };
-    return AddTask(settings_.task_scheduler, pending_requests_, std::move(task),
-                   std::move(callback));
-  }
+               "CacheWithUpdate option can not be used for versioned layer"}};
+    }
 
-  if (!request.GetTileKey().IsValid()) {
-    auto task = [](client::CancellationContext) -> DataResponse {
+    if (!request.GetTileKey().IsValid()) {
       return {{client::ErrorCode::InvalidArgument, "Tile key is invalid"}};
-    };
-    return AddTask(settings_.task_scheduler, pending_requests_, std::move(task),
-                   std::move(callback));
-  }
+    }
 
-  auto schedule_get_data = [&](TileRequest request,
-                               DataResponseCallback callback) {
-    auto catalog = catalog_;
-    auto layer_id = layer_id_;
-    auto settings = settings_;
-    auto pending_requests = pending_requests_;
-    auto lookup_client = lookup_client_;
+    auto version_response =
+        GetVersion(request.GetBillingTag(), request.GetFetchOption(), context);
+    if (!version_response.IsSuccessful()) {
+      return version_response.GetError();
+    }
 
-    auto data_task = [=](client::CancellationContext context) -> DataResponse {
-      auto version_response = GetVersion(request.GetBillingTag(),
-                                         request.GetFetchOption(), context);
-      if (!version_response.IsSuccessful()) {
-        return version_response.GetError();
-      }
-
-      repository::DataRepository repository(
-          std::move(catalog), std::move(settings), std::move(lookup_client));
-      return repository.GetVersionedTile(
-          layer_id, request, version_response.GetResult().GetVersion(),
-          context);
-    };
-
-    return AddTask(settings.task_scheduler, pending_requests,
-                   std::move(data_task), std::move(callback));
+    repository::DataRepository repository(
+        std::move(catalog), std::move(settings), std::move(lookup_client));
+    return repository.GetVersionedTile(
+        layer_id, request, version_response.GetResult().GetVersion(), context);
   };
 
-  return ScheduleFetch(std::move(schedule_get_data), std::move(request),
-                       std::move(callback));
+  return AddTaskWithPriority(settings.task_scheduler, pending_requests,
+                             std::move(data_task), std::move(callback),
+                             request.GetPriority());
 }
 
 client::CancellableFuture<DataResponse> VersionedLayerClientImpl::GetData(
@@ -629,8 +614,9 @@ client::CancellationToken VersionedLayerClientImpl::GetAggregatedData(
     return std::move(result);
   };
 
-  return AddTask(settings.task_scheduler, pending_requests,
-                 std::move(data_task), std::move(callback));
+  return AddTaskWithPriority(settings.task_scheduler, pending_requests,
+                             std::move(data_task), std::move(callback),
+                             request.GetPriority());
 }
 
 client::CancellableFuture<AggregatedDataResponse>


### PR DESCRIPTION
Adding an option for user to set GetData() and GetAggregatedData()
requests priority. Default value is Priority::NORMAL=500.

Resolves: OLPEDGE-2308

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>