### PR TITLE
Add proper request_id handling in NetworkMock.

### DIFF
--- a/tests/common/mocks/NetworkMock.h
+++ b/tests/common/mocks/NetworkMock.h
@@ -105,7 +105,8 @@ GenerateNetworkMockActions(std::shared_ptr<std::promise<void>> pre_signal,
 NetworkCallback ReturnHttpResponse(
     olp::http::NetworkResponse response, const std::string& response_body,
     const olp::http::Headers& headers = {},
-    std::chrono::nanoseconds delay = std::chrono::nanoseconds(0));
+    std::chrono::nanoseconds delay = std::chrono::nanoseconds(0),
+    olp::http::RequestId request_id = 5);
 
 inline olp::http::NetworkResponse GetResponse(int status) {
   return olp::http::NetworkResponse().WithStatus(status);


### PR DESCRIPTION
To integrate properly the merging of same url requests in OlpClient
NetworkMock needs to support injection of request_id from outside
so that we can simulate proper Network workflow.
Additionally we add full async to NetworkMock which now triggers all
responses on a separate thread.

Relates-To: OLPEDGE-1805

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>