### PR TITLE
Fix the cancellation function incorrectly called

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/TaskContext.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/TaskContext.h
@@ -225,10 +225,10 @@ class CORE_API TaskContext {
              response.GetError().GetErrorCode() == ErrorCode::RequestTimeout)) {
           user_response = std::move(response);
         }
-
-        // Reset the context after the task is finished.
-        context_ = CancellationContext();
       }
+
+      // Reset the context after the task is finished.
+      context_.ExecuteOrCancelled([]() { return CancellationToken(); });
 
       if (callback) {
         callback(std::move(user_response));

--- a/olp-cpp-sdk-dataservice-read/src/TaskSink.h
+++ b/olp-cpp-sdk-dataservice-read/src/TaskSink.h
@@ -41,6 +41,10 @@ class TaskSink {
 
   void CancelTasks();
 
+  client::CancellationToken AddTask(
+      std::function<void(client::CancellationContext)> func, uint32_t priority,
+      client::CancellationContext context);
+
   template <typename Function, typename Callback, typename... Args>
   client::CancellationToken AddTask(Function task, Callback callback,
                                     uint32_t priority, Args&&... args) {


### PR DESCRIPTION
The CancellationContext was incorrectly reset. The user could store the
cancellation token for the operation that is already finished and call
the Cancel method. Change the prefetch methods to share the same
context for all operations.

Relates-To: OAM-870

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>