### PR TITLE
Update compiler versions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The table below lists the platforms on which the HERE Data SDK for C++ has been 
 
 | Platform                   | Minimum requirement     |
 | :------------------------- | :---------------------- |
-| Ubuntu Linux               | GCC 7.4 and Clang 7.0   |
+| Ubuntu Linux               | GCC 7.5 and Clang 7.0   |
 | Embedded Linux (32 bit)    | GCC 7.4 armhf           |
 | Windows                    | MSVC++ 2017             |
 | macOS                      | Apple Clang 11.0.0      |


### PR DESCRIPTION
Travic CI and Gitlab images which we use for compile
verification alrady use GCC 7.5 for month or more after
Ubuntu bionic added it as supported version.
So we started compiling for it, but missed updating README.md.
It was detected that README.md need to be updated during
job logs checking.
See example of travis job:
https://travis-ci.com/github/heremaps/here-data-sdk-cpp
or any linux FV build job in Gitlab.
Armhf image will use 7.5 too after updates soon.

Relates-To: OAM-700

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>