### PR TITLE
Update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Additionally, the Data SDK includes classes for work with geospatial tiling sche
 
 We try to develop and maintain our API in a way that preserves its compatibility with the existing applications. Changes in Data SDK for C++ are greatly influenced by the Data API development. Data API introduces breaking changes 6 months in advance. Therefore, you may need to migrate to a new version of Data SDK for C++ every half a year.
 
-For more information on Data API, see its <a href="https://developer.here.com/olp/documentation/data-api/data_dev_guide/index.html" target="_blank">Developer Guide</a> and <a href="https://developer.here.com/olp/documentation/data-api/api-reference.html" target="_blank">API Reference</a>.
+For more information on Data API, see its <a href="https://developer.here.com/documentation/data-api/data_dev_guide/index.html" target="_blank">Developer Guide</a> and <a href="https://developer.here.com/documentation/data-api/api-reference.html" target="_blank">API Reference</a>.
 
 When new API is introduced in Data SDK for C++, the old one is not deleted straight away. The standard API deprecation time is 6 months. It gives you time to switch to new code. However, we do not provide ABI backward compatibility.
 
-All of the deprecated methods, functions, and parameters are documented in the Data SDK for C++ <a href="https://developer.here.com/olp/documentation/sdk-cpp/api_reference/index.html" target="_blank">API Reference</a> and <a href="https://github.com/heremaps/here-data-sdk-cpp/blob/master/CHANGELOG.md" target="_blank">changelog</a>.
+All of the deprecated methods, functions, and parameters are documented in the Data SDK for C++ <a href="https://developer.here.com/documentation/sdk-cpp/api_reference/index.html" target="_blank">API Reference</a> and <a href="https://github.com/heremaps/here-data-sdk-cpp/blob/master/CHANGELOG.md" target="_blank">changelog</a>.
 
 For more information on Data SDK for C++, see our <a href="https://developer.here.com/documentation/sdk-cpp/dev_guide/index.html" target="blank">Developer Guide</a>.
 

--- a/docs/GettingStartedGuide.md
+++ b/docs/GettingStartedGuide.md
@@ -13,12 +13,12 @@ Working with the Data SDK requires knowledge of the following subjects:
 
 To use HERE Data SDK for C++, you need to understand the following concepts related to the HERE platform:
 
