### PR TITLE
Expose methods related to cache size

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
@@ -242,6 +242,27 @@ class CORE_API DefaultCache : public KeyValueCache {
    */
   bool IsProtected(const std::string& key) const override;
 
+  /**
+   * @brief Gets size of the corresponding cache.
+   *
+   * @param cache_type The type of a cache.
+   *
+   * @return Size of the corresponding cache.
+   */
+  uint64_t Size(CacheType cache_type) const;
+
+  /**
+   * @brief Sets maximum size for the mutable cache. Evict data that exceeds
+   * new maximum size.
+   *
+   * @param new_size The new maximum size.
+   *
+   * @return The size of the evicted data. If no data evicted return 0u.
+   *
+   * @note Currently this operation may take a lot of time and RAM to finish.
+   */
+  uint64_t Size(uint64_t new_size);
+
  private:
   std::shared_ptr<DefaultCacheImpl> impl_;
 };

--- a/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
@@ -83,5 +83,11 @@ bool DefaultCache::IsProtected(const std::string& key) const {
   return impl_->IsProtected(key);
 }
 
+uint64_t DefaultCache::Size(CacheType cache_type) const {
+  return impl_->Size(cache_type);
+}
+
+uint64_t DefaultCache::Size(uint64_t new_size) { return impl_->Size(new_size); }
+
 }  // namespace cache
 }  // namespace olp


### PR DESCRIPTION
Exposed new methods for cache size management:
- Size(CacheType) will evaluate cache size of
the given type;
- Size(uint64_t) could be used to reduce/enlarge
mutable cache size;

Relates-To: OLPEDGE-2392, OLPEDGE-2393
Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>