### PR TITLE
Add PrefetchPartitions implementation

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/PrefetchPartitionsHelper.h
+++ b/olp-cpp-sdk-dataservice-read/src/PrefetchPartitionsHelper.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <olp/core/client/CancellationContext.h>
+#include <olp/core/client/PendingRequests.h>
+#include <olp/core/logging/Log.h>
+#include <olp/dataservice/read/Types.h>
+#include "Common.h"
+#include "DownloadItemsJob.h"
+#include "ExtendedApiResponse.h"
+#include "ExtendedApiResponseHelpers.h"
+#include "QueryMetadataJob.h"
+#include "TaskSink.h"
+#include "repositories/PartitionsRepository.h"
+
+namespace olp {
+namespace dataservice {
+namespace read {
+
+using PartitionDataHandleResult =
+    std::vector<std::pair<std::string, std::string>>;
+using PartitionsDataHandleExtendedResponse =
+    ExtendedApiResponse<PartitionDataHandleResult, client::ApiError,
+                        client::NetworkStatistics>;
+
+class PrefetchPartitionsHelper {
+ public:
+  using DownloadJob = DownloadItemsJob<std::string, PrefetchPartitionsResult,
+                                       PrefetchPartitionsStatus>;
+  using QueryFunc = QueryItemsFunc<std::string, std::vector<std::string>,
+                                   PartitionsDataHandleExtendedResponse>;
+
+  static client::CancellationToken Prefetch(
+      std::shared_ptr<DownloadJob> download_job,
+      const std::vector<std::string>& roots, QueryFunc query,
+      TaskSink& task_sink, size_t query_max_size, uint32_t priority) {
+    client::CancellationContext execution_context;
+
+    auto query_job = std::make_shared<QueryMetadataJob<
+        std::string, std::vector<std::string>, PrefetchPartitionsResult,
+        PartitionsDataHandleExtendedResponse, PrefetchPartitionsStatus>>(
+        std::move(query), nullptr, download_job, task_sink, execution_context,
+        priority);
+
+    auto query_size = roots.size() / query_max_size;
+    query_size += (roots.size() % query_max_size > 0) ? 1 : 0;
+
+    query_job->Initialize(query_size);
+
+    OLP_SDK_LOG_DEBUG_F("PrefetchJob", "Starting queries, requests=%zu",
+                        roots.size());
+
+    execution_context.ExecuteOrCancelled([&]() {
+      VectorOfTokens tokens;
+      tokens.reserve(query_size);
+
+      // split items to blocks
+      auto size_left = roots.size();
+      auto start = 0u;
+      while (size_left > start) {
+        auto size = std::min(query_max_size, size_left - start);
+        auto query_element = std::vector<std::string>(
+            roots.begin() + start, roots.begin() + start + size);
+
+        tokens.emplace_back(task_sink.AddTask(
+            [query_element, query_job](client::CancellationContext context) {
+              return query_job->Query(std::move(query_element), context);
+            },
+            [query_job](PartitionsDataHandleExtendedResponse response) {
+              query_job->CompleteQuery(std::move(response));
+            },
+            priority));
+
+        start += size;
+      }
+
+      return CreateToken(std::move(tokens));
+    });
+
+    return client::CancellationToken(
+        [execution_context]() mutable { execution_context.CancelOperation(); });
+  }
+};
+
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -29,6 +29,7 @@
 #include <olp/core/client/PendingRequests.h>
 #include <olp/dataservice/read/DataRequest.h>
 #include <olp/dataservice/read/PartitionsRequest.h>
+#include <olp/dataservice/read/PrefetchPartitionsRequest.h>
 #include <olp/dataservice/read/PrefetchTileResult.h>
 #include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/TileRequest.h>
@@ -80,6 +81,15 @@ class VersionedLayerClientImpl {
 
   virtual client::CancellableFuture<PrefetchTilesResponse> PrefetchTiles(
       PrefetchTilesRequest request, PrefetchStatusCallback status_callback);
+
+  virtual client::CancellationToken PrefetchPartitions(
+      PrefetchPartitionsRequest request,
+      PrefetchPartitionsResponseCallback callback,
+      PrefetchPartitionsStatusCallback status_callback);
+
+  virtual client::CancellableFuture<PrefetchPartitionsResponse>
+  PrefetchPartitions(PrefetchPartitionsRequest request,
+                     PrefetchPartitionsStatusCallback status_callback);
 
   virtual bool RemoveFromCache(const std::string& partition_id);
 

--- a/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientImplTest.cpp
@@ -28,13 +28,23 @@
 #include <olp/core/client/OlpClientSettingsFactory.h>
 #include <olp/core/utils/Dir.h>
 #include <olp/dataservice/read/VersionedLayerClient.h>
+#include "ApiDefaultResponses.h"
+#include "ReadDefaultResponses.h"
+#include "UrlGenerators.h"
 #include "VersionedLayerClientImpl.h"
 #include "repositories/QuadTreeIndex.h"
+// clang-format off
+#include "generated/serializer/ApiSerializer.h"
+#include "generated/serializer/VersionResponseSerializer.h"
+#include "generated/serializer/PartitionsSerializer.h"
+#include "generated/serializer/JsonSerializer.h"
+// clang-format on
 
 namespace {
 namespace read = olp::dataservice::read;
 namespace model = olp::dataservice::read::model;
 using ::testing::_;
+using ::testing::Mock;
 
 const std::string kCatalog =
     "hrn:here:data::olp-here-test:hereos-internal-test-v2";
@@ -47,25 +57,20 @@ constexpr auto kBlobDataHandle = R"(4eed6ed1-0d32-43b9-ae79-043cb4256432)";
 constexpr auto kHereTile = "23618364";
 constexpr auto kOtherHereTile = "1476147";
 constexpr auto kOtherHereTile2 = "5904591";
-constexpr auto kHereTileDataHandle = "f9a9fd8e-eb1b-48e5-bfdb-4392b3826443";
-constexpr auto kUrlQuadRequest =
-    R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/testlayer/versions/4/quadkeys/92259/depths/4)";
-constexpr auto kHttpResponceQuadkey =
-    R"jsonString({"subQuads": [{"subQuadKey":"19","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"316","version":4,"dataHandle":"f9a9fd8e-eb1b-48e5-bfdb-4392b3826443"},{"subQuadKey":"317","version":4,"dataHandle":"e119d20e-c7c6-4563-ae88-8aa5c6ca75c3"},{"subQuadKey":"318","version":4,"dataHandle":"a7a1afdf-db7e-4833-9627-d38bee6e2f81"},{"subQuadKey":"319","version":4,"dataHandle":"9d515348-afce-44e8-bc6f-3693cfbed104"},{"subQuadKey":"79","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString";
 constexpr auto kUrlLookup =
     R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data::olp-here-test:hereos-internal-test-v2/apis)";
-constexpr auto kHttpResponseLookup =
-    R"jsonString([{"api":"metadata","version":"v1","baseURL":"https://metadata.data.api.platform.here.com/metadata/v1/catalogs/hereos-internal-test-v2","parameters":{}}, {"api":"query","version":"v1","baseURL":"https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2","parameters":{}}, {"api":"blob","version":"v1","baseURL":"https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2","parameters":{}},{"api":"volatile-blob","version":"v1","baseURL":"https://volatile-blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2","parameters":{}},{"api":"stream","version":"v2","baseURL":"https://stream-ireland.data.api.platform.here.com/stream/v2/catalogs/hereos-internal-test-v2","parameters":{}}])jsonString";
-constexpr auto kUrlVersion =
-    R"(https://metadata.data.api.platform.here.com/metadata/v1/catalogs/hereos-internal-test-v2/versions/latest?startVersion=-1)";
-constexpr auto kHttpResponseVersion =
-    R"jsonString({"version":4})jsonString";
-constexpr auto kDataRequestTile =
-    R"(https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/f9a9fd8e-eb1b-48e5-bfdb-4392b3826443)";
-constexpr auto kDataRequestOtherTile =
-    R"(https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/95c5c703-e00e-4c38-841e-e419367474f1)";
-constexpr auto kDataRequestOtherTile2 =
-    R"(https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1)";
+
+template <class T>
+std::string serialize(std::vector<T> data) {
+  std::string str = "[";
+  for (const auto& el : data) {
+    str.append(olp::serializer::serialize(el));
+    str.append(",");
+  }
+  str[str.length() - 1] = ']';
+  return str;
+}
+
 TEST(VersionedLayerClientTest, CanBeMoved) {
   read::VersionedLayerClient client_a(olp::client::HRN(), "", boost::none, {});
   read::VersionedLayerClient client_b(std::move(client_a));
@@ -99,6 +104,7 @@ TEST(VersionedLayerClientTest, GetData) {
     EXPECT_EQ(response.GetError().GetErrorCode(),
               olp::client::ErrorCode::PreconditionFailed);
   }
+  Mock::VerifyAndClearExpectations(network_mock.get());
 }
 
 TEST(VersionedLayerClientTest, RemoveFromCachePartition) {
@@ -171,7 +177,10 @@ TEST(VersionedLayerClientTest, RemoveFromCacheTileKey) {
   auto depth = 4;
   auto tile_key = olp::geo::TileKey::FromHereTile(kHereTile);
   auto root = tile_key.ChangedLevelBy(-depth);
-  auto stream = std::stringstream(kHttpResponceQuadkey);
+
+  auto stream = std::stringstream(
+      mockserver::ReadDefaultResponses::GenerateQuadTreeResponse(
+          root, depth, {9, 10, 11, 12}));
   read::QuadTreeIndex quad_tree(root, depth, stream);
   auto buffer = quad_tree.GetRawData();
 
@@ -182,8 +191,10 @@ TEST(VersionedLayerClientTest, RemoveFromCacheTileKey) {
   };
 
   auto data_cache_remove = [&](const std::string& prefix) {
-    std::string expected_prefix = kHrn.ToCatalogHRNString() + "::" + kLayerId +
-                                  "::" + kHereTileDataHandle + "::Data";
+    std::string expected_prefix =
+        kHrn.ToCatalogHRNString() + "::" + kLayerId +
+        "::" + mockserver::ReadDefaultResponses::GenerateDataHandle(kHereTile) +
+        "::Data";
     EXPECT_EQ(prefix, expected_prefix);
     return true;
   };
@@ -351,26 +362,60 @@ TEST(VersionedLayerClientTest, ProtectThanRelease) {
   settings.cache = cache;
   settings.default_cache_expiration = std::chrono::seconds(2);
   settings.network_request_handler = network_mock;
+  auto version = 4u;
+  auto api_response =
+      mockserver::ApiDefaultResponses::GenerateResourceApisResponse(kCatalog);
+  auto quad_path = mock::GeneratePath(
+      api_response, "query",
+      mock::GenerateGetQuadKeyPath("92259", kLayerId, version, 4));
+  ASSERT_FALSE(quad_path.empty());
+  auto tile_key = olp::geo::TileKey::FromHereTile(kHereTile);
+  auto responce_quad =
+      mockserver::ReadDefaultResponses::GenerateQuadTreeResponse(
+          tile_key.ChangedLevelBy(-4), 4, {9, 10, 11, 12});
+  auto tile_path = mock::GeneratePath(
+      api_response, "blob",
+      mock::GenerateGetDataPath(
+          kLayerId,
+          mockserver::ReadDefaultResponses::GenerateDataHandle(kHereTile)));
+  ASSERT_FALSE(tile_path.empty());
+  auto tile2_path = mock::GeneratePath(
+      api_response, "blob",
+      mock::GenerateGetDataPath(
+          kLayerId, mockserver::ReadDefaultResponses::GenerateDataHandle(
+                        kOtherHereTile2)));
+  ASSERT_FALSE(tile2_path.empty());
+  auto other_tile_path = mock::GeneratePath(
+      api_response, "blob",
+      mock::GenerateGetDataPath(
+          kLayerId, mockserver::ReadDefaultResponses::GenerateDataHandle(
+                        kOtherHereTile)));
+  ASSERT_FALSE(other_tile_path.empty());
 
   read::VersionedLayerClientImpl client(kHrn, kLayerId, boost::none, settings);
   {
     SCOPED_TRACE("Cache tile key");
-    auto tile_key = olp::geo::TileKey::FromHereTile(kHereTile);
 
     EXPECT_CALL(*network_mock, Send(IsGetRequest(kUrlLookup), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     kHttpResponseLookup));
-    EXPECT_CALL(*network_mock, Send(IsGetRequest(kUrlVersion), _, _, _, _))
-        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                         olp::http::HttpStatusCode::OK),
-                                     kHttpResponseVersion));
-    EXPECT_CALL(*network_mock, Send(IsGetRequest(kUrlQuadRequest), _, _, _, _))
-        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                         olp::http::HttpStatusCode::OK),
-                                     kHttpResponceQuadkey));
+                                     serialize(api_response)));
+    auto version_path = mock::GeneratePath(
+        api_response, "metadata", mock::GenerateGetLatestVersionPath());
+    ASSERT_FALSE(version_path.empty());
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(version_path), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(
+                olp::http::HttpStatusCode::OK),
+            olp::serializer::serialize(
+                mockserver::ReadDefaultResponses::GenerateVersionResponse(
+                    version))));
 
