### PR TITLE
Fix the expiration of the latest version.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogCacheRepository.cpp
@@ -36,8 +36,6 @@
 namespace {
 constexpr auto kLogTag = "CatalogCacheRepository";
 
-// Currently, we expire the catalog version after 5 minutes. Later we plan to
-// give the user the control when to expire it.
 constexpr auto kChronoSecondsMax = std::chrono::seconds::max();
 constexpr auto kTimetMax = std::numeric_limits<time_t>::max();
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
@@ -55,8 +55,8 @@ CatalogResponse CatalogRepository::GetCatalog(
   const auto fetch_options = request.GetFetchOption();
   const auto catalog_str = catalog_.ToCatalogHRNString();
 
-  repository::CatalogCacheRepository repository{
-      catalog_, settings_.cache, settings_.default_cache_expiration};
+  repository::CatalogCacheRepository repository(
+      catalog_, settings_.cache, settings_.default_cache_expiration);
 
   if (fetch_options != OnlineOnly && fetch_options != CacheWithUpdate) {
     auto cached = repository.Get();
@@ -106,7 +106,8 @@ CatalogResponse CatalogRepository::GetCatalog(
 
 CatalogVersionResponse CatalogRepository::GetLatestVersion(
     const CatalogVersionRequest& request, client::CancellationContext context) {
-  repository::CatalogCacheRepository repository(catalog_, settings_.cache);
+  repository::CatalogCacheRepository repository(
+      catalog_, settings_.cache, settings_.default_cache_expiration);
 
   const auto fetch_option = request.GetFetchOption();
   // in case if get version online was never called and version was not found in


### PR DESCRIPTION
The user provided default expiration is passed to the
CatalogCacheRepository.

Resolves: OLPEDGE-2360

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>