### PR TITLE
Init get version response.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
@@ -110,8 +110,10 @@ CatalogVersionResponse CatalogRepository::GetLatestVersion(
   repository::CatalogCacheRepository repository(catalog_, settings_.cache);
 
   const auto fetch_option = request.GetFetchOption();
-
-  CatalogVersionResponse version_response;
+  // in case if get version online was never called and version was not found in
+  // cache
+  CatalogVersionResponse version_response = {
+      {client::ErrorCode::NotFound, "Failed to find version."}};
 
   if (fetch_option != CacheOnly) {
     version_response = GetLatestVersionOnline(request.GetBillingTag(), context);

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
@@ -156,6 +156,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionCacheOnlyNotFound) {
   auto response = repository.GetLatestVersion(request, context);
 
   EXPECT_FALSE(response.IsSuccessful());
+  EXPECT_EQ(response.GetError().GetErrorCode(),
+            olp::client::ErrorCode::NotFound);
 }
 
 TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyNotFound) {


### PR DESCRIPTION
In case if we do not request version
online CatalogVersionResponse variable
stays initialized bu default with
error code unknown. If getting from cache
also fails we do not exchange result,
so it should be NotFound.

Relates-To: OLPEDGE-2339

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>