### PR TITLE
Add method to get current size and set max size of the mutable cache

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
@@ -67,6 +67,9 @@ class DefaultCacheImpl {
   bool Release(const DefaultCache::KeyListType& keys);
   bool IsProtected(const std::string& key) const;
 
+  uint64_t Size(DefaultCache::CacheType type) const;
+  uint64_t Size(uint64_t new_size);
+
  protected:
   /// The LRU value property.
   struct ValueProperties {
@@ -98,15 +101,24 @@ class DefaultCacheImpl {
     return memory_cache_;
   }
 
-  /// Returns mutable cache size, used for tests.
-  uint64_t GetMutableCacheSize() const { return mutable_cache_data_size_; }
-
   /// Gets expiry key, used for tests.
   std::string GetExpiryKey(const std::string& key) const;
 
+  /// Sets exiction portion, used for tests.
+  void SetEvictionPortion(uint64_t size);
+
  private:
+  /// Represents intermediate eviction result.
+  struct EvictionResult {
+    /// Number of evicted elements.
+    unsigned count;
+    /// The size of evicted elements.
+    uint64_t size;
+  };
+
   /// Add single key to LRU.
   bool AddKeyLru(std::string key, const leveldb::Slice& value);
+
   /// Initializes LRU mutable cache if possible.
   void InitializeLru();
 
@@ -122,6 +134,19 @@ class DefaultCacheImpl {
 
   /// Returns evicted data size.
   uint64_t MaybeEvictData(leveldb::WriteBatch& batch);
+
+  /// Returns number of evicted elements, evicted data size and a flag indicatin
+  /// if eviction limit reached. If the flag is true, another
+  /// EvictExpiredDataPortion call is needed to continue eviction.
+  EvictionResult EvictExpiredDataPortion(leveldb::WriteBatch& batch,
+                                         uint64_t target_eviction_size);
+
+  /// Returns number of evicted elements, evicted data size and a flag indicatin
+  /// if eviction limit reached. If the flag is true, another EvictDataPortion
+  /// call is needed to continue eviction.
+  /// To be used when all expired data already evicted and it is not enough.
+  EvictionResult EvictDataPortion(leveldb::WriteBatch& batch,
+                                  uint64_t target_eviction_size);
 
   /// Returns changed data size.
   int64_t MaybeUpdatedProtectedKeys(leveldb::WriteBatch& batch);
@@ -155,6 +180,7 @@ class DefaultCacheImpl {
   uint64_t mutable_cache_data_size_;
   ProtectedKeyList protected_keys_;
   mutable std::mutex cache_lock_;
+  uint64_t eviction_portion_;
 };
 
 }  // namespace cache


### PR DESCRIPTION
Using Size() method users will be able to check current size of the data stored
in the mutable cache. Note that the returned size is approximate and
may not match cache folder size. It is the size of real data and
does not include levelDB overhead.

Using SetMaxSize() method users will be able to change maximum alowed size
of the mutable cache on a fly. If size increases, no side actions happen.
If size decreases, the data that doesn't fit into new size (taking into account
data eviction thresholds) will be exicted from the cache. If a lot of data
must be evicted, it will be splitted to chunks that fits into
CacheSettings::max_eviction_portion.

Note that implementation is done into DefaultCacheImpl and not exposed to
DefaultCache public API. New APIs will be exposed in a separate commit when
Size() for the protected cache will be implemented.

Relates-To: OLPEDGE-2392

Signed-off-by: Mykola Malik <ext-mykola.malik@here.com>