### PR TITLE
Add checks for integers overflow

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/PrefetchPartitionsHelper.h
+++ b/olp-cpp-sdk-dataservice-read/src/PrefetchPartitionsHelper.h
@@ -59,7 +59,10 @@ class PrefetchPartitionsHelper {
         priority);
 
     auto query_size = roots.size() / query_max_size;
-    query_size += (roots.size() % query_max_size > 0) ? 1 : 0;
+    if ((roots.size() % query_max_size > 0) &&
+        query_size < std::numeric_limits<decltype(query_size)>::max()) {
+      ++query_size;
+    }
 
     query_job->Initialize(query_size);
 


### PR DESCRIPTION
Add check to increment
size of qeries for prefech only
if it is not reached max value.

Add chack that size for QuadTreeIndex
blob do not overflow.

Relates-To: OLPEDGE-2396

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>