### PR TITLE
Change the instruction on auth and update links

### DIFF
--- a/docs/GettingStartedGuide.md
+++ b/docs/GettingStartedGuide.md
@@ -17,7 +17,7 @@ For more information, see the [Data User Guide](https://developer.here.com/olp/d
 
 To work with catalog or service requests to the HERE platform, you need to get authentication and authorization credentials.
 
-You can authenticate to the HERE platform within your application with the platform credentials available on the HERE platform Portal by means of the Data SDK for C++ authentication library. For instructions on how to get credentials, see the [related section](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) in the Terms and Permissions User Guide.
+You can authenticate to the HERE platform within your application with the platform credentials available on the HERE Portal by means of the Data SDK for C++ authentication library. For the available authentication options, see the [Identity & Access Management Developer Guide](https://developer.here.com/documentation/identity-access-management/dev_guide/index.html).
 
 ## Available Components
 

--- a/docs/authenticate.md
+++ b/docs/authenticate.md
@@ -1,18 +1,20 @@
 # Authenticate to the HERE Platform
 
-To authenticate to the HERE platform and start working with HERE Data SDK for C++, you need to get an access token. You can receive it using a [default token provider](#authenticate-using-a-default-token-provider), [project authentication](#authenticate-using-project-authentication), or [federated credentials](#authenticate-using-federated-credentials)
+To authenticate to the HERE platform and start working with HERE Data SDK for C++, you need to get an access token. You can receive it using a [default token provider](#authenticate-using-a-default-token-provider), [project authentication](#authenticate-using-project-authentication), or [federated credentials](#authenticate-using-federated-credentials).
+
+> Note: Keep your credentials secure and do not disclose them. Make sure that your credentials are not stored in a way that enables others to access them.
 
 ## Authenticate using a default token provider
 
 1. Get your platform credentials.
 
-   For instructions, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+   For instructions, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
    You get the `credentials.properties` file.
 
 2. Initialize the authentification settings using the **here.access.key.іd** and **here.access.key.secret** from the `credentials.properties` file as `kKeyId` and `kKeySecret` respectively.
 
-   > Note: You can also retrieve your credentials from the `credentials.properties` file using the `ReadFromFile` method. For more information, see the [related API documentation](https://developer.here.com/documentation/sdk-cpp/api_reference/classolp_1_1authentication_1_1AuthenticationCredentials.html#a6bfd8347ebe89e45713b966e621dccdd).
+   > Note: You can also retrieve your credentials from the `credentials.properties` file using the `ReadFromFile` method. For more information, see the [related API documentation](https://developer.here.com/documentation/sdk-cpp/api_reference/classolp_1_1authentication_1_1_authentication_credentials.html#a6bfd8347ebe89e45713b966e621dccdd).
 
    ```cpp
    olp::authentication::Settings settings({kKeyId, kKeySecret});
@@ -30,40 +32,61 @@ To authenticate to the HERE platform and start working with HERE Data SDK for C+
 
 You get an access token.
 
-You can use the `AuthenticationSettings` object to create the `OlpClientSettings` object. For more information, see the [related](https://developer.here.com/documentation/sdk-cpp/dev_guide/topics/create-olp-client-settings.html) section in the Developer Guide.
+You can use the `AuthenticationSettings` object to create the `OlpClientSettings` object. For more information, see the [related section](https://developer.here.com/documentation/sdk-cpp/dev_guide/topics/create-olp-client-settings.html) in the Developer Guide.
 
 ## Authenticate using project authentication
 
-1. Create your application and get your API key.
+1. Get your platform credentials.
 
-   For instructions, see the [Manage Apps](https://developer.here.com/documentation/access-control/user_guide/topics/manage-apps.html) section in the Terms and Permissions User Guide.
+   For instructions, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
-2. Create a function that returns your API key.
-3. Set up the `AuthenticationSettings` object with your function that returns the API key.
+2. Initialize the `AuthenticationCredentials` class using the **here.access.key.іd** and **here.access.key.secret** from the `credentials.properties` file as `kKeyId` and `kKeySecret` respectively.
 
-   > Note: Do not trigger any tasks on `TaskScheduler` as this might result in a deadlock.
+   > Note: You can also retrieve your credentials from the `credentials.properties` file using the `ReadFromFile` method. For more information, see the [related API documentation](https://developer.here.com/documentation/sdk-cpp/api_reference/classolp_1_1authentication_1_1_authentication_credentials.html#a6bfd8347ebe89e45713b966e621dccdd).
 
    ```cpp
-   olp::client::AuthenticationSettings auth_settings;
-   auth_settings.api_key_provider =
-   [](){ return "your-api-key"; };
+   olp::authentication::AuthenticationCredentials credentials(kKeyId, kKeySecret);
+   ```
+
+3. Create an authentication client.
+
+   ```cpp
+   olp::authentication::AuthenticationSettings settings;
+   settings.task_scheduler = task_scheduler;
+   settings.network_request_handler = http_client;
+   authentication::AutnhentucationClient client(settings);
+   ```
+
+4. Create the `SignInProperties` object with your project ID.
+
+   ```cpp
+   authentication::SignInProperties signin_properties;
+   signin_properties.scope = "<project ID>";
+   ```
+
+5. Create the `SignInClient` object.
+
+   ```cpp
+   authentication:: SignInClient(AuthenticationCredentials credentials,
+                                         SignInProperties properties,
+                                         SignInClientCallback callback);
    ```
 
 You get an access token.
 
-You can use the `AuthenticationSettings` object to create the `OlpClientSettings` object. For more information, see the [related](https://developer.here.com/documentation/sdk-cpp/dev_guide/topics/create-olp-client-settings.html) section in the Developer Guide.
+You can use the `AuthenticationSettings` object to create the `OlpClientSettings` object. For more information, see the [related section](https://developer.here.com/documentation/sdk-cpp/dev_guide/topics/create-olp-client-settings.html) in the Developer Guide.
 
 ## Authenticate using federated credentials
 
 1. Get your platform credentials.
 
-   For instructions, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+   For instructions, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
    You get the `credentials.properties` file.
 
 2. Initialize the `AuthenticationCredentials` class using the **here.access.key.іd** and **here.access.key.secret** from the `credentials.properties` file as `kKeyId` and `kKeySecret` respectively.
 
-   > Note: You can also retrieve your credentials from the `credentials.properties` file using the `ReadFromFile` method. For more information, see the [related API documentation](https://developer.here.com/documentation/sdk-cpp/api_reference/classolp_1_1authentication_1_1AuthenticationCredentials.html#a6bfd8347ebe89e45713b966e621dccdd).
+   > Note: You can also retrieve your credentials from the `credentials.properties` file using the `ReadFromFile` method. For more information, see the [related API documentation](https://developer.here.com/documentation/sdk-cpp/api_reference/classolp_1_1authentication_1_1_authentication_credentials.html#a6bfd8347ebe89e45713b966e621dccdd).
 
    ```cpp
    olp::authentication::AuthenticationCredentials credentials(kKeyId, kKeySecret);
@@ -80,7 +103,7 @@ You can use the `AuthenticationSettings` object to create the `OlpClientSettings
 
 4. Get your federated (Facebook or ArcGIS) properties.
 
-   You should have at least your federated access token. For the complete list of federated properties, see the [related](https://developer.here.com/documentation/sdk-cpp/api_reference/structolp_1_1authentication_1_1AuthenticationClient_1_1FederatedProperties.html) documentation.
+   You should have at least your federated access token. For the complete list of federated properties, see the [related documentation](https://developer.here.com/documentation/sdk-cpp/api_reference/structolp_1_1authentication_1_1_authentication_client_1_1_federated_properties.html).
 
 5. Initialize your federated properties.
 
@@ -91,7 +114,7 @@ You can use the `AuthenticationSettings` object to create the `OlpClientSettings
 
 6. Create the `SignInUserCallback` class.
 
-   For more information, see the [`AuthenticationClient` reference documentation](https://developer.here.com/documentation/sdk-cpp/api_reference/classolp_1_1authentication_1_1AuthenticationClient.html)
+   For more information, see the [`AuthenticationClient` reference documentation](https://developer.here.com/documentation/sdk-cpp/api_reference/classolp_1_1authentication_1_1_authentication_client.html).
 
 7. Create your own token provider using the authentication client created in step 3, your federated credentials, and the `SignInUserCallback` class.
 
@@ -118,4 +141,4 @@ You can use the `AuthenticationSettings` object to create the `OlpClientSettings
 
 You get an access token. By default, it expires in 24 hours. To continue working with the HERE platform after your token expires, generate a new access token.
 
-You can use the `AuthenticationSettings` object to create the `OlpClientSettings` object.
+You can use the `AuthenticationSettings` object to create the `OlpClientSettings` object. For more information, see the [related section](https://developer.here.com/documentation/sdk-cpp/dev_guide/topics/create-olp-client-settings.html) in the Developer Guide.

--- a/docs/dataservice-cache-example.md
+++ b/docs/dataservice-cache-example.md
@@ -5,7 +5,8 @@ On this page, find instructions on how to build and run the example project, get
 Before you run the example project, authorize to the HERE platform:
 
 1. On the [Apps & keys](https://platform.here.com/admin/apps) page, copy your application access key ID and access key secret.
-   For instructions on how to get the access key ID and access key secret, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+
+   For instructions on how to get the access key ID and access key secret, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
 2. In `examples/main.cpp`, replace the placeholders with your access key ID, access key secret, and Here Resource Name (HRN) of the catalog.
    **Note:**  You can also specify these values using the command line options.
@@ -65,7 +66,7 @@ To authenticate with the HERE platform, you must get platform credentials that c
 
 1. Get your platform credentials.
 
-   For instructions, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+   For instructions, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
    You get the `credentials.properties` file.
 

--- a/docs/dataservice-read-catalog-example.md
+++ b/docs/dataservice-read-catalog-example.md
@@ -5,7 +5,8 @@ On this page, find instructions on how to build and run the example project on d
 Before you run the example project, authorize to the HERE platform:
 
 1. On the [Apps & keys](https://platform.here.com/admin/apps) page, copy your application access key ID and access key secret.
-   For instructions on how to get the access key ID and access key secret, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+
+   For instructions on how to get the access key ID and access key secret, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
 2. In `examples/main.cpp`, replace the placeholders with your access key ID, access key secret, and Here Resource Name (HRN) of the catalog.
    **Note:**  You can also specify these values using the command line options.
@@ -68,8 +69,9 @@ To integrate the HERE Data SDK for C++ libraries in the Android example project:
 Before you integrate the HERE Data SDK for C++ libraries in the Android example project:
 
 1. Set up the Android environment.
-2.  In `examples/android/app/src/main/cpp/MainActivityNative.cpp.in`, replace the placeholders with your application access key ID, access key secret, and catalog HRN and specify that the example should run `RunExampleRead`.
-   For instructions on how to get the access key ID and access key secret, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+2. In `examples/android/app/src/main/cpp/MainActivityNative.cpp.in`, replace the placeholders with your application access key ID, access key secret, and catalog HRN and specify that the example should run `RunExampleRead`.
+
+   For instructions on how to get the access key ID and access key secret, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
 ### <a name="build-sdk-android"></a>Build the HERE Data SDK for C++
 
@@ -119,9 +121,11 @@ Before you integrate the HERE Data SDK for C++ libraries in the iOS example proj
 
 1. To set up the iOS development environment, install the `XCode` and command-line tools.
 2. Install external dependencies.
+
    For information on dependencies and installation instructions, see the [related section](https://github.com/heremaps/here-data-sdk-cpp#dependencies) in the README.md file.
 3. In `examples/ios/ViewController.mm`, replace the placeholders with your application access key ID, access key secret, and catalog HRN and specify that the example should run `RunExampleRead`.
-   For instructions on how to get the access key ID and access key secret, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+
+   For instructions on how to get the access key ID and access key secret, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
 ### <a name="build-sdk-ios"></a>Build the HERE Data SDK for C++
 
@@ -169,7 +173,7 @@ To authenticate with the HERE platform, you must get platform credentials that c
 
 1. Get your platform credentials.
 
-   For instructions, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+   For instructions, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
    You get the `credentials.properties` file.
 

--- a/docs/dataservice-read-from-stream-layer-example.md
+++ b/docs/dataservice-read-from-stream-layer-example.md
@@ -5,7 +5,8 @@ On this page, you can find instructions on how to build and run the example proj
 Before you run the example project, authorize to the HERE platform:
 
 1. On the [Apps & keys](https://platform.here.com/admin/apps) page, copy your application access key ID and access key secret.
-   For instructions on how to get the access key ID and access key secret, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+
+   For instructions on how to get the access key ID and access key secret, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
 2. In `examples/main.cpp`, replace the placeholders with your access key ID, access key secret, and Here Resource Name (HRN) of the catalog.
    **Note:**  You can also specify these values using the command line options.
@@ -65,7 +66,7 @@ To authenticate with the HERE platform, you must get platform credentials that c
 
 1. Get your platform credentials.
 
-   For instructions, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+   For instructions, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
    You get the `credentials.properties` file.
 

--- a/docs/dataservice-write-example.md
+++ b/docs/dataservice-write-example.md
@@ -5,7 +5,8 @@ On this page, find instructions on how to build and run the example project on d
 Before you run the example project, authorize to the HERE platform:
 
 1. On the [Apps & keys](https://platform.here.com/admin/apps) page, copy your application access key ID and access key secret.
-   For instructions on how to get the access key ID and access key secret, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+
+   For instructions on how to get the access key ID and access key secret, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
 2. 2. In `examples/main.cpp`, replace the placeholders with your access key ID, access key secret, Here Resource Name (HRN) of the catalog, and name of the layer to which you want to publish data.
    **Note:**  You can also specify these values using the command line options.
@@ -58,8 +59,9 @@ To integrate the HERE Data SDK for C++ libraries in the Android example project:
 Before you integrate the HERE Data SDK for C++ libraries in the Android example project:
 
 1. Set up the Android environment.
-2. In `examples/android/app/src/main/cpp/MainActivityNative.cpp.in`, replace the placeholders with your application access key ID, access key secret, catalog HRN, and layer name and specify that the example should run 'RunExampleWrite'.
-   For instructions on how to get the access key ID and access key secret, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+2. In `examples/android/app/src/main/cpp/MainActivityNative.cpp.in`, replace the placeholders with your application access key ID, access key secret, catalog HRN, and layer name and specify that the example should run `RunExampleWrite`.
+
+   For instructions on how to get the access key ID and access key secret, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
 ### <a name="build-sdk-android"></a>Build HERE Data SDK for C++
 
@@ -110,7 +112,8 @@ Before you integrate the HERE Data SDK for C++ libraries in the iOS example proj
 2. Install external dependencies.
    For information on dependencies and installation instructions, see the [related section](https://github.com/heremaps/here-data-sdk-cpp#dependencies) in the README.md file.
 3. In `examples/ios/ViewController.mm`, replace the placeholders with your application access key ID, access key secret, catalog HRN, and layer name and specify that the example should run `RunExampleWrite`.
-   For instructions on how to get the access key ID and access key secret, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+
+   For instructions on how to get the access key ID and access key secret, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
 ```bash
 mkdir build && cd build
@@ -163,7 +166,7 @@ To authenticate with the HERE platform, you must get platform credentials that c
 
 1. Get your platform credentials.
 
-   For instructions, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+   For instructions, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
    You get the `credentials.properties` file.
 


### PR DESCRIPTION
* Modify the instruction on project authentication.
* As the Teams and Permissions guide will be deleted, and
the Identity & Access Management Developer Guide will be used instead,
update the links.

Relates-To: OLPEDGE-2364, OLPEDGE-2366

Signed-off-by: Halyna Dumych <ext-halyna.dumych@here.com>