### PR TITLE
Minor changes in VersionedLayerTestBase

### DIFF
--- a/tests/common/ApiDefaultResponses.h
+++ b/tests/common/ApiDefaultResponses.h
@@ -23,13 +23,13 @@
 #include <utility>
 #include <vector>
 
-#include "generated/model/Api.h"
+#include <olp/core/client/model/Api.h>
 
 namespace mockserver {
 
 class ApiDefaultResponses {
  public:
-  static olp::dataservice::read::model::Apis GenerateResourceApisResponse(
+  static olp::client::Apis GenerateResourceApisResponse(
       std::string catalog) {
     return GenerateApisResponse({{"blob", "v1"},
                                  {"index", "v1"},
@@ -44,7 +44,7 @@ class ApiDefaultResponses {
                                 catalog);
   }
 
-  static olp::dataservice::read::model::Apis GeneratePlatformApisResponse() {
+  static olp::client::Apis GeneratePlatformApisResponse() {
     return GenerateApisResponse({{"account", "v1"},
                                  {"artifact", "v1"},
                                  {"authentication", "v1"},
@@ -57,10 +57,10 @@ class ApiDefaultResponses {
                                  {"pipelines", "v2"}});
   }
 
-  static olp::dataservice::read::model::Apis GenerateApisResponse(
+  static olp::client::Apis GenerateApisResponse(
       std::vector<std::pair<std::string, std::string>> api_types,
       std::string catalog = "") {
-    olp::dataservice::read::model::Apis apis(api_types.size());
+    olp::client::Apis apis(api_types.size());
     std::string version = "v1";
     if (!catalog.empty()) {
       catalog.insert(0, "/catalogs/");

--- a/tests/common/PlatformUrlsGenerator.h
+++ b/tests/common/PlatformUrlsGenerator.h
@@ -23,23 +23,16 @@
 #include <string>
 #include <vector>
 
+#include <olp/core/client/model/Api.h>
 #include <olp/dataservice/read/PartitionsRequest.h>
 #include <olp/dataservice/read/model/VersionResponse.h>
 
-namespace olp {
-namespace dataservice {
-namespace read {
-namespace model {
-class Api;
-using Apis = std::vector<Api>;
-}  // namespace model
-}  // namespace read
-}  // namespace dataservice
-}  // namespace olp
-
 class PlatformUrlsGenerator {
  public:
-  PlatformUrlsGenerator(const std::string& apis, const std::string& layer);
+  PlatformUrlsGenerator(olp::client::Apis apis, const std::string& layer);
+
+  PlatformUrlsGenerator(const std::string& endpoint, const std::string& catalog,
+                        const std::string& layer);
 
   std::string PartitionsQuery(
       const olp::dataservice::read::PartitionsRequest::PartitionIds& partitions,
@@ -53,9 +46,10 @@ class PlatformUrlsGenerator {
                                 uint64_t depth);
 
  private:
-  std::string FullPath(const std::string& api_type, const std::string& path);
+  std::string FullPath(const std::string& service, const std::string& path);
 
- private:
-  std::shared_ptr<olp::dataservice::read::model::Apis> apis_;
-  std::string layer_;
+  std::shared_ptr<olp::client::Apis> apis_;
+  const std::string http_prefix_;
+  const std::string catalog_;
+  const std::string layer_;
 };

--- a/tests/common/ResponseGenerator.cpp
+++ b/tests/common/ResponseGenerator.cpp
@@ -37,8 +37,24 @@
 // clang-format on
 
 std::string ResponseGenerator::ResourceApis(const std::string& catalog) {
-  return olp::serializer::serialize(
+  return ResourceApis(
       mockserver::ApiDefaultResponses::GenerateResourceApisResponse(catalog));
+}
+
+std::string ResponseGenerator::ResourceApis(const olp::client::Apis& apis) {
+  // Temporary convert to another model that can be serialized
+  olp::dataservice::read::model::Apis converted_apis;
+  std::transform(std::begin(apis), std::end(apis),
+                 std::back_inserter(converted_apis),
+                 [](const olp::client::Api& api) {
+                   olp::dataservice::read::model::Api new_api;
+                   new_api.SetApi(api.GetApi());
+                   new_api.SetBaseUrl(api.GetBaseUrl());
+                   new_api.SetParameters(api.GetParameters());
+                   new_api.SetVersion(api.GetVersion());
+                   return new_api;
+                 });
+  return olp::serializer::serialize(converted_apis);
 }
 
 std::string ResponseGenerator::Version(uint32_t version) {

--- a/tests/common/ResponseGenerator.h
+++ b/tests/common/ResponseGenerator.h
@@ -22,11 +22,13 @@
 #include <string>
 #include <vector>
 
+#include <olp/core/client/model/Api.h>
 #include <olp/dataservice/read/model/Partitions.h>
 
 class ResponseGenerator {
  public:
   static std::string ResourceApis(const std::string& catalog);
+  static std::string ResourceApis(const olp::client::Apis& apis);
   static std::string Version(uint32_t version);
   static std::string Partitions(
       const olp::dataservice::read::model::Partitions& partitions_response);

--- a/tests/functional/utils/MockServerHelper.cpp
+++ b/tests/functional/utils/MockServerHelper.cpp
@@ -21,6 +21,8 @@
 #include <utility>
 #include <vector>
 
+#include "ResponseGenerator.h"
+
 namespace mockserver {
 
 void MockServerHelper::MockGetError(olp::client::ApiError error,
@@ -54,16 +56,15 @@ void MockServerHelper::MockGetVersionResponse(
                   "/metadata/v1/catalogs/" + catalog_ + "/versions/latest");
 }
 
-void MockServerHelper::MockLookupResourceApiResponse(
-    olp::dataservice::read::model::Apis data) {
-  MockGetResponse(std::move(data),
-                  "/lookup/v1/resources/" + catalog_ + "/apis");
+void MockServerHelper::MockLookupResourceApiResponse(olp::client::Apis data) {
+  mock_server_client_.MockResponse("GET",
+                                   "/lookup/v1/resources/" + catalog_ + "/apis",
+                                   ResponseGenerator::ResourceApis(data));
 }
 
-void MockServerHelper::MockLookupPlatformApiResponse(
-    olp::dataservice::read::model::Apis data) {
-  MockGetResponse<olp::dataservice::read::model::Api>(
-      std::move(data), "/lookup/v1/platform/apis");
+void MockServerHelper::MockLookupPlatformApiResponse(olp::client::Apis data) {
+  mock_server_client_.MockResponse("GET", "/lookup/v1/platform/apis",
+                                   ResponseGenerator::ResourceApis(data));
 }
 
 void MockServerHelper::MockGetResponse(const std::string& layer,

--- a/tests/functional/utils/MockServerHelper.h
+++ b/tests/functional/utils/MockServerHelper.h
@@ -23,10 +23,10 @@
 #include <string>
 #include <vector>
 
-#include "generated/model/Api.h"
+#include <olp/core/client/model/Api.h>
+
 #include "olp/dataservice/read/Types.h"
 // clang-format off
-#include "generated/serializer/ApiSerializer.h"
 #include "generated/serializer/VersionResponseSerializer.h"
 #include "generated/serializer/JsonSerializer.h"
 // clang-format on
@@ -79,7 +79,7 @@ class MockServerHelper {
    *
    * @param Apis to be returned by server.
    */
-  void MockLookupResourceApiResponse(olp::dataservice::read::model::Apis data);
+  void MockLookupResourceApiResponse(olp::client::Apis data);
 
   /**
    * @brief Mock get platform apis request.
@@ -88,7 +88,7 @@ class MockServerHelper {
    *
    * @param Apis to be returned by server.
    */
-  void MockLookupPlatformApiResponse(olp::dataservice::read::model::Apis data);
+  void MockLookupPlatformApiResponse(olp::client::Apis data);
 
   /**
    * @brief Mock get blob data request.
@@ -129,7 +129,7 @@ class MockServerHelper {
    * @param path request path for type T.
    */
   template <class T>
-  void MockGetResponse(T data, const std::string &path) {
+  void MockGetResponse(T data, const std::string& path) {
     auto str = olp::serializer::serialize(data);
     paths_.push_back(path);
     mock_server_client_.MockResponse("GET", path, str);
@@ -144,9 +144,9 @@ class MockServerHelper {
    * @param path request path for type T.
    */
   template <class T>
-  void MockGetResponse(std::vector<T> data, const std::string &path) {
+  void MockGetResponse(std::vector<T> data, const std::string& path) {
     std::string str = "[";
-    for (const auto &el : data) {
+    for (const auto& el : data) {
       str.append(olp::serializer::serialize(el));
       str.append(",");
     }
@@ -163,7 +163,7 @@ class MockServerHelper {
    * @param error to be returned by server.
    * @param path request path.
    */
-  void MockGetError(olp::client::ApiError error, const std::string &path);
+  void MockGetError(olp::client::ApiError error, const std::string& path);
 
  private:
   std::string catalog_;

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerGetAggregatedDataTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerGetAggregatedDataTest.cpp
@@ -28,7 +28,6 @@ constexpr auto kWaitTimeout = std::chrono::seconds(3);
 class VersionedLayerGetAggregatedDataTest : public VersionedLayerTestBase {};
 
 TEST_F(VersionedLayerGetAggregatedDataTest, ParentTileFarAway) {
-  const auto layer_name = "testlayer";
   const auto layer_version = 7;
 
   const auto target_tile =
@@ -55,15 +54,15 @@ TEST_F(VersionedLayerGetAggregatedDataTest, ParentTileFarAway) {
     tree_0.WithSubQuad(tree_root, "handle-0")
         .WithSubQuad(aggregated_parent, "handle-1");
 
-    ExpectQuadTreeRequest(layer_name, layer_version, tree_10);
-    ExpectQuadTreeRequest(layer_name, layer_version, tree_5);
-    ExpectQuadTreeRequest(layer_name, layer_version, tree_0);
+    ExpectQuadTreeRequest(layer_version, tree_10);
+    ExpectQuadTreeRequest(layer_version, tree_5);
+    ExpectQuadTreeRequest(layer_version, tree_0);
 
     // Expect to download handle-1
-    ExpectBlobRequest(layer_name, "handle-1", "A");
+    ExpectBlobRequest("handle-1", "A");
   }
 
-  read::VersionedLayerClient client(kCatalogHrn, layer_name, layer_version,
+  read::VersionedLayerClient client(kCatalogHrn, kLayerName, layer_version,
                                     settings_);
 
   auto api_call_outcome =

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerPrefetch.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerPrefetch.cpp
@@ -31,7 +31,6 @@ constexpr auto kWaitTimeout = std::chrono::seconds(3);
 class VersionedLayerPrefetch : public VersionedLayerTestBase {};
 
 TEST_F(VersionedLayerPrefetch, AggregatedPrefetch) {
-  const auto layer_name = "testlayer";
   const auto layer_version = 7;
 
   const auto target_tile =
@@ -58,15 +57,15 @@ TEST_F(VersionedLayerPrefetch, AggregatedPrefetch) {
     tree_0.WithSubQuad(tree_root, "handle-0")
         .WithSubQuad(aggregated_parent, "handle-1");
 
-    ExpectQuadTreeRequest(layer_name, layer_version, tree_10);
-    ExpectQuadTreeRequest(layer_name, layer_version, tree_5);
-    ExpectQuadTreeRequest(layer_name, layer_version, tree_0);
+    ExpectQuadTreeRequest(layer_version, tree_10);
+    ExpectQuadTreeRequest(layer_version, tree_5);
+    ExpectQuadTreeRequest(layer_version, tree_0);
 
     // Expect to download handle-1
-    ExpectBlobRequest(layer_name, "handle-1", "A");
+    ExpectBlobRequest("handle-1", "A");
   }
 
-  read::VersionedLayerClient client(kCatalogHrn, layer_name, layer_version,
+  read::VersionedLayerClient client(kCatalogHrn, kLayerName, layer_version,
                                     settings_);
 
   auto api_call_outcome =

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerTestBase.h
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerTestBase.h
@@ -20,33 +20,34 @@
 #pragma once
 
 #include <gmock/gmock.h>
-
+#include <mocks/NetworkMock.h>
+#include <olp/core/http/HttpStatusCode.h>
 #include <olp/dataservice/read/VersionedLayerClient.h>
 
-#include <mocks/NetworkMock.h>
-
-#include <olp/core/http/HttpStatusCode.h>
-
+#include "PlatformUrlsGenerator.h"
 #include "ReadDefaultResponses.h"
 
 class VersionedLayerTestBase : public ::testing::Test {
  public:
+  VersionedLayerTestBase();
+
   void SetUp() override;
 
   void TearDown() override;
 
-  void ExpectQuadTreeRequest(const std::string& layer, int64_t version,
+  void ExpectQuadTreeRequest(int64_t version,
                              mockserver::QuadTreeBuilder quad_tree);
 
-  void ExpectBlobRequest(const std::string& layer,
-                         const std::string& data_handle,
+  void ExpectBlobRequest(const std::string& data_handle,
                          const std::string& data);
 
  protected:
   const std::string kCatalog = "hrn:here:data::olp-here-test:catalog";
+  const std::string kLayerName = "testlayer";
   const olp::client::HRN kCatalogHrn = olp::client::HRN::FromString(kCatalog);
   const std::string kEndpoint = "https://localhost";
 
   olp::client::OlpClientSettings settings_;
   std::shared_ptr<NetworkMock> network_mock_;
+  PlatformUrlsGenerator url_generator_;
 };


### PR DESCRIPTION
Change VersionedLayerTestBase to use PlatformUrlsGenerator.
Change ApiDefaultResponses to use Apis from olp::client namespace.

Relates-To: OLPEDGE-2312

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>