### PR TITLE
Fix PrefetchPartitions test

### DIFF
--- a/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientPrefetchTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientPrefetchTest.cpp
@@ -33,7 +33,7 @@
 
 namespace {
 namespace read = olp::dataservice::read;
-constexpr auto kWaitTimeout = std::chrono::seconds(10);
+constexpr auto kWaitTimeout = std::chrono::seconds(20);
 using VersionedLayerClientPrefetchTest = VersionedLayerTestBase;
 
 TEST_F(VersionedLayerClientPrefetchTest, PrefetchTiles) {


### PR DESCRIPTION
Fix PrefetchPartitions FV test
by increasing timeout.

Resolves: OLPEDGE-2380

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>