-    EXPECT_CALL(*network_mock, Send(IsGetRequest(kDataRequestTile), _, _, _, _))
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(quad_path), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     responce_quad));
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(tile_path), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
                                      "data"));
@@ -381,25 +426,25 @@ TEST(VersionedLayerClientTest, ProtectThanRelease) {
     const auto& response = future.get();
     ASSERT_TRUE(response.IsSuccessful());
   }
+
   {
     SCOPED_TRACE("Cache tile other key");
-    auto tile_key = olp::geo::TileKey::FromHereTile(kOtherHereTile);
+    auto other_tile_key = olp::geo::TileKey::FromHereTile(kOtherHereTile);
 
-    EXPECT_CALL(*network_mock,
-                Send(IsGetRequest(kDataRequestOtherTile), _, _, _, _))
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(other_tile_path), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
                                      "data"));
 
     auto future =
-        client.GetData(read::TileRequest().WithTileKey(tile_key)).GetFuture();
+        client.GetData(read::TileRequest().WithTileKey(other_tile_key))
+            .GetFuture();
 
     const auto& response = future.get();
     ASSERT_TRUE(response.IsSuccessful());
   }
   {
     SCOPED_TRACE("Protect");
-    auto tile_key = olp::geo::TileKey::FromHereTile(kHereTile);
     auto other_tile_key = olp::geo::TileKey::FromHereTile(kOtherHereTile);
     auto response = client.Protect({tile_key, other_tile_key});
     ASSERT_TRUE(response);
@@ -407,39 +452,38 @@ TEST(VersionedLayerClientTest, ProtectThanRelease) {
     ASSERT_TRUE(client.IsCached(tile_key));
     ASSERT_TRUE(client.IsCached(other_tile_key));
   }
+
   {
     SCOPED_TRACE("Protect tile which not in cache but has known data handle");
-    auto tile_key = olp::geo::TileKey::FromHereTile(kOtherHereTile2);
-    auto response = client.Protect({tile_key});
+    auto tile_key2 = olp::geo::TileKey::FromHereTile(kOtherHereTile2);
+    auto response = client.Protect({tile_key2});
     ASSERT_TRUE(response);
-    ASSERT_FALSE(client.IsCached(tile_key));
+    ASSERT_FALSE(client.IsCached(tile_key2));
 
     // now get protected tile
-    EXPECT_CALL(*network_mock,
-                Send(IsGetRequest(kDataRequestOtherTile2), _, _, _, _))
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(tile2_path), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
                                      "data"));
 
     auto data_future =
