### PR TITLE
Add responses generator to test-common lib.

### DIFF
--- a/tests/common/ApiDefaultResponses.h
+++ b/tests/common/ApiDefaultResponses.h
@@ -23,11 +23,6 @@
 #include <utility>
 #include <vector>
 
-#include <olp/core/generated/serializer/SerializerWrapper.h>
-#include <rapidjson/document.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
-
 #include "generated/model/Api.h"
 
 namespace mockserver {

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -22,7 +22,7 @@ set(OLP_SDK_TESTS_COMMON_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/ApiDefaultResponses.h
     ${CMAKE_CURRENT_SOURCE_DIR}/ReadDefaultResponses.h
     ${CMAKE_CURRENT_SOURCE_DIR}/WriteDefaultResponses.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/PathGenerator.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/PlatformUrlsGenerator.h
     ${CMAKE_CURRENT_SOURCE_DIR}/ResponseGenerator.h
 )
 
@@ -30,7 +30,7 @@ set(OLP_SDK_TESTS_COMMON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/mocks/CacheMock.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mocks/NetworkMock.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ReadDefaultResponses.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/PathGenerator.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/PlatformUrlsGenerator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ResponseGenerator.cpp
 )
 

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -22,12 +22,16 @@ set(OLP_SDK_TESTS_COMMON_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/ApiDefaultResponses.h
     ${CMAKE_CURRENT_SOURCE_DIR}/ReadDefaultResponses.h
     ${CMAKE_CURRENT_SOURCE_DIR}/WriteDefaultResponses.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/PathGenerator.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/ResponseGenerator.h
 )
 
 set(OLP_SDK_TESTS_COMMON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/mocks/CacheMock.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mocks/NetworkMock.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ReadDefaultResponses.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/PathGenerator.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ResponseGenerator.cpp
 )
 
 add_library(olp-cpp-sdk-tests-common
@@ -36,6 +40,11 @@ add_library(olp-cpp-sdk-tests-common
 
 target_include_directories(olp-cpp-sdk-tests-common PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+)
+
+target_include_directories(olp-cpp-sdk-tests-common 
+    PRIVATE 
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../olp-cpp-sdk-dataservice-read/src/
 )
 
 target_link_libraries(olp-cpp-sdk-tests-common

--- a/tests/common/PathGenerator.cpp
+++ b/tests/common/PathGenerator.cpp
@@ -17,17 +17,20 @@
  * License-Filename: LICENSE
  */
 
-#pragma once
+#include "PathGenerator.h"
 
 #include <string>
 #include <vector>
 
+// clang-format off
+#include "generated/parser/ApiParser.h"
+// clang-format on
+#include <olp/core/generated/parser/JsonParser.h>
+#include <olp/dataservice/read/model/Partitions.h>
+#include <olp/dataservice/read/model/VersionResponse.h>
 #include "generated/model/Api.h"
-#include "olp/dataservice/read/model/Partitions.h"
-#include "olp/dataservice/read/model/VersionResponse.h"
 
-namespace mock {
-std::string GenerateGetPartitionsPath(
+std::string PathGenerator::GetPartitions(
     const std::string& layer,
     const olp::dataservice::read::PartitionsRequest::PartitionIds& partitions,
     uint64_t version) {
@@ -39,24 +42,27 @@ std::string GenerateGetPartitionsPath(
   return path;
 }
 
-std::string GenerateGetDataPath(const std::string& layer,
-                                const std::string& data_handle) {
+std::string PathGenerator::GetData(const std::string& layer,
+                                   const std::string& data_handle) {
   return "/layers/" + layer + "/data/" + data_handle;
 }
 
-std::string GenerateGetLatestVersionPath() {
+std::string PathGenerator::GetLatestVersion() {
   return "/versions/latest?startVersion=-1";
 }
 
-std::string GenerateGetQuadKeyPath(const std::string& quadkey,
-                                   const std::string& layer, uint64_t version,
-                                   uint64_t depth) {
+std::string PathGenerator::GetQuadKey(const std::string& quadkey,
+                                      const std::string& layer,
+                                      uint64_t version, uint64_t depth) {
   return "/layers/" + layer + "/versions/" + std::to_string(version) +
          "/quadkeys/" + quadkey + "/depths/" + std::to_string(depth);
 }
 
-std::string GeneratePath(const olp::dataservice::read::model::Apis& apis,
-                         const std::string& api_type, const std::string& path) {
+std::string PathGenerator::FullPath(const std::string& apis_response,
+                                    const std::string& api_type,
+                                    const std::string& path) {
+  auto apis =
+      olp::parser::parse<olp::dataservice::read::model::Apis>(apis_response);
   auto it = find_if(apis.begin(), apis.end(),
                     [&](olp::dataservice::read::model::Api api) {
                       return api.GetApi() == api_type;
@@ -67,5 +73,3 @@ std::string GeneratePath(const olp::dataservice::read::model::Apis& apis,
   auto url = it->GetBaseUrl();
   return url.append(path);
 }
-
-}  // namespace mock

--- a/tests/common/PathGenerator.h
+++ b/tests/common/PathGenerator.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <olp/dataservice/read/PartitionsRequest.h>
+#include <olp/dataservice/read/model/VersionResponse.h>
+
+class PathGenerator {
+ public:
+  static std::string GetPartitions(
+      const std::string& layer,
+      const olp::dataservice::read::PartitionsRequest::PartitionIds& partitions,
+      uint64_t version);
+
+  static std::string GetData(const std::string& layer,
+                             const std::string& data_handle);
+
+  static std::string GetLatestVersion();
+
+  static std::string GetQuadKey(const std::string& quadkey,
+                                const std::string& layer, uint64_t version,
+                                uint64_t depth);
+
+  static std::string FullPath(const std::string& apis,
+                              const std::string& api_type,
+                              const std::string& path);
+};

--- a/tests/common/PlatformUrlsGenerator.h
+++ b/tests/common/PlatformUrlsGenerator.h
@@ -19,29 +19,43 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 
 #include <olp/dataservice/read/PartitionsRequest.h>
 #include <olp/dataservice/read/model/VersionResponse.h>
 
-class PathGenerator {
+namespace olp {
+namespace dataservice {
+namespace read {
+namespace model {
+class Api;
+using Apis = std::vector<Api>;
+}  // namespace model
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp
+
+class PlatformUrlsGenerator {
  public:
-  static std::string GetPartitions(
-      const std::string& layer,
+  PlatformUrlsGenerator(const std::string& apis, const std::string& layer);
+
+  std::string PartitionsQuery(
       const olp::dataservice::read::PartitionsRequest::PartitionIds& partitions,
       uint64_t version);
 
-  static std::string GetData(const std::string& layer,
-                             const std::string& data_handle);
+  std::string DataBlob(const std::string& data_handle);
 
-  static std::string GetLatestVersion();
+  std::string LatestVersion();
 
-  static std::string GetQuadKey(const std::string& quadkey,
-                                const std::string& layer, uint64_t version,
+  std::string VersionedQuadTree(const std::string& quadkey, uint64_t version,
                                 uint64_t depth);
 
-  static std::string FullPath(const std::string& apis,
-                              const std::string& api_type,
-                              const std::string& path);
+ private:
+  std::string FullPath(const std::string& api_type, const std::string& path);
+
+ private:
+  std::shared_ptr<olp::dataservice::read::model::Apis> apis_;
+  std::string layer_;
 };

--- a/tests/common/ResponseGenerator.cpp
+++ b/tests/common/ResponseGenerator.cpp
@@ -25,31 +25,19 @@
 #include <olp/dataservice/read/model/Partitions.h>
 #include <olp/dataservice/read/model/VersionResponse.h>
 #include "ApiDefaultResponses.h"
-#include "PathGenerator.h"
+#include "PlatformUrlsGenerator.h"
 #include "ReadDefaultResponses.h"
 #include "generated/model/Api.h"
 // clang-format off
 #include "generated/serializer/ApiSerializer.h"
 #include "generated/serializer/VersionResponseSerializer.h"
 #include "generated/serializer/PartitionsSerializer.h"
+#include <olp/core/generated/serializer/SerializerWrapper.h>
 #include "generated/serializer/JsonSerializer.h"
 // clang-format on
 
-namespace {
-template <class T>
-std::string serialize(std::vector<T> data) {
-  std::string str = "[";
-  for (const auto& el : data) {
-    str.append(olp::serializer::serialize(el));
-    str.append(",");
-  }
-  str[str.length() - 1] = ']';
-  return str;
-}
-}  // namespace
-
 std::string ResponseGenerator::ResourceApis(const std::string& catalog) {
-  return serialize(
+  return olp::serializer::serialize(
       mockserver::ApiDefaultResponses::GenerateResourceApisResponse(catalog));
 }
 

--- a/tests/common/ResponseGenerator.cpp
+++ b/tests/common/ResponseGenerator.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "ResponseGenerator.h"
+
+#include <string>
+#include <vector>
+
+#include <olp/dataservice/read/model/Partitions.h>
+#include <olp/dataservice/read/model/VersionResponse.h>
+#include "ApiDefaultResponses.h"
+#include "PathGenerator.h"
+#include "ReadDefaultResponses.h"
+#include "generated/model/Api.h"
+// clang-format off
+#include "generated/serializer/ApiSerializer.h"
+#include "generated/serializer/VersionResponseSerializer.h"
+#include "generated/serializer/PartitionsSerializer.h"
+#include "generated/serializer/JsonSerializer.h"
+// clang-format on
+
+namespace {
+template <class T>
+std::string serialize(std::vector<T> data) {
+  std::string str = "[";
+  for (const auto& el : data) {
+    str.append(olp::serializer::serialize(el));
+    str.append(",");
+  }
+  str[str.length() - 1] = ']';
+  return str;
+}
+}  // namespace
+
+std::string ResponseGenerator::ResourceApis(const std::string& catalog) {
+  return serialize(
+      mockserver::ApiDefaultResponses::GenerateResourceApisResponse(catalog));
+}
+
+std::string ResponseGenerator::Version(uint32_t version) {
+  return olp::serializer::serialize(
+      mockserver::ReadDefaultResponses::GenerateVersionResponse(version));
+}
+
+std::string ResponseGenerator::Partitions(
+    const olp::dataservice::read::model::Partitions& partitions_response) {
+  return olp::serializer::serialize(partitions_response);
+}

--- a/tests/common/ResponseGenerator.h
+++ b/tests/common/ResponseGenerator.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <olp/dataservice/read/model/Partitions.h>
+
+class ResponseGenerator {
+ public:
+  static std::string ResourceApis(const std::string& catalog);
+  static std::string Version(uint32_t version);
+  static std::string Partitions(
+      const olp::dataservice::read::model::Partitions& partitions_response);
+};


### PR DESCRIPTION
Integration tests should have dependency only
from public dataservice api. Move generating
urls and responses to test-common lib.

Relates-To: OLPEDGE-1901

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>