### PR TITLE
Fix compilation on windows with UNICODE enabled

### DIFF
--- a/olp-cpp-sdk-core/src/utils/Dir.cpp
+++ b/olp-cpp-sdk-core/src/utils/Dir.cpp
@@ -409,9 +409,10 @@ uint64_t Dir::Size(const std::string& path, FilterFunction filter_fn) {
 
 #if defined(_WIN32) && !defined(__MINGW32__)
 
-  WIN32_FIND_DATA find_data;
+  WIN32_FIND_DATAA find_data;
   std::string current_path = path + "\\*.*";
-  HANDLE handle = FindFirstFile(current_path.c_str(), &find_data);
+
+  HANDLE handle = FindFirstFileA(current_path.c_str(), &find_data);
 
   if (handle != INVALID_HANDLE_VALUE) {
     do {
@@ -433,7 +434,7 @@ uint64_t Dir::Size(const std::string& path, FilterFunction filter_fn) {
         size.HighPart = find_data.nFileSizeHigh;
         result += size.QuadPart;
       }
-    } while (FindNextFile(handle, &find_data) != 0);
+    } while (FindNextFileA(handle, &find_data) != 0);
 
     FindClose(handle);
   }

--- a/olp-cpp-sdk-core/tests/cache/Helpers.cpp
+++ b/olp-cpp-sdk-core/tests/cache/Helpers.cpp
@@ -135,8 +135,11 @@ namespace helpers {
 bool MakeDirectoryContentReadonly(const std::string& path, bool readonly) {
 #if defined(_WIN32) && !defined(__MINGW32__)
 #ifdef _UNICODE
-  std::wstring wstrPath = ConvertStringToWideString(path);
-  const TCHAR* n_path = wstrPath.c_str();
+
+  int size_needed = MultiByteToWideChar(CP_ACP, 0, &path[0], path.size(), NULL, 0);
+  std::wstring wstr_path(size_needed, 0);
+  MultiByteToWideChar(CP_ACP, 0, &path[0], path.size(), &wstr_path[0], size_needed);
+  const TCHAR* n_path = wstr_path.c_str();
 #else
   const TCHAR* n_path = path.c_str();
 #endif  // _UNICODE


### PR DESCRIPTION
Modify Dir::Size to use only non unicode paths.
Repair the missing function in Helpers.cpp

Relates-To: OLPEDGE-2393

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>