### PR TITLE
DefaultCache Open()/Close() individual caches.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
@@ -54,11 +54,20 @@ class DefaultCacheImpl;
 class CORE_API DefaultCache : public KeyValueCache {
  public:
   /**
-   * @brief The storage open result type
+   * @brief The storage open result type.
    */
   enum StorageOpenResult {
-    Success,            /*!< The operation succeeded. */
-    OpenDiskPathFailure /*!< The disk cache failure. */
+    Success,             /*!< The operation succeeded. */
+    OpenDiskPathFailure, /*!< The disk cache failure. */
+    NotReady             /*!< The DefaultCache is closed. */
+  };
+
+  /**
+   * @brief The cache type.
+   */
+  enum class CacheType {
+    kMutable,  /*!< The mutable cache type. */
+    kProtected /*!< The protected cache type. */
   };
 
   /**
@@ -78,9 +87,30 @@ class CORE_API DefaultCache : public KeyValueCache {
   StorageOpenResult Open();
 
   /**
+   * @brief Creates a new cache of the corresponding type.
+   *
+   * @param type The type of cache to open.
+   *
+   * @return `Success` if the cache is created or already open, `NotReady` if
+   * DefaultCache is closed and `OpenDiskPathFailure` if there are problems
+   * opening the provided path on the disk.
+   */
+  StorageOpenResult Open(CacheType type);
+
+  /**
    * @brief Closes the cache.
    */
   void Close();
+
+  /**
+   * @brief Closes the cache internally so that it is not keept open and thus
+   * blocking others from accessing it.
+   *
+   * @param type The type of cache to close.
+   *
+   * @return true if the cache was closed successfully; false otherwise.
+   */
+  bool Close(CacheType type);
 
   /**
    * @brief Clears the cache content.

--- a/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
@@ -31,7 +31,13 @@ DefaultCache::~DefaultCache() = default;
 
 DefaultCache::StorageOpenResult DefaultCache::Open() { return impl_->Open(); }
 
+DefaultCache::StorageOpenResult DefaultCache::Open(CacheType type) {
+  return impl_->Open(type);
+}
+
 void DefaultCache::Close() { impl_->Close(); }
+
+bool DefaultCache::Close(CacheType type) { return impl_->Close(type); }
 
 bool DefaultCache::Clear() { return impl_->Clear(); }
 

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
@@ -39,8 +39,10 @@ class DefaultCacheImpl {
   ~DefaultCacheImpl();
 
   DefaultCache::StorageOpenResult Open();
+  DefaultCache::StorageOpenResult Open(DefaultCache::CacheType type);
 
   void Close();
+  bool Close(DefaultCache::CacheType type);
 
   bool Clear();
 
@@ -81,9 +83,14 @@ class DefaultCacheImpl {
     return mutable_cache_lru_;
   }
 
-  /// Returns mutable cache, used for tests.
-  const std::unique_ptr<DiskCache>& GetMutableCache() const {
-    return mutable_cache_;
+  /// Returns mutable or protected cache, used for tests.
+  const std::unique_ptr<DiskCache>& GetCache(
+      DefaultCache::CacheType type) const {
+    if (type == DefaultCache::CacheType::kMutable) {
+      return mutable_cache_;
+    }
+
+    return protected_cache_;
   }
 
   /// Returns memory cache, used for tests.
@@ -124,6 +131,12 @@ class DefaultCacheImpl {
                        time_t expiry);
 
   DefaultCache::StorageOpenResult SetupStorage();
+
+  DefaultCache::StorageOpenResult SetupProtectedCache();
+
+  DefaultCache::StorageOpenResult SetupMutableCache();
+
+  void DestroyCache(DefaultCache::CacheType type);
 
   bool GetFromDiskCache(const std::string& key,
                         KeyValueCache::ValueTypePtr& value, time_t& expiry);

--- a/olp-cpp-sdk-core/src/cache/DiskCache.h
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.h
@@ -145,6 +145,14 @@ class DiskCache {
   bool Contains(const std::string& key);
 
  private:
+  /// Initialize empty db, so it can be used as protected cache.
+  leveldb::Status InitializeDB(const StorageSettings& settings,
+                               const std::string& path) const;
+
+  /// Create options for DB basing on settings and cache type.
+  leveldb::Options CreateOpenOptions(const StorageSettings& settings,
+                                     bool is_read_only) const;
+
   std::string disk_cache_path_;
   std::unique_ptr<leveldb::DB> database_;
   std::unique_ptr<const leveldb::FilterPolicy> filter_policy_;


### PR DESCRIPTION
Adding new Open/Close API for DefaultCache. Now it's possible to
disable protected or mutable cache, modify and enable it again. This
can be useful if for some reason we want to update individual cache
while DefaultCache is still in use.

Changed DiskCache behavior when try to open not existing folder for
read-only. Now it's creating folder and an empty leveldb DB.

Removed CreadteDir() function, since it's not used anymore and also
we have alternative util for that purpose(olp::utils::Dir::create()).

Resolves: OAM-731, OLPSUP-12312

Signed-off-by: Kostiantyn Zvieriev ext-kostiantyn.zvieriev@here.com