-        client.GetData(read::TileRequest().WithTileKey(tile_key)).GetFuture();
+        client.GetData(read::TileRequest().WithTileKey(tile_key2)).GetFuture();
 
     const auto& data_response = data_future.get();
     ASSERT_TRUE(data_response.IsSuccessful());
     std::this_thread::sleep_for(std::chrono::seconds(3));
     // tile stays in cache, as it was protected before
-    ASSERT_TRUE(client.IsCached(tile_key));
+    ASSERT_TRUE(client.IsCached(tile_key2));
   }
   {
     SCOPED_TRACE("Protect tile which not in cache");
-    auto tile_key = olp::geo::TileKey::FromHereTile("5904592");
+    auto some_tile_key = olp::geo::TileKey::FromHereTile("6904592");
 
-    auto response = client.Protect({tile_key});
+    auto response = client.Protect({some_tile_key});
     ASSERT_FALSE(response);
   }
   {
     SCOPED_TRACE("Release tiles without releasing quad tree");
-    auto tile_key = olp::geo::TileKey::FromHereTile(kHereTile);
     auto other_tile_key = olp::geo::TileKey::FromHereTile(kOtherHereTile);
     auto other_tile_key2 = olp::geo::TileKey::FromHereTile(kOtherHereTile2);
     auto response = client.Release({tile_key, other_tile_key2});
@@ -467,19 +511,18 @@ TEST(VersionedLayerClientTest, ProtectThanRelease) {
   }
   {
     SCOPED_TRACE("Protect and release keys within one quad");
-    auto tile_key = olp::geo::TileKey::FromHereTile(kHereTile);
     auto other_tile_key = olp::geo::TileKey::FromHereTile(kOtherHereTile);
 
-    EXPECT_CALL(*network_mock, Send(IsGetRequest(kUrlQuadRequest), _, _, _, _))
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(quad_path), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     kHttpResponceQuadkey));
-    EXPECT_CALL(*network_mock, Send(IsGetRequest(kDataRequestTile), _, _, _, _))
+                                     responce_quad));
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(tile_path), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
                                      "data"));
