### PR TITLE
Add priority to DataRequest

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/DataRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/DataRequest.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <utility>
 
+#include <olp/core/thread/TaskScheduler.h>
 #include <olp/dataservice/read/DataServiceReadApi.h>
 #include <olp/dataservice/read/FetchOptions.h>
 #include <boost/optional.hpp>
@@ -199,6 +200,27 @@ class DATASERVICE_READ_API DataRequest final {
   }
 
   /**
+   * @brief Gets the request priority.
+   *
+   * The default priority is `Priority::NORMAL`.
+   *
+   * @return The request priority.
+   */
+  inline uint32_t GetPriority() const { return priority_; }
+
+  /**
+   * @brief Sets the priority of the request.
+   *
+   * @param priority The priority of the request.
+   *
+   * @return A reference to the updated `DataRequest` instance.
+   */
+  inline DataRequest& WithPriority(uint32_t priority) {
+    priority_ = priority;
+    return *this;
+  }
+
+  /**
    * @brief Creates a readable format for the request.
    *
    * @param layer_id The ID of the layer that is used for the request.
@@ -231,6 +253,7 @@ class DATASERVICE_READ_API DataRequest final {
   boost::optional<std::string> data_handle_;
   boost::optional<std::string> billing_tag_;
   FetchOptions fetch_option_{OnlineIfNotFound};
+  uint32_t priority_{thread::NORMAL};
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -134,46 +134,37 @@ VersionedLayerClientImpl::GetPartitions(PartitionsRequest partitions_request) {
 
 client::CancellationToken VersionedLayerClientImpl::GetData(
     DataRequest request, DataResponseCallback callback) {
-  if (request.GetFetchOption() == CacheWithUpdate) {
-    auto task = [](client::CancellationContext) -> DataResponse {
+  auto catalog = catalog_;
+  auto layer_id = layer_id_;
+  auto settings = settings_;
+  auto lookup_client = lookup_client_;
+
+  auto data_task =
+      [=](client::CancellationContext context) mutable -> DataResponse {
+    if (request.GetFetchOption() == CacheWithUpdate) {
       return {{client::ErrorCode::InvalidArgument,
                "CacheWithUpdate option can not be used for versioned "
                "layer"}};
-    };
-    return AddTask(settings_.task_scheduler, pending_requests_, std::move(task),
-                   std::move(callback));
-  }
+    }
 
-  auto schedule_get_data = [&](DataRequest request,
-                               DataResponseCallback callback) {
-    auto catalog = catalog_;
-    auto layer_id = layer_id_;
-    auto settings = settings_;
-    auto lookup_client = lookup_client_;
-
-    auto data_task =
-        [=](client::CancellationContext context) mutable -> DataResponse {
-      int64_t version = -1;
-      if (!request.GetDataHandle()) {
-        auto version_response = GetVersion(request.GetBillingTag(),
-                                           request.GetFetchOption(), context);
-        if (!version_response.IsSuccessful()) {
-          return version_response.GetError();
-        }
-        version = version_response.GetResult().GetVersion();
+    int64_t version = -1;
+    if (!request.GetDataHandle()) {
+      auto version_response = GetVersion(request.GetBillingTag(),
+                                         request.GetFetchOption(), context);
+      if (!version_response.IsSuccessful()) {
+        return version_response.GetError();
       }
+      version = version_response.GetResult().GetVersion();
+    }
 
-      repository::DataRepository repository(
-          std::move(catalog), std::move(settings), std::move(lookup_client));
-      return repository.GetVersionedData(layer_id, request, version, context);
-    };
-
-    return AddTask(settings.task_scheduler, pending_requests_,
-                   std::move(data_task), std::move(callback));
+    repository::DataRepository repository(
+        std::move(catalog), std::move(settings), std::move(lookup_client));
+    return repository.GetVersionedData(layer_id, request, version, context);
   };
 
-  return ScheduleFetch(std::move(schedule_get_data), std::move(request),
-                       std::move(callback));
+  return AddTaskWithPriority(settings.task_scheduler, pending_requests_,
+                             std::move(data_task), std::move(callback),
+                             request.GetPriority());
 }
 
 client::CancellableFuture<DataResponse> VersionedLayerClientImpl::GetData(


### PR DESCRIPTION
Adding an option for user to set GetData(DataRequest) requests
priority. Default value is Priority::NORMAL=500.

Resolves: OLPEDGE-2309

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>