### PR TITLE
Lower log levels for high frequency logs.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -358,7 +358,8 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchTiles(
         auto version = response.GetResult().GetVersion();
 
         const auto key = request.CreateKey(layer_id);
-        OLP_SDK_LOG_INFO_F(kLogTag, "PrefetchTiles: using key=%s", key.c_str());
+        OLP_SDK_LOG_DEBUG_F(kLogTag, "PrefetchTiles: using key=%s",
+                            key.c_str());
 
         // Calculate the minimal set of Tile keys and depth to
         // cover tree.

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -378,9 +378,9 @@ PrefetchTilesRepository::DownloadVersionedQuadTree(
 
   auto tile_key = tile.ToHereTile();
 
-  OLP_SDK_LOG_INFO_F(kLogTag,
-                     "GetSubQuads execute(%s, %" PRId64 ", %" PRId32 ")",
-                     tile_key.c_str(), version, depth);
+  OLP_SDK_LOG_DEBUG_F(kLogTag,
+                      "GetSubQuads execute(%s, %" PRId64 ", %" PRId32 ")",
+                      tile_key.c_str(), version, depth);
 
   auto quad_tree = QueryApi::QuadTreeIndex(query_api.GetResult(), layer_id_,
                                            tile_key, version, depth,


### PR DESCRIPTION
These two logs are triggered very often and produce a lot of output with
no extra information gain for production releases.
Moving it to debug level will lighten the output. Next step is to
enhance overall logging to consider more error cases and leave the good
results noise free.

Resolves: OLPSUP-12666

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>