-    EXPECT_CALL(*network_mock,
-                Send(IsGetRequest(kDataRequestOtherTile), _, _, _, _))
+
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(other_tile_path), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
                                      "data"));
@@ -505,6 +548,515 @@ TEST(VersionedLayerClientTest, ProtectThanRelease) {
     ASSERT_FALSE(client.IsCached(other_tile_key));
   }
   ASSERT_TRUE(cache->Clear());
+  Mock::VerifyAndClearExpectations(network_mock.get());
+}
+
+TEST(VersionedLayerClientTest, PrefetchPartitionsSplitted) {
+  std::shared_ptr<NetworkMock> network_mock = std::make_shared<NetworkMock>();
+  olp::client::OlpClientSettings settings;
+  settings.network_request_handler = network_mock;
+  auto version = 4u;
+
+  auto partitions_count = 200u;
+  std::vector<std::string> partitions1;
+  std::vector<std::string> partitions2;
+
+  for (auto i = 0u; i < partitions_count / 2; i++) {
+    partitions1.emplace_back(std::to_string(i));
+  }
+  for (auto i = partitions_count / 2; i < partitions_count; i++) {
+    partitions2.emplace_back(std::to_string(i));
+  }
+  std::vector<std::string> partitions = partitions1;
+  partitions.insert(partitions.end(), partitions2.begin(), partitions2.end());
+
+  read::VersionedLayerClientImpl client(kHrn, kLayerId, boost::none, settings);
+  {
+    SCOPED_TRACE("Prefetch multiple partitions");
+
+    auto api_response =
+        mockserver::ApiDefaultResponses::GenerateResourceApisResponse(kCatalog);
+    auto partitions_response1 =
+        mockserver::ReadDefaultResponses::GeneratePartitionsResponse(
+            partitions_count / 2);
+    auto partitions_response2 =
+        mockserver::ReadDefaultResponses::GeneratePartitionsResponse(
+            partitions_count / 2, partitions_count / 2);
+
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(kUrlLookup), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     serialize(api_response)));
+
+    auto version_path = mock::GeneratePath(
+        api_response, "metadata", mock::GenerateGetLatestVersionPath());
+    ASSERT_FALSE(version_path.empty());
+
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(version_path), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(
+                olp::http::HttpStatusCode::OK),
+            olp::serializer::serialize(
+                mockserver::ReadDefaultResponses::GenerateVersionResponse(
+                    version))));
+
+    auto partitions_path1 = mock::GeneratePath(
+        api_response, "query",
+        mock::GenerateGetPartitionsPath(kLayerId, partitions1, version));
+    ASSERT_FALSE(partitions_path1.empty());
+    auto partitions_path2 = mock::GeneratePath(
+        api_response, "query",
+        mock::GenerateGetPartitionsPath(kLayerId, partitions2, version));
+    ASSERT_FALSE(partitions_path2.empty());
+
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(partitions_path1), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(
+                olp::http::HttpStatusCode::OK),
+            olp::serializer::serialize(partitions_response1)));
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(partitions_path2), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(
+                olp::http::HttpStatusCode::OK),
+            olp::serializer::serialize(partitions_response2)));
+
+    for (const auto& partition : partitions_response1.GetPartitions()) {
+      auto partition_path = mock::GeneratePath(
+          api_response, "blob",
+          mock::GenerateGetDataPath(kLayerId, partition.GetDataHandle()));
+      ASSERT_FALSE(partition_path.empty());
+
+      EXPECT_CALL(*network_mock, Send(IsGetRequest(partition_path), _, _, _, _))
+          .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                           olp::http::HttpStatusCode::OK),
+                                       "data"));
+    }
+
+    for (const auto& partition : partitions_response2.GetPartitions()) {
+      auto partition_path = mock::GeneratePath(
+          api_response, "blob",
+          mock::GenerateGetDataPath(kLayerId, partition.GetDataHandle()));
+      ASSERT_FALSE(partition_path.empty());
+
+      EXPECT_CALL(*network_mock, Send(IsGetRequest(partition_path), _, _, _, _))
+          .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                           olp::http::HttpStatusCode::OK),
+                                       "data"));
+    }
+
+    const auto request =
+        olp::dataservice::read::PrefetchPartitionsRequest().WithPartitionIds(
+            partitions);
+
+    std::promise<olp::dataservice::read::PrefetchPartitionsResponse> promise;
+    auto future = promise.get_future();
+    auto token = client.PrefetchPartitions(
+        request,
+        [&promise](
+            olp::dataservice::read::PrefetchPartitionsResponse response) {
+          promise.set_value(std::move(response));
+        },
+        nullptr);
+    ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),
+              std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_TRUE(response.IsSuccessful());
+    const auto result = response.MoveResult();
+
+    ASSERT_EQ(result.GetPartitions().size(), partitions_count);
+
+    for (const auto& partition : result.GetPartitions()) {
+      ASSERT_TRUE(client.IsCached(partition));
+    }
+  }
+  {
+    SCOPED_TRACE("Prefetch cached partitions");
+    const auto request =
+        olp::dataservice::read::PrefetchPartitionsRequest().WithPartitionIds(
+            partitions);
+    auto future = client.PrefetchPartitions(request, nullptr).GetFuture();
+    ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),
+              std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_TRUE(response.IsSuccessful());
+    const auto result = response.MoveResult();
+
+    ASSERT_EQ(result.GetPartitions().size(), partitions_count);
+
+    for (const auto& partition : result.GetPartitions()) {
+      ASSERT_TRUE(client.IsCached(partition));
+    }
+  }
+  Mock::VerifyAndClearExpectations(network_mock.get());
+}
+
+TEST(VersionedLayerClientTest, PrefetchPartitionsSomeFail) {
+  std::shared_ptr<NetworkMock> network_mock = std::make_shared<NetworkMock>();
+  olp::client::OlpClientSettings settings;
+  settings.network_request_handler = network_mock;
+  auto version = 4u;
+
+  auto partitions_count = 5u;
+  std::vector<std::string> partitions;
+  partitions.reserve(partitions_count);
+  for (auto i = 0u; i < partitions_count; i++) {
+    partitions.emplace_back(std::to_string(i));
+  }
+  auto api_response =
+      mockserver::ApiDefaultResponses::GenerateResourceApisResponse(kCatalog);
+  auto partitions_response =
+      mockserver::ReadDefaultResponses::GeneratePartitionsResponse(
+          partitions_count);
+  const auto request =
+      olp::dataservice::read::PrefetchPartitionsRequest().WithPartitionIds(
+          partitions);
+  read::VersionedLayerClientImpl client(kHrn, kLayerId, boost::none, settings);
+  auto partitions_path = mock::GeneratePath(
+      api_response, "query",
+      mock::GenerateGetPartitionsPath(kLayerId, partitions, version));
+  ASSERT_FALSE(partitions_path.empty());
+  {
+    SCOPED_TRACE("Prefetch partitions, some fails");
+
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(kUrlLookup), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     serialize(api_response)));
+
+    auto version_path = mock::GeneratePath(
+        api_response, "metadata", mock::GenerateGetLatestVersionPath());
+    ASSERT_FALSE(version_path.empty());
+
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(version_path), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(
+                olp::http::HttpStatusCode::OK),
+            olp::serializer::serialize(
+                mockserver::ReadDefaultResponses::GenerateVersionResponse(
+                    version))));
+
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(partitions_path), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            olp::http::NetworkResponse()
+                .WithBytesDownloaded(10ull)
+                .WithBytesUploaded(5ull)
+                .WithStatus(olp::http::HttpStatusCode::OK),
+            olp::serializer::serialize(partitions_response)));
+    for (auto i = 0u; i < partitions_response.GetPartitions().size(); i++) {
+      const auto& partition = partitions_response.GetPartitions().at(i);
+      auto partition_path = mock::GeneratePath(
+          api_response, "blob",
+          mock::GenerateGetDataPath(kLayerId, partition.GetDataHandle()));
+      ASSERT_FALSE(partition_path.empty());
+
+      EXPECT_CALL(*network_mock, Send(IsGetRequest(partition_path), _, _, _, _))
+          .WillOnce(ReturnHttpResponse(
+              olp::http::NetworkResponse()
+                  .WithBytesDownloaded(2ull)
+                  .WithBytesUploaded(1ull)
+                  .WithStatus((i == 0 ? olp::http::HttpStatusCode::OK
+                                      : olp::http::HttpStatusCode::NOT_FOUND)),
+              "data"));
+    }
+
+    olp::dataservice::read::PrefetchPartitionsStatus statistic;
+    std::promise<olp::dataservice::read::PrefetchPartitionsResponse> promise;
+    auto future = promise.get_future();
+    auto token = client.PrefetchPartitions(
+        request,
+        [&promise](
+            olp::dataservice::read::PrefetchPartitionsResponse response) {
+          promise.set_value(std::move(response));
+        },
+        [&](olp::dataservice::read::PrefetchPartitionsStatus status) {
+          statistic = std::move(status);
+        });
+    ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),
+              std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_TRUE(response.IsSuccessful());
+    ASSERT_EQ(statistic.bytes_transferred, 15 + 5 * 3);
+    ASSERT_EQ(statistic.total_partitions_to_prefetch, partitions_count);
+    ASSERT_EQ(statistic.prefetched_partitions, partitions_count);
+    const auto result = response.MoveResult();
+    // only 1 partition downloaded
+    ASSERT_EQ(result.GetPartitions().size(), 1u);
+    for (const auto& partition : result.GetPartitions()) {
+      ASSERT_TRUE(client.IsCached(partition));
+      ASSERT_TRUE(client.RemoveFromCache(partition));
+    }
+  }
+  {
+    SCOPED_TRACE("Prefetch partitions, all fails");
+
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(partitions_path), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(
+                olp::http::HttpStatusCode::OK),
+            olp::serializer::serialize(partitions_response)));
+
+    for (auto i = 0u; i < partitions_response.GetPartitions().size(); i++) {
+      const auto& partition = partitions_response.GetPartitions().at(i);
+      auto partition_path = mock::GeneratePath(
+          api_response, "blob",
+          mock::GenerateGetDataPath(kLayerId, partition.GetDataHandle()));
+      ASSERT_FALSE(partition_path.empty());
+
+      EXPECT_CALL(*network_mock, Send(IsGetRequest(partition_path), _, _, _, _))
+          .WillOnce(
+              ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                     olp::http::HttpStatusCode::NOT_FOUND),
+                                 "data"));
+    }
+
+    std::promise<olp::dataservice::read::PrefetchPartitionsResponse> promise;
+    auto future = promise.get_future();
+    auto token = client.PrefetchPartitions(
+        request,
+        [&promise](
+            olp::dataservice::read::PrefetchPartitionsResponse response) {
+          promise.set_value(std::move(response));
+        },
+        nullptr);
+    ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),
+              std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(),
+              olp::client::ErrorCode::Unknown);
+    ASSERT_EQ("No partitions were prefetched.",
+              response.GetError().GetMessage());
+  }
+  Mock::VerifyAndClearExpectations(network_mock.get());
+}
+
+TEST(VersionedLayerClientTest, PrefetchPartitionsFail) {
+  std::shared_ptr<NetworkMock> network_mock = std::make_shared<NetworkMock>();
+  olp::client::OlpClientSettings settings;
+  settings.network_request_handler = network_mock;
+  auto version = 4u;
+
+  auto partitions_count = 2u;
+  std::vector<std::string> partitions;
+  partitions.reserve(partitions_count);
+  for (auto i = 0u; i < partitions_count; i++) {
+    partitions.emplace_back(std::to_string(i));
+  }
+  auto api_response =
+      mockserver::ApiDefaultResponses::GenerateResourceApisResponse(kCatalog);
+  const auto request =
+      olp::dataservice::read::PrefetchPartitionsRequest().WithPartitionIds(
+          partitions);
+  read::VersionedLayerClientImpl client(kHrn, kLayerId, boost::none, settings);
+  auto partitions_path = mock::GeneratePath(
+      api_response, "query",
+      mock::GenerateGetPartitionsPath(kLayerId, partitions, version));
+  ASSERT_FALSE(partitions_path.empty());
+  {
+    SCOPED_TRACE("Prefetch partitions, empty request");
+
+    std::promise<olp::dataservice::read::PrefetchPartitionsResponse> promise;
+    auto future = promise.get_future();
+    auto token = client.PrefetchPartitions(
+        olp::dataservice::read::PrefetchPartitionsRequest(),
+        [&promise](
+            olp::dataservice::read::PrefetchPartitionsResponse response) {
+          promise.set_value(std::move(response));
+        },
+        nullptr);
+    ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),
+              std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(),
+              olp::client::ErrorCode::InvalidArgument);
+  }
+  {
+    SCOPED_TRACE("Get version fails");
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(kUrlLookup), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     serialize(api_response)));
+
+    auto version_path = mock::GeneratePath(
+        api_response, "metadata", mock::GenerateGetLatestVersionPath());
+    ASSERT_FALSE(version_path.empty());
+
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(version_path), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(
+                olp::http::HttpStatusCode::BAD_REQUEST),
+            olp::serializer::serialize(
+                mockserver::ReadDefaultResponses::GenerateVersionResponse(
+                    version))));
+
+    std::promise<olp::dataservice::read::PrefetchPartitionsResponse> promise;
+    auto future = promise.get_future();
+    auto token = client.PrefetchPartitions(
+        request,
+        [&promise](
+            olp::dataservice::read::PrefetchPartitionsResponse response) {
+          promise.set_value(std::move(response));
+        },
+        nullptr);
+    ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),
+              std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(),
+              olp::client::ErrorCode::BadRequest);
+  }
+  {
+    SCOPED_TRACE("Get data handles fails");
+
+    auto version_path = mock::GeneratePath(
+        api_response, "metadata", mock::GenerateGetLatestVersionPath());
+    ASSERT_FALSE(version_path.empty());
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(version_path), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(
+                olp::http::HttpStatusCode::OK),
+            olp::serializer::serialize(
+                mockserver::ReadDefaultResponses::GenerateVersionResponse(
+                    version))));
+
+    auto partitions_response =
+        mockserver::ReadDefaultResponses::GeneratePartitionsResponse(
+            partitions_count);
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(partitions_path), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(
+                olp::http::HttpStatusCode::BAD_REQUEST),
+            olp::serializer::serialize(partitions_response)));
+
+    std::promise<olp::dataservice::read::PrefetchPartitionsResponse> promise;
+    auto future = promise.get_future();
+    auto token = client.PrefetchPartitions(
+        request,
+        [&promise](
+            olp::dataservice::read::PrefetchPartitionsResponse response) {
+          promise.set_value(std::move(response));
+        },
+        nullptr);
+    ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),
+              std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_FALSE(response.IsSuccessful())
+        << response.GetError().GetMessage().c_str();
+    EXPECT_EQ(response.GetError().GetErrorCode(),
+              olp::client::ErrorCode::BadRequest);
+  }
+  {
+    SCOPED_TRACE("Invalid json");
+
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(partitions_path), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     "invalid json"));
+
+    std::promise<olp::dataservice::read::PrefetchPartitionsResponse> promise;
+    auto future = promise.get_future();
+    auto token = client.PrefetchPartitions(
+        request,
+        [&promise](
+            olp::dataservice::read::PrefetchPartitionsResponse response) {
+          promise.set_value(std::move(response));
+        },
+        nullptr);
+    ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),
+              std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(),
+              olp::client::ErrorCode::Unknown);
+    ASSERT_EQ("Fail parsing response.", response.GetError().GetMessage());
+  }
+  {
+    SCOPED_TRACE("Empty data handles");
+
+    auto partitions_response =
+        mockserver::ReadDefaultResponses::GeneratePartitionsResponse(
+            partitions_count);
+    auto& mutable_partitions = partitions_response.GetMutablePartitions();
+    // force empty data handles
+    for (auto& partition : mutable_partitions) {
+      partition.SetDataHandle("");
+    }
+
+    EXPECT_CALL(*network_mock, Send(IsGetRequest(partitions_path), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(
+            olp::http::NetworkResponse().WithStatus(
+                olp::http::HttpStatusCode::OK),
+            olp::serializer::serialize(partitions_response)));
+
+    std::promise<olp::dataservice::read::PrefetchPartitionsResponse> promise;
+    auto future = promise.get_future();
+    auto token = client.PrefetchPartitions(
+        request,
+        [&promise](
+            olp::dataservice::read::PrefetchPartitionsResponse response) {
+          promise.set_value(std::move(response));
+        },
+        nullptr);
+    ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),
+              std::future_status::timeout);
+
+    auto response = future.get();
+    ASSERT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(response.GetError().GetErrorCode(),
+              olp::client::ErrorCode::Unknown);
+    ASSERT_EQ("No partitions were prefetched.",
+              response.GetError().GetMessage());
+  }
+  Mock::VerifyAndClearExpectations(network_mock.get());
+}
+
+TEST(VersionedLayerClientTest, PrefetchPartitionsCancel) {
+  std::shared_ptr<NetworkMock> network_mock = std::make_shared<NetworkMock>();
+  olp::client::OlpClientSettings settings;
+  settings.network_request_handler = network_mock;
+  settings.task_scheduler =
+      olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1);
+  auto partitions_count = 2u;
+  std::vector<std::string> partitions;
+  partitions.reserve(partitions_count);
+  for (auto i = 0u; i < partitions_count; i++) {
+    partitions.emplace_back(std::to_string(i));
+  }
+  const auto request =
+      olp::dataservice::read::PrefetchPartitionsRequest().WithPartitionIds(
+          partitions);
+  read::VersionedLayerClientImpl client(kHrn, kLayerId, boost::none, settings);
+  {
+    SCOPED_TRACE("Cancel request");
+    std::promise<void> block_promise;
+    auto block_future = block_promise.get_future();
+    settings.task_scheduler->ScheduleTask(
+        [&block_future]() { block_future.get(); });
+    auto cancellable = client.PrefetchPartitions(request, nullptr);
+
+    // cancel the request and unblock queue
+    cancellable.GetCancellationToken().Cancel();
+    block_promise.set_value();
+    auto future = cancellable.GetFuture();
+
+    ASSERT_EQ(future.wait_for(kTimeout), std::future_status::ready);
+
+    auto data_response = future.get();
+
+    EXPECT_FALSE(data_response.IsSuccessful());
+    EXPECT_EQ(data_response.GetError().GetErrorCode(),
+              olp::client::ErrorCode::Cancelled);
+  }
+  Mock::VerifyAndClearExpectations(network_mock.get());
 }
 
 }  // namespace

