### PR TITLE
Merge the parallel query partitions requests.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/PendingRequests.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/PendingRequests.h
@@ -68,10 +68,17 @@ class CORE_API PendingRequests final {
    */
   void Remove(TaskContext task_context);
 
+  /**
+   * @brief Gets the number of tasks.
+   *
+   * @return The number of tasks pending.
+   */
+  size_t GetTaskCount() const;
+
  private:
   using ContextMap = std::unordered_set<TaskContext, TaskContextHash>;
   ContextMap task_contexts_;
-  std::mutex task_contexts_lock_;
+  mutable std::mutex task_contexts_lock_;
 };
 
 }  // namespace client

--- a/olp-cpp-sdk-core/src/client/ApiLookupClientImpl.cpp
+++ b/olp-cpp-sdk-core/src/client/ApiLookupClientImpl.cpp
@@ -242,13 +242,12 @@ boost::optional<OlpClient> ApiLookupClientImpl::GetCachedClient(
     std::lock_guard<std::mutex> lock(cached_clients_mutex_);
     const auto client_it = cached_clients_.find(key);
     if (client_it != cached_clients_.end()) {
-      const ClientWithExpiration& client_with_expirtation = client_it->second;
-      if (client_with_expirtation.expire_at >
-          std::chrono::steady_clock::now()) {
+      const ClientWithExpiration& client_with_expiration = client_it->second;
+      if (client_with_expiration.expire_at > std::chrono::steady_clock::now()) {
         OLP_SDK_LOG_DEBUG_F(
             kLogTag, "LookupApi(%s/%s) found in client cache, hrn='%s'",
             service.c_str(), service_version.c_str(), catalog_string_.c_str());
-        return client_with_expirtation.client;
+        return client_with_expiration.client;
       }
     }
   }

--- a/olp-cpp-sdk-core/src/client/PendingRequests.cpp
+++ b/olp-cpp-sdk-core/src/client/PendingRequests.cpp
@@ -71,5 +71,10 @@ void PendingRequests::Remove(TaskContext task_context) {
   task_contexts_.erase(task_context);
 }
 
+size_t PendingRequests::GetTaskCount() const {
+  std::lock_guard<std::mutex> lock(task_contexts_lock_);
+  return task_contexts_.size();
+}
+
 }  // namespace client
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/TaskSink.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/TaskSink.cpp
@@ -34,10 +34,14 @@ TaskSink::TaskSink(std::shared_ptr<thread::TaskScheduler> task_scheduler)
       closed_(false) {}
 
 TaskSink::~TaskSink() {
-  OLP_SDK_LOG_INFO(kLogTag, "Finishing, canceling all current tasks.");
   {
     std::lock_guard<std::mutex> lock(mutex_);
     closed_ = true;
+    const auto task_count = pending_requests_->GetTaskCount();
+    if (task_count > 0) {
+      OLP_SDK_LOG_INFO_F(kLogTag, "Finishing, canceling %" PRIu64 " tasks.",
+                         static_cast<std::uint64_t>(task_count));
+    }
   }
   // CancelAllAndWait method should be called without mutex, since potentially
   // there might be new added tasks, it may result in deadlock.


### PR DESCRIPTION
The order of partition ids in the request matters. Worst case - two
parallel downloads. This is a temporary workaround.
Change the log in TaskSink to print the number of tasks pending.
Add a new method to PendingRequests to query a number of task
pending.
Fix a typo.

Resolves: OLPEDGE-2395

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>