### PR TITLE
Switch VersionedLayerClientPrefetchTest to Mock

### DIFF
--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test-mock.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test-mock.sh
@@ -51,7 +51,7 @@ update-ca-certificates
 echo ">>> Starting Functional Test against Mock Server... >>>"
 $REPO_HOME/build/tests/functional/olp-cpp-sdk-functional-tests \
     --gtest_output="xml:$REPO_HOME/reports/olp-functional-test-mock-report.xml" \
-    --gtest_filter="VersionedLayerClientTest.GetPartitions":"VersionedLayerClientTest.GetAggregatedData":"CatalogClientTest.*":"VersionedLayerClientPrefetchTest.Prefetch":"VersionedLayerClientProtectTest.*":"VersionedLayerClientGetDataTest.*"
+    --gtest_filter="VersionedLayerClientTest.GetPartitions":"VersionedLayerClientTest.GetAggregatedData":"CatalogClientTest.*":"VersionedLayerClientPrefetchTest.*":"VersionedLayerClientProtectTest.*":"VersionedLayerClientGetDataTest.*"
 result=$?
 echo "Functional test with Mock finished with status: ${result}"
 

--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test.sh
@@ -20,7 +20,7 @@
 echo ">>> Functional Test ... >>>"
 $REPO_HOME/build/tests/functional/olp-cpp-sdk-functional-tests \
     --gtest_output="xml:$REPO_HOME/reports/olp-functional-test-report.xml" \
-    --gtest_filter="-ArcGisAuthenticationTest.SignInArcGis":"FacebookAuthenticationTest.SignInFacebook":"VersionedLayerClientTest.GetPartitions":"VersionedLayerClientTest.GetAggregatedData":"CatalogClientTest.*":"VersionedLayerClientPrefetchTest.Prefetch":"VersionedLayerClientProtectTest.*":"VersionedLayerClientGetDataTest.*"
+    --gtest_filter="-ArcGisAuthenticationTest.SignInArcGis":"FacebookAuthenticationTest.SignInFacebook":"VersionedLayerClientTest.GetPartitions":"VersionedLayerClientTest.GetAggregatedData":"CatalogClientTest.*":"VersionedLayerClientPrefetchTest.*":"VersionedLayerClientProtectTest.*":"VersionedLayerClientGetDataTest.*"
     #The test VersionedLayerClientTest.GetPartitions uses mock server and it will be started in separate script. (OLPEDGE-732)
 result=$?
 echo "Functional test finished with status: ${result}"


### PR DESCRIPTION
After renaming both testcases of VersionedLayerClientPrefetchTest
were running against real server, which is wrong.

Resolves: OLPEDGE-2380

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>