### PR TITLE
Android job fixes due to changes in Azure images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,13 +45,12 @@ jobs:
   pool:
     vmImage: 'ubuntu-20.04'
   variables:
-    ANDROID_NDK_HOME: $(ANDROID_HOME)/ndk-bundle
     LD_PRELOAD: "/lib/x86_64-linux-gnu/libSegFault.so"
     SEGFAULT_SIGNALS: "all"
   steps:
-    - bash: ls -la $(ANDROID_NDK_HOME)/build/cmake/android.toolchain.cmake
-      displayName: 'Verification of cmake script'
-    - bash: ANDROID_NDK_HOME=$(ANDROID_NDK_HOME) && scripts/android/build.sh
+    - bash: env && ls -la $ANDROID_HOME && ls -la $ANDROID_HOME/ndk-bundle
+      displayName: 'Verification of prerequisites'
+    - bash: scripts/android/build.sh
       displayName: 'Android build and Examples'
 
 - job: Android_Emulator

--- a/examples/android/build.gradle
+++ b/examples/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:4.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/scripts/android/build.sh
+++ b/scripts/android/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright (C) 2019 HERE Europe B.V.
+# Copyright (C) 2019-2021 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,17 +17,37 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
+#
+# This script will compile Data SDK for C++
+# with ANDROID_PLATFORM=android-28 and -DANDROID_ABI=arm64-v8a
+# by using Android NDK 21.
+#
+
+# Install required NDK version (output disabled as it causes issues during page loading)
+env
+${ANDROID_HOME}/tools/bin/sdkmanager --list
+${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.3.6528147" --sdk_root=${ANDROID_HOME} >/dev/null
+${ANDROID_HOME}/tools/bin/sdkmanager --list
+export ANDROID_NDK_HOME=$ANDROID_HOME/ndk/21.3.6528147
+env
+# Verify content of NDK directories
+ls -la $ANDROID_NDK_HOME
+ls -la $ANDROID_NDK_HOME/platforms
 
 mkdir -p build && cd build
-cmake .. -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake" \
-	-DANDROID_PLATFORM=android-28 \
-	-DANDROID_ABI=arm64-v8a \
-	-DOLP_SDK_ENABLE_TESTING=NO \
-	-DOLP_SDK_BUILD_EXAMPLES=ON
+cmake .. -DCMAKE_TOOLCHAIN_FILE="$ANDROID_HOME/ndk/21.3.6528147/build/cmake/android.toolchain.cmake" \
+  -DANDROID_PLATFORM=android-28 \
+  -DANDROID_ABI=arm64-v8a \
+  -DANDROID_NDK="$ANDROID_HOME/ndk/21.3.6528147" \
+  -DOLP_SDK_ENABLE_TESTING=NO \
+  -DOLP_SDK_BUILD_EXAMPLES=ON
 
 #cmake --build . # this is alternative option for build
 sudo make install -j$(nproc)
 
 pushd examples/android
-sudo ./gradlew assemble
+  # check java version
+  echo "java is $(java --version)"
+  echo "sudo java is $(sudo java --version)"
+  ./gradlew assemble --stacktrace
 popd


### PR DESCRIPTION
Azure updated their pre-installed NDK from 21 to 22.
Also NDK 22 don't include `platforms` directory.
Examples were not compiling due to error:
"NDK is missing a "platforms" directory"
Fixed by installing NDK 21 in job and using it for
further compilations.
Discussed in:
https://github.com/actions/virtual-environments/issues/2420

Also gradle and android-gradle-plugin were updated.

Relates-To: OLPEDGE-2443

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>