### PR TITLE
Marked DefaultCache-specific methods as virtual

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/CacheSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/CacheSettings.h
@@ -145,7 +145,7 @@ struct CORE_API CacheSettings {
    *
    * This cache is used as a primary cache for lookup. `DefaultCache` opens this
    * cache in the read-only mode and does not write to it if
-   * `disk_path_mutable` is empty. Use this cash if you want to have a stable
+   * `disk_path_mutable` is empty. Use this cache if you want to have a stable
    * fallback state or offline data that you can always access regardless of
    * the network state.
    */

--- a/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
@@ -84,7 +84,7 @@ class CORE_API DefaultCache : public KeyValueCache {
    * @return `StorageOpenResult` if there are problems opening any of
    * the provided paths on the disk.
    */
-  StorageOpenResult Open();
+  virtual StorageOpenResult Open();
 
   /**
    * @brief Creates a new cache of the corresponding type.
@@ -95,12 +95,12 @@ class CORE_API DefaultCache : public KeyValueCache {
    * DefaultCache is closed and `OpenDiskPathFailure` if there are problems
    * opening the provided path on the disk.
    */
-  StorageOpenResult Open(CacheType type);
+  virtual StorageOpenResult Open(CacheType type);
 
   /**
    * @brief Closes the cache.
    */
-  void Close();
+  virtual void Close();
 
   /**
    * @brief Closes the cache internally so that it is not keept open and thus
@@ -110,14 +110,14 @@ class CORE_API DefaultCache : public KeyValueCache {
    *
    * @return true if the cache was closed successfully; false otherwise.
    */
-  bool Close(CacheType type);
+  virtual bool Close(CacheType type);
 
   /**
    * @brief Clears the cache content.
    *
    * @return True if the operation is successful; false otherwise.
    */
-  bool Clear();
+  virtual bool Clear();
 
   /**
    * @brief Compacts the underlying mutable cache storage.
@@ -134,7 +134,7 @@ class CORE_API DefaultCache : public KeyValueCache {
    * that automatic asynchronous compacting operation is triggered internally
    * once the database size exceeds the CacheSettings::max_disk_storage size.
    */
-  void Compact();
+  virtual void Compact();
 
   /**
    * @brief Stores the key-value pair in the cache.


### PR DESCRIPTION
This is necessary for being able to fully mock this class.
Also fixed typo in the 'disk_path_protected' description

Relates-To: OAM-739
Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>