--- a/tests/common/ReadDefaultResponses.h
+++ b/tests/common/ReadDefaultResponses.h
@@ -59,12 +59,12 @@ class ReadDefaultResponses {
   }
 
   static olp::dataservice::read::model::Partitions GeneratePartitionsResponse(
-      size_t size = 10) {
+      size_t size = 10, uint32_t start_index = 0) {
     std::vector<olp::dataservice::read::model::Partition> partitions_vect;
     partitions_vect.reserve(size);
     for (size_t i = 0; i < size; i++) {
       partitions_vect.emplace_back(
-          GeneratePartitionResponse(std::to_string(i)));
+          GeneratePartitionResponse(std::to_string(start_index + i)));
     }
 
     olp::dataservice::read::model::Partitions partitions;

--- a/tests/common/UrlGenerators.h
+++ b/tests/common/UrlGenerators.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "generated/model/Api.h"
+#include "olp/dataservice/read/model/Partitions.h"
+#include "olp/dataservice/read/model/VersionResponse.h"
+
+namespace mock {
+std::string GenerateGetPartitionsPath(
+    const std::string& layer,
+    const olp::dataservice::read::PartitionsRequest::PartitionIds& partitions,
+    uint64_t version) {
+  std::string path = "/layers/" + layer + "/partitions?";
+  for (const auto& partition : partitions) {
+    path.append("partition=" + partition + "&");
+  }
+  path.append("version=" + std::to_string(version));
+  return path;
+}
+
+std::string GenerateGetDataPath(const std::string& layer,
+                                const std::string& data_handle) {
+  return "/layers/" + layer + "/data/" + data_handle;
+}
+
+std::string GenerateGetLatestVersionPath() {
+  return "/versions/latest?startVersion=-1";
+}
+
+std::string GenerateGetQuadKeyPath(const std::string& quadkey,
+                                   const std::string& layer, uint64_t version,
+                                   uint64_t depth) {
+  return "/layers/" + layer + "/versions/" + std::to_string(version) +
+         "/quadkeys/" + quadkey + "/depths/" + std::to_string(depth);
+}
+
+std::string GeneratePath(const olp::dataservice::read::model::Apis& apis,
+                         const std::string& api_type, const std::string& path) {
+  auto it = find_if(apis.begin(), apis.end(),
+                    [&](olp::dataservice::read::model::Api api) {
+                      return api.GetApi() == api_type;
+                    });
+  if (it == apis.end()) {
+    return {};
+  }
+  auto url = it->GetBaseUrl();
+  return url.append(path);
+}
+
+}  // namespace mock


### PR DESCRIPTION
Add implementation to prefetch partitions.
Split partitions requests for blocks by 100.
Query data handles for partitions and
download data. Add unit test
to check if after prefetched data is available
in cache.

Relates-To: OLPEDGE-1902

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>