### PR TITLE
Fix published partition Id for streamed partitions of size bigger than 20MB

### DIFF
--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
@@ -437,7 +437,8 @@ PublishDataResponse StreamLayerClientImpl::PublishDataGreaterThanTwentyMib(
   }
 
   // 3. Upload partition:
-  const auto partition_id = GenerateUuid();
+  const auto partition_id =
+      request.GetTraceId() ? request.GetTraceId().value() : GenerateUuid();
   model::PublishPartition publish_partition;
   publish_partition.SetPartition(partition_id);
   publish_partition.SetDataHandle(data_handle);


### PR DESCRIPTION
The published partiton Id must be equal to the trace Id of the respective request.

Resolves: OLPSUP-12034