### PR TITLE
Add shallow clone flag to ExternalProject_Add.

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 set(COMMON_PLATFORM_FLAGS)
 
 if(ANDROID)
-  set(COMMON_PLATFORM_FLAGS -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} 
+  set(COMMON_PLATFORM_FLAGS -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
                             -DANDROID_PLATFORM=${ANDROID_PLATFORM}
                             -DANDROID_STL=${ANDROID_STL}
                             -DANDROID_ABI=${ANDROID_ABI})
@@ -45,7 +45,7 @@ elseif(IOS)
                             -DSIMULATOR=${SIMULATOR})
 endif()
 
-# Setup versions for external project 
+# Setup versions for external project
 set(OLP_SDK_CPP_GOOGLETEST_URL "https://github.com/google/googletest.git")
 set(OLP_SDK_CPP_GOOGLETEST_TAG "release-1.10.0")
 

--- a/external/boost/CMakeLists.txt.boost.in
+++ b/external/boost/CMakeLists.txt.boost.in
@@ -23,7 +23,7 @@ include(ExternalProject)
 
 ExternalProject_Add(boost-download
     GIT_REPOSITORY      @OLP_SDK_CPP_BOOST_URL@
-    GIT_TAG             @OLP_SDK_CPP_BOOST_TAG@ 
+    GIT_TAG             @OLP_SDK_CPP_BOOST_TAG@
     GIT_SUBMODULES      libs/any
                         libs/assert
                         libs/config
@@ -55,6 +55,7 @@ ExternalProject_Add(boost-download
                         libs/winapi
                         tools/build
                         tools/boost_install
+    GIT_SHALLOW         1
     SOURCE_DIR          "@CMAKE_CURRENT_BINARY_DIR@/external_boost"
     UPDATE_COMMAND      ""
     CONFIGURE_COMMAND   cd "@CMAKE_CURRENT_BINARY_DIR@/external_boost" && @BOOTSTRAP_CMD@ && cd "@CMAKE_CURRENT_BINARY_DIR@/external_boost" && @B2_CMD@ headers

--- a/external/googletest/CMakeLists.txt.googletest.in
+++ b/external/googletest/CMakeLists.txt.googletest.in
@@ -23,6 +23,7 @@ include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    @OLP_SDK_CPP_GOOGLETEST_URL@
   GIT_TAG           @OLP_SDK_CPP_GOOGLETEST_TAG@
+  GIT_SHALLOW       1
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""

--- a/external/leveldb/CMakeLists.txt.leveldb.in
+++ b/external/leveldb/CMakeLists.txt.leveldb.in
@@ -24,10 +24,11 @@ include(ExternalProject)
 ExternalProject_Add(snappy
   GIT_REPOSITORY    @OLP_SDK_CPP_SNAPPY_URL@
   GIT_TAG           @OLP_SDK_CPP_SNAPPY_TAG@
+  GIT_SHALLOW       1
   INSTALL_DIR       "@EXTERNAL_BINARY_INSTALL_DIR@"
-  CMAKE_ARGS        ${CMAKE_ARGS} 
-                    ${COMMON_CMAKE_ARGS} 
-                    -DCMAKE_INSTALL_LIBDIR=lib 
+  CMAKE_ARGS        ${CMAKE_ARGS}
+                    ${COMMON_CMAKE_ARGS}
+                    -DCMAKE_INSTALL_LIBDIR=lib
                     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                     -DSNAPPY_BUILD_TESTS=OFF
   BUILD_COMMAND     "${CMAKE_COMMAND}" --build . --config ${CMAKE_BUILD_TYPE} ${EXTERNAL_BUILD_FLAGS}
@@ -37,16 +38,18 @@ ExternalProject_Add(snappy
 ExternalProject_Add(leveldb
   GIT_REPOSITORY    @OLP_SDK_CPP_LEVELDB_URL@
   GIT_TAG           @OLP_SDK_CPP_LEVELDB_TAG@
+  GIT_SHALLOW       1
   INSTALL_DIR       "@EXTERNAL_BINARY_INSTALL_DIR@"
   PATCH_COMMAND     "${CMAKE_COMMAND}" -E copy_directory "${CMAKE_CURRENT_BINARY_DIR}/config/leveldb" "${CMAKE_CURRENT_BINARY_DIR}/download/leveldb-prefix/src/leveldb/."
-  CMAKE_ARGS        ${CMAKE_ARGS} 
-                    ${COMMON_CMAKE_ARGS} 
-                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> 
+  CMAKE_ARGS        ${CMAKE_ARGS}
+                    ${COMMON_CMAKE_ARGS}
+                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                     -DCMAKE_SYSTEM_PREFIX_PATH=<INSTALL_DIR>
                     -DHAVE_CRC32C=OFF
                     -DHAVE_TCMALLOC=OFF
                     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-  BUILD_COMMAND     "${CMAKE_COMMAND}" --build . --config ${CMAKE_BUILD_TYPE} ${EXTERNAL_BUILD_FLAGS} 
+  BUILD_COMMAND     "${CMAKE_COMMAND}" --build . --config ${CMAKE_BUILD_TYPE} ${EXTERNAL_BUILD_FLAGS}
   TEST_COMMAND      ""
 )
+
 ExternalProject_Add_StepDependencies(leveldb build snappy)

--- a/external/rapidjson/CMakeLists.txt.rapidjson.in
+++ b/external/rapidjson/CMakeLists.txt.rapidjson.in
@@ -23,6 +23,7 @@ include(ExternalProject)
 ExternalProject_Add(rapidjson
   GIT_REPOSITORY    @OLP_SDK_CPP_RAPIDJSON_URL@
   GIT_TAG           @OLP_SDK_CPP_RAPIDJSON_TAG@
+  GIT_SHALLOW       1
   INSTALL_DIR       "@EXTERNAL_BINARY_INSTALL_DIR@"
   CMAKE_ARGS        @COMMON_PLATFORM_FLAGS@
                     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>


### PR DESCRIPTION
Adding the GIT_SHALLOW flag to ExternalProject_Add will speed up our
external dependencies cloning and avoids timeouts due to stucked
or slow connections.

Relates-To: OLPEDGE-2410

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>