### PR TITLE
Make ThreadedTaskScheduler to move tasks.

### DIFF
--- a/olp-cpp-sdk-core/src/thread/PriorityQueueExtended.h
+++ b/olp-cpp-sdk-core/src/thread/PriorityQueueExtended.h
@@ -89,7 +89,8 @@ class PriorityQueueExtended<T, COMPARE>::PriorityQueueExtendedImpl {
     DistinguishableObject(std::uint32_t id, Args... args)
         : id(id), obj(args...) {}
     DistinguishableObject(std::uint32_t id, const T& obj) : id(id), obj(obj) {}
-    DistinguishableObject(std::uint32_t id, T&& obj) : id(id), obj(obj) {}
+    DistinguishableObject(std::uint32_t id, T&& obj)
+        : id(id), obj(std::move(obj)) {}
 
     std::uint32_t id;
     T obj;
@@ -137,7 +138,7 @@ void PriorityQueueExtended<T, COMPARE>::push(const T& value) {
 
 template <class T, class COMPARE>
 void PriorityQueueExtended<T, COMPARE>::push(T&& value) {
-  impl_->Push(value);
+  impl_->Push(std::move(value));
 }
 
 template <class T, class COMPARE>
@@ -176,7 +177,7 @@ void PriorityQueueExtended<T, COMPARE>::PriorityQueueExtendedImpl::Push(
 template <class T, class COMPARE>
 void PriorityQueueExtended<T, COMPARE>::PriorityQueueExtendedImpl::Push(
     T&& value) {
-  container_.push_back(DistinguishableObject(GetNextId(), value));
+  container_.push_back(DistinguishableObject(GetNextId(), std::move(value)));
   std::push_heap(container_.begin(), container_.end(), compare_);
 }
 

--- a/olp-cpp-sdk-core/src/thread/ThreadPoolTaskScheduler.cpp
+++ b/olp-cpp-sdk-core/src/thread/ThreadPoolTaskScheduler.cpp
@@ -82,9 +82,7 @@ class ThreadPoolTaskScheduler::QueueImpl {
 
   bool Pull(ElementType& element) { return sync_queue_.Pull(element); }
 
-  void Push(ElementType&& element) {
-    sync_queue_.Push(std::forward<ElementType>(element));
-  }
+  void Push(ElementType&& element) { sync_queue_.Push(std::move(element)); }
 
   void Close() { sync_queue_.Close(); }
 

--- a/olp-cpp-sdk-core/tests/thread/PriorityQueueExtendedTest.cpp
+++ b/olp-cpp-sdk-core/tests/thread/PriorityQueueExtendedTest.cpp
@@ -74,7 +74,7 @@ TEST(PriorityQueueExtendedTest, BasicFunctionality) {
     thread::PriorityQueueExtended<std::string> queue;
     queue.push(std::move(value));
 
-    EXPECT_FALSE(value.empty());
+    EXPECT_TRUE(value.empty());
     ASSERT_FALSE(queue.empty());
     EXPECT_FALSE(queue.front().empty());
   }


### PR DESCRIPTION
For correct template deduction of rvalue references std::forward should
be used. Otherwise, scheduler task will be copied. Also added simple
test to check the issue.

Resolves: OLPEDGE-2418

Signed-off-by: Kostiantyn Zvieriev ext-kostiantyn.zvieriev@here.com