### PR TITLE
Add a TaskSink internal class.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/TaskSink.h
+++ b/olp-cpp-sdk-dataservice-read/src/TaskSink.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <olp/core/client/CancellationToken.h>
+#include <olp/core/client/PendingRequests.h>
+#include <olp/core/client/TaskContext.h>
+#include <olp/core/logging/Log.h>
+#include <olp/core/thread/TaskScheduler.h>
+
+#include "repositories/ExecuteOrSchedule.inl"
+
+namespace olp {
+namespace dataservice {
+namespace read {
+
+class TaskSink {
+ public:
+  explicit TaskSink(std::shared_ptr<thread::TaskScheduler> task_scheduler)
+      : task_scheduler_(std::move(task_scheduler)),
+        pending_requests_(std::make_shared<client::PendingRequests>()),
+        closed_(false) {}
+
+  TaskSink(const TaskSink&) = delete;
+  TaskSink& operator=(const TaskSink&) = delete;
+
+  ~TaskSink() {
+    closed_.store(true);
+    pending_requests_->CancelAllAndWait();
+  }
+
+  void CancelTasks() { pending_requests_->CancelAll(); }
+
+  template <typename Function, typename Callback, typename... Args>
+  client::CancellationToken AddTask(Function task, Callback callback,
+                                    uint32_t priority, Args&&... args) {
+    auto context = client::TaskContext::Create(
+        std::move(task), std::move(callback), std::forward<Args>(args)...);
+    AddTaskImpl(context, priority);
+    return context.CancelToken();
+  }
+
+  template <typename Function, typename Callback, typename... Args>
+  boost::optional<client::CancellationToken> AddTaskChecked(Function task,
+                                                            Callback callback,
+                                                            uint32_t priority,
+                                                            Args&&... args) {
+    auto context = client::TaskContext::Create(
+        std::move(task), std::move(callback), std::forward<Args>(args)...);
+    if (!AddTaskImpl(context, priority)) {
+      return boost::none;
+    }
+    return context.CancelToken();
+  }
+
+ private:
+  bool AddTaskImpl(client::TaskContext task, uint32_t priority) {
+    if (closed_.load()) {
+      OLP_SDK_LOG_WARNING(
+          "TaskSink", "Attempt to add a task when the sink is already closed");
+      return false;
+    }
+
+    pending_requests_->Insert(task);
+
+    auto pending_requests = pending_requests_;
+
+    repository::ExecuteOrSchedule(task_scheduler_,
+                                  [=] {
+                                    task.Execute();
+                                    pending_requests->Remove(task);
+                                  },
+                                  priority);
+
+    return true;
+  }
+
+  std::shared_ptr<thread::TaskScheduler> task_scheduler_;
+  std::shared_ptr<client::PendingRequests> pending_requests_;
+  std::atomic_bool closed_;
+};
+
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -34,7 +34,7 @@
 #include <olp/dataservice/read/TileRequest.h>
 #include <olp/dataservice/read/Types.h>
 #include <boost/optional.hpp>
-#include "repositories/ExecuteOrSchedule.inl"
+#include "TaskSink.h"
 
 namespace olp {
 namespace thread {
@@ -53,7 +53,7 @@ class VersionedLayerClientImpl {
                            boost::optional<int64_t> catalog_version,
                            client::OlpClientSettings settings);
 
-  virtual ~VersionedLayerClientImpl();
+  virtual ~VersionedLayerClientImpl() = default;
 
   virtual bool CancelPendingRequests();
 
@@ -107,9 +107,9 @@ class VersionedLayerClientImpl {
   client::HRN catalog_;
   std::string layer_id_;
   client::OlpClientSettings settings_;
-  std::shared_ptr<client::PendingRequests> pending_requests_;
   std::atomic<int64_t> catalog_version_;
   client::ApiLookupClient lookup_client_;
+  TaskSink task_sink_;
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
@@ -29,6 +29,8 @@
 #include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/Types.h>
 
+#include "TaskSink.h"
+
 namespace olp {
 
 namespace client {
@@ -47,7 +49,7 @@ class VolatileLayerClientImpl {
   VolatileLayerClientImpl(client::HRN catalog, std::string layer_id,
                           client::OlpClientSettings settings);
 
-  virtual ~VolatileLayerClientImpl();
+  virtual ~VolatileLayerClientImpl() = default;
 
   virtual bool CancelPendingRequests();
 
@@ -76,8 +78,8 @@ class VolatileLayerClientImpl {
   client::HRN catalog_;
   std::string layer_id_;
   client::OlpClientSettings settings_;
-  std::shared_ptr<client::PendingRequests> pending_requests_;
   client::ApiLookupClient lookup_client_;
+  TaskSink task_sink_;
 };
 
 }  // namespace read


### PR DESCRIPTION
Add a new TaskSink class to handle the tasks creation and enqueuing.
Fix a scenario when the task could be enqueued during destruction.

Relates-To: OAM-695

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>