### PR TITLE
Make DiskCache create db if folder is an empty.

### DIFF
--- a/olp-cpp-sdk-core/tests/cache/DefaultCacheTest.cpp
+++ b/olp-cpp-sdk-core/tests/cache/DefaultCacheTest.cpp
@@ -485,6 +485,21 @@ TEST(DefaultCacheTest, ProtectedCacheTest) {
     ASSERT_EQ(olp::cache::DefaultCache::Success, cache.Open());
     ASSERT_TRUE(olp::utils::Dir::Exists(protected_path));
   }
+
+  {
+    SCOPED_TRACE("Open empty folder");
+
+    // create an empty folder without db
+    olp::utils::Dir::Remove(protected_path);
+    olp::utils::Dir::Create(protected_path);
+
+    olp::cache::CacheSettings settings;
+    settings.disk_path_protected = protected_path;
+
+    olp::cache::DefaultCache cache(settings);
+    ASSERT_EQ(olp::cache::DefaultCache::Success, cache.Open());
+    ASSERT_TRUE(olp::utils::Dir::Exists(protected_path));
+  }
 }
 
 TEST(DefaultCacheTest, AlreadyInUsePath) {


### PR DESCRIPTION
Now db and folder creation is independent for protected cache. Also
added a simple test for the case.

Resolves: OLPSUP-12312

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>