### PR TITLE
Fix the prefetch for the aggregated tiles.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/ProtectDependencyResolver.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ProtectDependencyResolver.cpp
@@ -86,7 +86,7 @@ bool ProtectDependencyResolver::AddDataHandle(
 bool ProtectDependencyResolver::ProcessTileKeyInCache(
     const geo::TileKey& tile) {
   read::QuadTreeIndex cached_tree;
-  if (partitions_cache_repository_.FindQuadTree(version_, tile, cached_tree) &&
+  if (partitions_cache_repository_.FindQuadTree(tile, version_, cached_tree) &&
       AddDataHandle(tile, cached_tree)) {
     auto root_tile = cached_tree.GetRootTile();
     // add quad tree to list for protection

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -393,9 +393,12 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
         OLP_SDK_LOG_DEBUG_F(kLogTag, "PrefetchTiles, subquads=%zu, key=%s",
                             sliced_tiles.size(), key.c_str());
 
+        const bool aggregation_enabled = request.GetDataAggregationEnabled();
+
         auto query = [=](geo::TileKey root,
                          client::CancellationContext inner_context) mutable {
           return repository.GetVersionedSubQuads(root, kQuadTreeDepth, version,
+                                                 aggregation_enabled,
                                                  inner_context);
         };
 
@@ -607,7 +610,7 @@ bool VersionedLayerClientImpl::RemoveFromCache(const geo::TileKey& tile) {
     return false;
   }
 
-  if (partitions_cache_repository.FindQuadTree(version, tile, cached_tree)) {
+  if (partitions_cache_repository.FindQuadTree(tile, version, cached_tree)) {
     auto data = cached_tree.Find(tile, false);
     if (!data) {
       return true;
@@ -668,7 +671,7 @@ bool VersionedLayerClientImpl::IsCached(const geo::TileKey& tile,
   repository::PartitionsCacheRepository partitions_repo(catalog_, layer_id_,
                                                         cache);
 
-  if (partitions_repo.FindQuadTree(version, tile, cached_tree)) {
+  if (partitions_repo.FindQuadTree(tile, version, cached_tree)) {
     auto data = cached_tree.Find(tile, aggregated);
     if (data) {
       repository::DataCacheRepository data_repo(catalog_, cache);

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -19,6 +19,8 @@
 
 #include "VolatileLayerClientImpl.h"
 
+#include <iterator>
+
 #include <olp/core/cache/DefaultCache.h>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
@@ -83,12 +83,14 @@ class PartitionsCacheRepository final {
                           const boost::optional<int64_t>& catalog_version,
                           std::string& data_handle);
 
-  std::string CreateQuadKey(olp::geo::TileKey key, int32_t depth,
+  std::string CreateQuadKey(geo::TileKey key, int32_t depth,
                             const boost::optional<int64_t>& version) const;
 
-  bool FindQuadTree(boost::optional<int64_t> version,
-                    const olp::geo::TileKey& tile_key,
+  bool FindQuadTree(geo::TileKey key, boost::optional<int64_t> version,
                     read::QuadTreeIndex& tree);
+
+  bool ContainsTree(geo::TileKey key, int32_t depth,
+                    const boost::optional<int64_t>& version) const;
 
  private:
   const std::string catalog_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -333,7 +333,7 @@ QuadTreeIndexResponse PartitionsRepository::GetQuadTreeIndexForTile(
   // Look for QuadTree covering the tile in the cache
   if (fetch_option != OnlineOnly && fetch_option != CacheWithUpdate) {
     read::QuadTreeIndex cached_tree;
-    if (cache_.FindQuadTree(version, tile_key, cached_tree)) {
+    if (cache_.FindQuadTree(tile_key, version, cached_tree)) {
       OLP_SDK_LOG_DEBUG_F(kLogTag,
                           "GetQuadTreeIndexForTile found in cache, "
                           "tile='%s', depth='%" PRId32 "'",

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -100,6 +100,7 @@ class PrefetchTilesRepository {
 
   SubQuadsResponse GetVersionedSubQuads(geo::TileKey tile, int32_t depth,
                                         std::int64_t version,
+                                        bool aggregation_enabled,
                                         client::CancellationContext context);
 
   SubQuadsResponse GetVolatileSubQuads(geo::TileKey tile, int32_t depth,
@@ -109,6 +110,13 @@ class PrefetchTilesRepository {
   static void SplitSubtree(RootTilesForRequest& root_tiles_depth,
                            RootTilesForRequest::iterator subtree_to_split,
                            const geo::TileKey& tile_key, std::uint32_t min);
+
+  using QuadTreeResponse = ExtendedApiResponse<QuadTreeIndex, client::ApiError,
+                                               client::NetworkStatistics>;
+
+  QuadTreeResponse DownloadVersionedQuadTree(
+      geo::TileKey tile, int32_t depth, std::int64_t version,
+      client::CancellationContext context);
 
  private:
   client::HRN catalog_;

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -23,6 +23,8 @@ set(OLP_SDK_INTEGRATIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-dataservice-read/VolatileLayerClientCacheTest.cpp
     ./olp-cpp-sdk-dataservice-read/VersionedLayerClientCacheTest.cpp
     ./olp-cpp-sdk-dataservice-read/VersionedLayerGetAggregatedDataTest.cpp
+    ./olp-cpp-sdk-dataservice-read/VersionedLayerPrefetch.cpp
+    ./olp-cpp-sdk-dataservice-read/VersionedLayerTestBase.cpp
     ./olp-cpp-sdk-dataservice-read/CatalogClientTestBase.cpp
     ./olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
     ./olp-cpp-sdk-dataservice-read/HttpResponses.h

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerTestBase.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerTestBase.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "VersionedLayerTestBase.h"
+
+#include <olp/core/cache/CacheSettings.h>
+#include <olp/core/cache/KeyValueCache.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/utils/Dir.h>
+
+#include "matchers/NetworkUrlMatchers.h"
+
+namespace {
+const auto kCachePathMutable = "./tmp_cache";
+}
+
+using testing::_;
+
+void VersionedLayerTestBase::SetUp() {
+  olp::utils::Dir::remove(kCachePathMutable);
+
+  network_mock_ = std::make_shared<NetworkMock>();
+
+  settings_.api_lookup_settings.catalog_endpoint_provider =
+      [=](const olp::client::HRN&) { return kEndpoint; };
+
+  settings_.network_request_handler = network_mock_;
+  settings_.task_scheduler =
+      olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1);
+
+  olp::cache::CacheSettings settings;
+  settings.disk_path_mutable = kCachePathMutable;
+  settings_.cache =
+      olp::client::OlpClientSettingsFactory::CreateDefaultCache(settings);
+}
+
+void VersionedLayerTestBase::TearDown() {
+  testing::Mock::VerifyAndClearExpectations(network_mock_.get());
+  network_mock_.reset();
+  settings_.task_scheduler.reset();
+  olp::utils::Dir::remove(kCachePathMutable);
+}
+
+void VersionedLayerTestBase::ExpectQuadTreeRequest(
+    const std::string& layer, int64_t version,
+    mockserver::QuadTreeBuilder quad_tree) {
+  std::stringstream url;
+  url << kEndpoint << "/catalogs/" << kCatalog << "/layers/" << layer
+      << "/versions/" << version << "/quadkeys/"
+      << quad_tree.Root().ToHereTile() << "/depths/4";
+
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(url.str()), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   quad_tree.BuildJson()));
+}
+
+void VersionedLayerTestBase::ExpectBlobRequest(const std::string& layer,
+                                               const std::string& data_handle,
+                                               const std::string& data) {
+  std::stringstream url;
+  url << kEndpoint << "/catalogs/" << kCatalog << "/layers/" << layer
+      << "/data/" << data_handle;
+
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(url.str()), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   data));
+}

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerTestBase.h
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerTestBase.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <olp/dataservice/read/VersionedLayerClient.h>
+
+#include <mocks/NetworkMock.h>
+
+#include <olp/core/http/HttpStatusCode.h>
+
+#include "ReadDefaultResponses.h"
+
+class VersionedLayerTestBase : public ::testing::Test {
+ public:
+  void SetUp() override;
+
+  void TearDown() override;
+
+  void ExpectQuadTreeRequest(const std::string& layer, int64_t version,
+                             mockserver::QuadTreeBuilder quad_tree);
+
+  void ExpectBlobRequest(const std::string& layer,
+                         const std::string& data_handle,
+                         const std::string& data);
+
+ protected:
+  const std::string kCatalog = "hrn:here:data::olp-here-test:catalog";
+  const olp::client::HRN kCatalogHrn = olp::client::HRN::FromString(kCatalog);
+  const std::string kEndpoint = "https://localhost";
+
+  olp::client::OlpClientSettings settings_;
+  std::shared_ptr<NetworkMock> network_mock_;
+};


### PR DESCRIPTION
Fix the prefetch API behavior for the aggregated tiles when the
aggregated tile is too far away. A new approach is to download and
store quadtrees of lower levels until the needed aggregated tile is
placed in sub quads (which means that we can find it later).

Relates-To: OLPEDGE-2312

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>