### PR TITLE
Reset memory cache on reopen disk cache

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -158,6 +158,10 @@ DefaultCache::StorageOpenResult DefaultCacheImpl::Open(
       return DefaultCache::OpenDiskPathFailure;
     }
 
+    if (memory_cache_) {
+      memory_cache_->Clear();
+    }
+
     return SetupMutableCache();
   }
 
@@ -170,6 +174,10 @@ DefaultCache::StorageOpenResult DefaultCacheImpl::Open(
     OLP_SDK_LOG_ERROR_F(kLogTag,
                         "Failed to open the protected cache - path is empty");
     return DefaultCache::OpenDiskPathFailure;
+  }
+
+  if (memory_cache_) {
+    memory_cache_->Clear();
   }
 
   return SetupProtectedCache();


### PR DESCRIPTION
When we using Open with cache type to
open specific disk cache we do not reset memory
cache. In this case if disk cache was chenged, we
still could return keys from memory which is not
longer cached. Reseting memory cache was added to
avoid this problem.

Relates-To: OAM-735

Signed-off-by: Liubov Didkivska <ext-liubov.didkivska@here.com>