### PR TITLE
Enable OlpClient caching inside ApiLookupClient

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -238,6 +238,7 @@ set(OLP_SDK_CLIENT_SOURCES
     ./src/client/ApiLookupClientImpl.cpp
     ./src/client/ApiLookupClientImpl.h
     ./src/client/CancellationToken.cpp
+    ./src/client/DefaultLookupEndpointProvider.cpp
     ./src/client/HRN.cpp
     ./src/client/OlpClient.cpp
     ./src/client/OlpClientFactory.cpp

--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClient.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClient.h
@@ -62,7 +62,7 @@ class CORE_API OlpClient {
    *
    * @return The base URL.
    */
-  const std::string& GetBaseUrl() const;
+  std::string GetBaseUrl() const;
 
   /**
    * @brief Gets the default headers that are added to each request.

--- a/olp-cpp-sdk-core/src/client/DefaultLookupEndpointProvider.cpp
+++ b/olp-cpp-sdk-core/src/client/DefaultLookupEndpointProvider.cpp
@@ -17,24 +17,31 @@
  * License-Filename: LICENSE
  */
 
-#pragma once
-
-#include <string>
-
-#include <olp/core/CoreApi.h>
+#include <olp/core/client/DefaultLookupEndpointProvider.h>
 
 namespace olp {
 namespace client {
-/**
- * @brief Default implementation of the lookup API endpoint provider.
- *
- * This is returning the default lookup API endpoint URLs based on the HRN
- * partition.
- */
-struct CORE_API DefaultLookupEndpointProvider {
- public:
-  std::string operator()(const std::string& partition);
-};
+
+std::string DefaultLookupEndpointProvider::operator()(
+    const std::string& partition) {
+  constexpr struct {
+    const char* partition;
+    const char* url;
+  } kDatastoreServerUrl[4] = {
+      {"here", "https://api-lookup.data.api.platform.here.com/lookup/v1"},
+      {"here-dev",
+       "https://api-lookup.data.api.platform.in.here.com/lookup/v1"},
+      {"here-cn", "https://api-lookup.data.api.platform.hereolp.cn/lookup/v1"},
+      {"here-cn-dev",
+       "https://api-lookup.data.api.platform.in.hereolp.cn/lookup/v1"}};
+
+  for (const auto& it : kDatastoreServerUrl) {
+    if (partition == it.partition)
+      return it.url;
+  }
+
+  return std::string();
+}
 
 }  // namespace client
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
@@ -177,9 +177,6 @@ TEST(VolatileLayerClientImplTest, GetData) {
   {
     SCOPED_TRACE("Get Data from non existent partition");
 
-    SetupNetworkExpectation(*network_mock, kUrlLookup, kHttpResponseLookup,
-                            olp::http::HttpStatusCode::OK);
-
     SetupNetworkExpectation(*network_mock, kUrlQueryPartition269,
                             kHttpResponseNoPartition,
                             olp::http::HttpStatusCode::OK);


### PR DESCRIPTION
This enables SDK to route user requests to the same OlpClient instances.
Needed to implement a proper request merging. Another benefit
for users is fewer cache lookups. The client is cached for a max-age time
provided by the server or one hour. When the URL is resolved from the
cache, we assume it will expire in five minutes.
Move DefaultLookupEndpointProvider source code to the cpp file.

Resolves: OLPEDGE-2230

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>