### PR TITLE
Inverse the GetLatestVersion logic.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -48,14 +48,19 @@ class VersionedLayerClientImpl;
  *
  * The versioned layer stores slowly-changing data that must remain logically
  * consistent with other layers in a catalog. You can request any data version
- * from the versioned
- * layer.
+ * from the versioned layer.
  * When you request a particular version of data from the versioned layer,
  * the partition you receive in the response may have a lower version number
  * than you requested. The version of a layer or partition represents the
  * catalog version in which the layer or partition was last updated.
  *
- * @note If the catalog version is not specified, the latest version is used.
+ * @note If the catalog version is not specified, the version is set upon the
+ * first request made, based on this rules which apply for each specific FetchOptions:
+ * - OnlineOnly - version is resolved from online.
+ * - CacheOnly - version is resolved from cache.
+ * - OnlineIfNotFound - retrieve from online first, then checks the cache in 
+ * case of error. Update cache version if online version is higher then the 
+ * cache version.
  *
  * An example with the catalog version provided that saves one network request:
  * @code{.cpp}

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogCacheRepository.cpp
@@ -38,7 +38,6 @@ constexpr auto kLogTag = "CatalogCacheRepository";
 
 // Currently, we expire the catalog version after 5 minutes. Later we plan to
 // give the user the control when to expire it.
-constexpr auto kCatalogVersionExpiryTime = 5 * 60;
 constexpr auto kChronoSecondsMax = std::chrono::seconds::max();
 constexpr auto kTimetMax = std::numeric_limits<time_t>::max();
 
@@ -93,7 +92,7 @@ void CatalogCacheRepository::PutVersion(const model::VersionResponse& version) {
 
   cache_->Put(VersionKey(hrn), version,
               [&]() { return olp::serializer::serialize(version); },
-              kCatalogVersionExpiryTime);
+              default_expiry_);
 }
 
 boost::optional<model::VersionResponse> CatalogCacheRepository::GetVersion() {

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.h
@@ -52,6 +52,10 @@ class CatalogRepository final {
                                    client::CancellationContext context);
 
  private:
+  CatalogVersionResponse GetLatestVersionOnline(
+      const boost::optional<std::string>& billing_tag,
+      client::CancellationContext context);
+
   client::HRN catalog_;
   client::OlpClientSettings settings_;
   client::ApiLookupClient lookup_client_;


### PR DESCRIPTION
Change the logic of GetLatestVersion, so in the case of fetch option is
OnlineIfNotFound, we check the online first, then in case of an error,
the cache is checked. It is needed in the use case when you need to get
the latest data from online, and be able to use the data from cache.

Remove the five minutes expiration of the latest version, this enables
the users to work with data offline with ease.

Relates-To: OLPEDGE-2325, OLPEDGE-2326

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>