-- [Catalogs](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/catalogs.html)
-- [Layers](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html)
-- [Partitions](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/partitions.html)
-- [HERE Resource Names (HRNs)](https://developer.here.com/olp/documentation/data-user-guide/shared_content/topics/olp/concepts/hrn.html)
+- [Catalogs](https://developer.here.com/documentation/data-user-guide/portal/layers/catalogs.html)
+- [Layers](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html)
+- [Partitions](https://developer.here.com/documentation/data-user-guide/portal/layers/partitions.html)
+- [HERE Resource Names (HRNs)](https://developer.here.com/documentation/data-user-guide/shared_content/topics/concepts/hrn.html)
 
-For more details, see the [Data User Guide](https://developer.here.com/olp/documentation/data-user-guide/index.html).
+For more details, see the [Data User Guide](https://developer.here.com/documentation/data-user-guide/index.html).
 
 ## Get credentials
 

--- a/docs/OverallArchitecture.md
+++ b/docs/OverallArchitecture.md
@@ -48,21 +48,21 @@ For more information on how to use this module, see the [read and write examples
 The dataservice-read module wraps a subset of the Data REST API related to reading data from platform catalogs. It allows reading of data from the following layer types and with the listed Data APIs:
 
 * Versioned layer. Used Data APIs:
-  * [Config API](https://developer.here.com/olp/documentation/data-store/api-reference-config.html)
-  * [Metadata API](https://developer.here.com/olp/documentation/data-store/api-reference-metadata.html)
-  * [Query API](https://developer.here.com/olp/documentation/data-store/api-reference-query.html)
-  * [Blob API](https://developer.here.com/olp/documentation/data-store/api-reference-blob.html)
+  * [Config API](https://developer.here.com/documentation/data-store/api-reference-config.html)
+  * [Metadata API](https://developer.here.com/documentation/data-store/api-reference-metadata.html)
+  * [Query API](https://developer.here.com/documentation/data-store/api-reference-query.html)
+  * [Blob API](https://developer.here.com/documentation/data-store/api-reference-blob.html)
 * Volatile layer. Used Data APIs:
-  * [Config API](https://developer.here.com/olp/documentation/data-store/api-reference-config.html)
-  * [Metadata API](https://developer.here.com/olp/documentation/data-store/api-reference-metadata.html)
-  * [Query API](https://developer.here.com/olp/documentation/data-store/api-reference-query.html)
-  * [Volatile API](https://developer.here.com/olp/documentation/data-store/api-reference-volatile-blob.html)
+  * [Config API](https://developer.here.com/documentation/data-store/api-reference-config.html)
+  * [Metadata API](https://developer.here.com/documentation/data-store/api-reference-metadata.html)
+  * [Query API](https://developer.here.com/documentation/data-store/api-reference-query.html)
+  * [Volatile API](https://developer.here.com/documentation/data-store/api-reference-volatile-blob.html)
 * Index layer (not supported yet). Used Data APIs:
-  * [Index API](https://developer.here.com/olp/documentation/data-store/api-reference-index.html)
-  * [Blob API](https://developer.here.com/olp/documentation/data-store/api-reference-blob.html)
+  * [Index API](https://developer.here.com/documentation/data-store/api-reference-index.html)
+  * [Blob API](https://developer.here.com/documentation/data-store/api-reference-blob.html)
 * Stream layer. Used Data APIs:
-  * [Stream API](https://developer.here.com/olp/documentation/data-store/api-reference-stream.html)
-  * [Blob API](https://developer.here.com/olp/documentation/data-store/api-reference-blob.html)
+  * [Stream API](https://developer.here.com/documentation/data-store/api-reference-stream.html)
+  * [Blob API](https://developer.here.com/documentation/data-store/api-reference-blob.html)
 
 For more information on how to use this module, see the [read example](dataservice-read-catalog-example.md).
 
@@ -71,18 +71,18 @@ For more information on how to use this module, see the [read example](dataservi
 The dataservice-write module wraps a subset of the Data REST API related to writing data to platform catalogs. It allows writing of data to the following layer types and with the listed Data APIs:
 
 * Versioned layer. Used Data APIs:
-  * [Publish API](https://developer.here.com/olp/documentation/data-store/api-reference-publish.html)
-  * [Blob API](https://developer.here.com/olp/documentation/data-store/api-reference-blob.html)
+  * [Publish API](https://developer.here.com/documentation/data-store/api-reference-publish.html)
+  * [Blob API](https://developer.here.com/documentation/data-store/api-reference-blob.html)
 * Volatile layer. Used Data APIs:
-  * [Publish API](https://developer.here.com/olp/documentation/data-store/api-reference-publish.html)
-  * [Volatile API](https://developer.here.com/olp/documentation/data-store/api-reference-volatile-blob.html)
+  * [Publish API](https://developer.here.com/documentation/data-store/api-reference-publish.html)
+  * [Volatile API](https://developer.here.com/documentation/data-store/api-reference-volatile-blob.html)
 * Index layer. Used Data APIs:
-  * [Index API](https://developer.here.com/olp/documentation/data-store/api-reference-index.html)
-  * [Blob API](https://developer.here.com/olp/documentation/data-store/api-reference-blob.html)
+  * [Index API](https://developer.here.com/documentation/data-store/api-reference-index.html)
+  * [Blob API](https://developer.here.com/documentation/data-store/api-reference-blob.html)
 * Stream layer. Used Data APIs:
-  * [Ingest API](https://developer.here.com/olp/documentation/data-store/api-reference-ingest.html)
-  * [Publish API](https://developer.here.com/olp/documentation/data-store/api-reference-publish.html)
-  * [Blob API](https://developer.here.com/olp/documentation/data-store/api-reference-blob.html)
+  * [Ingest API](https://developer.here.com/documentation/data-store/api-reference-ingest.html)
+  * [Publish API](https://developer.here.com/documentation/data-store/api-reference-publish.html)
+  * [Blob API](https://developer.here.com/documentation/data-store/api-reference-blob.html)
 
 For more information on how to use this module, see the [write example](dataservice-write-example.md).
 

--- a/docs/dataservice-cache-example.md
+++ b/docs/dataservice-cache-example.md
@@ -64,7 +64,7 @@ After building and running the example project, you see the following informatio
 
 ### <a name="get-partition-data-mutable"></a>Get data from a versioned layer with a cache
 
-You can get data from a [versioned layer](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html#versioned-layers) with a mutable or protected cache.
+You can get data from a [versioned layer](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html#versioned-layers) with a mutable or protected cache.
 
 **To get data from the versioned layer with mutable cache:**
 

--- a/docs/dataservice-read-catalog-example.md
+++ b/docs/dataservice-read-catalog-example.md
@@ -350,7 +350,7 @@ The `Partition` class contains partition metadata and exposes the following memb
 
 ### Get data from a versioned layer
 
-You can request any data version from a [versioned layer](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html#versioned-layers). When you request a particular version of data from the versioned layer, the partition you receive in the response may have a lower version number than you requested. The version of a layer or partition represents the catalog version in which the layer or partition was last updated.
+You can request any data version from a [versioned layer](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html#versioned-layers). When you request a particular version of data from the versioned layer, the partition you receive in the response may have a lower version number than you requested. The version of a layer or partition represents the catalog version in which the layer or partition was last updated.
 
 **To get data from the versioned layer:**
 

--- a/docs/dataservice-read-from-stream-layer-example.md
+++ b/docs/dataservice-read-from-stream-layer-example.md
@@ -62,7 +62,7 @@ After building and running the example project, you see the following informatio
 
 ### Get data from a stream layer
 
-You can read messages from a [stream layer](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html#stream-layers) if you subscribe to it.
+You can read messages from a [stream layer](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html#stream-layers) if you subscribe to it.
 
 **To get data from the stream layer:**
 

--- a/docs/dataservice-write-example.md
+++ b/docs/dataservice-write-example.md
@@ -168,7 +168,7 @@ If you encounter an error message, for a detailed error description, check the d
 
 ### Publish data to a stream layer
 
-You can create a queue that streams data to data consumers in real time using a [stream layer](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html#stream-layers).
+You can create a queue that streams data to data consumers in real time using a [stream layer](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html#stream-layers).
 
 **To publish data to the stream layer:**
 

--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationCredentials.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationCredentials.h
@@ -39,7 +39,7 @@ namespace authentication {
  *
  * For instructions on how to get the access keys, see
  * the [Get
- * Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html)
+ * Credentials](https://developer.here.com/documentation/access-control/user-guide/topics/get-credentials.html)
  * section in the Terms and Permissions User Guide.
  */
 class AUTHENTICATION_API AuthenticationCredentials {
@@ -71,7 +71,7 @@ class AUTHENTICATION_API AuthenticationCredentials {
    *
    * For instructions on how to get the **credentials.properties** file, see
    * the [Get
-   * Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html)
+   * Credentials](https://developer.here.com/documentation/access-control/user-guide/topics/get-credentials.html)
    * section in the Terms and Permissions User Guide.
    *
    * @param[in] filename The path to the file that contains the credentials.

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/StreamLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/StreamLayerClient.h
@@ -88,9 +88,9 @@ class StreamLayerClientImpl;
  * @endcode
  *
  * @see The
- * [Layers](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html)
+ * [Layers](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html)
  * section of the Data User Guide and the [Get Data from a Stream
- * Layer](https://developer.here.com/olp/documentation/data-api/data_dev_guide/rest/getting-data-stream.html)
+ * Layer](https://developer.here.com/documentation/data-api/data_dev_guide/rest/getting-data-stream.html)
  * section of the Data API Developer Guide.
  */
 class DATASERVICE_READ_API StreamLayerClient final {

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/SubscribeRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/SubscribeRequest.h
@@ -130,7 +130,7 @@ class DATASERVICE_READ_API SubscribeRequest final {
    * @brief Sets the consumer properties for the request.
    *
    * @see The [Get Data from a Stream
-   * Layer](https://developer.here.com/olp/documentation/data-api/data_dev_guide/rest/getting-data-stream.html)
+   * Layer](https://developer.here.com/documentation/data-api/data_dev_guide/rest/getting-data-stream.html)
    * section in the Data API Developer Guide.
    *
    * @param properties The consumer properties.

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -91,7 +91,7 @@ class VersionedLayerClientImpl;
  *
  * @see
  * The [versioned
- * layer](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html#versioned-layers)
+ * layer](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html#versioned-layers)
  * section in the Data User Guide.
  */
 // clang-format on

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VolatileLayerClient.h
@@ -74,7 +74,7 @@ class VolatileLayerClientImpl;
  *
  * @see
  * The [volatile
- * layer](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html#volatile-layers)
+ * layer](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html#volatile-layers)
  * section in the Data User Guide.
  */
 // clang-format on

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/model/Catalog.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/model/Catalog.h
@@ -359,9 +359,9 @@ class DATASERVICE_READ_API Partitioning {
    * The partitioning scheme can be generic or HERE tile.
    *
    * @see [Generic
-   * Partitioninc](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/partitions.html#generic-partitioning)
+   * Partitioninc](https://developer.here.com/documentation/data-user-guide/portal/layers/partitions.html#generic-partitioning)
    * and [HERE Tile
-   * Partitioning](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/partitions.html#here-tile-partitioning)
+   * Partitioning](https://developer.here.com/documentation/data-user-guide/portal/layers/partitions.html#here-tile-partitioning)
    * sections in the Get Started guide.
    *
    * @return The name of the catalog partitioning scheme.

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/model/Messages.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/model/Messages.h
@@ -43,7 +43,7 @@ class DATASERVICE_READ_API Metadata final {
    * @brief Gets the partition of this metadata.
    *
    * For more information on partitions, see the [related
-   * section](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/partitions.html)
+   * section](https://developer.here.com/documentation/data-user-guide/portal/layers/partitions.html)
    * in the Data User Guide.
    *
    * @return The partition to which this metadata content is related.

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/model/StreamOffsets.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/model/StreamOffsets.h
@@ -67,7 +67,7 @@ class DATASERVICE_READ_API StreamOffset final {
  private:
   /// The partition of the stream layer for which this offset applies. It is not
   /// the same as [Partitions
-  /// object](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/partitions.html).
+  /// object](https://developer.here.com/documentation/data-user-guide/portal/layers/partitions.html).
   int32_t partition_;
 
   /// The offset in the partition of the stream layer.


### PR DESCRIPTION
DHC is about to remove the redirection on their side, so all links like
developer.here.com/olp/documentation should be updated to be
developer.here.com/documentation

Relates-To: OLPEDGE-2442

Signed-off-by: Halyna Dumych <ext-halyna.dumych@here.com>