### PR TITLE
Adapt PendingUrlRequest to be used by OlpClient.

### DIFF
--- a/olp-cpp-sdk-core/src/client/PendingUrlRequests.h
+++ b/olp-cpp-sdk-core/src/client/PendingUrlRequests.h
@@ -113,6 +113,8 @@ class PendingUrlRequests {
   /// Alias for a shareable pending request
   using PendingUrlRequestPtr = std::shared_ptr<PendingUrlRequest>;
 
+  virtual ~PendingUrlRequests() { CancelAllAndWait(); }
+
   /// Get the total size of requests pending and cancelled requests.
   size_t Size() const;
 


### PR DESCRIPTION
Adapt PendingUrlRequest to be used by OlpClient.

This commit prepares the PendingUrlRequest class
to be used by the async OlpClient::CallApi() method.
This means we allow calling ExecuteOrCancel()
multiple times to cover the use case where you need
to retry the request when 429/5xx HTTP status was
returned and we allow the recycling of a pending
request instance so that we can accommodate the
retry which results in a new Network request id.

Additionally, this commit enhances logging in
PendingUrlRequest classes and NetworkCurl.

Relates-To: OLPEDGE-1805

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>