### PR TITLE
Fixed the unexpected warning on Android

### DIFF
--- a/olp-cpp-sdk-core/src/http/android/HttpClient.java
+++ b/olp-cpp-sdk-core/src/http/android/HttpClient.java
@@ -116,6 +116,9 @@ public class HttpClient {
       this.proxyPort = proxyPort;
 
       switch (proxyType) {
+        case 0:
+          this.proxyType = Proxy.Type.DIRECT;
+          break;
         case 1:
           this.proxyType = Proxy.Type.HTTP;
           break;
@@ -189,7 +192,7 @@ public class HttpClient {
     }
 
     public final boolean noProxy() {
-      return hasProxy() && this.proxyServer.equals("No");
+      return (hasProxy() && this.proxyServer.equals("No")) || this.proxyType == Proxy.Type.DIRECT;
     }
 
     public final int maxRetries() {


### PR DESCRIPTION
"Unsupported proxy version (0). Falling back to HTTP(0)."
This warning may occur when we selected to not use a proxy

Relates-To: OLPEDGE-2356
Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>