### PR TITLE
Fix compilation on QNX

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DiskCache.h
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <time.h>
+#include <atomic>
 #include <functional>
 #include <limits>
 #include <map>

--- a/olp-cpp-sdk-core/src/client/repository/ApiCacheRepository.h
+++ b/olp-cpp-sdk-core/src/client/repository/ApiCacheRepository.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,12 @@
 
 #pragma once
 
+#include <time.h>
 #include <memory>
+#include <string>
 
 #include <olp/core/client/HRN.h>
 #include <boost/optional.hpp>
-#include <string>
 
 namespace olp {
 namespace cache {

--- a/olp-cpp-sdk-core/src/utils/Dir.cpp
+++ b/olp-cpp-sdk-core/src/utils/Dir.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,8 +56,8 @@ std::wstring ConvertStringToWideString(const std::string& str) {
                       size_needed);
   return wstr_path;
 }
-#endif // _UNICODE
-#endif // _WIN32 && _MINGW32
+#endif  // _UNICODE
+#endif  // _WIN32 && _MINGW32
 
 #if !defined(_WIN32) || defined(__MINGW32__)
 int remove_dir_callback(const char* file, const struct stat* /*stat*/, int flag,
@@ -127,7 +127,7 @@ static bool mkdir_all(const char* dirname, int mode) {
 
 #if defined(_WIN32) && !defined(__MINGW32__)
 void Tokenize(const std::string& path, const std::string& delimiters,
-                     std::vector<std::string>& result) {
+              std::vector<std::string>& result) {
   std::string sub_path = path;
   while (1) {
     size_t position = sub_path.find(delimiters);
@@ -445,15 +445,14 @@ uint64_t Dir::Size(const std::string& path, FilterFunction filter_fn) {
   struct dirent* ent = nullptr;
 
   if ((dir = opendir(path.c_str())) != nullptr) {
-    int fd = dirfd(dir);
-
     while ((ent = readdir(dir)) != nullptr) {
+      std::string ent_path = path + "/" + ent->d_name;
 #ifdef __APPLE__
       struct stat sb;
-      if (fstatat(fd, ent->d_name, &sb, AT_SYMLINK_NOFOLLOW) == 0) {
+      if (lstat(ent_path.c_str(), &sb) == 0) {
 #else
       struct stat64 sb;
-      if (fstatat64(fd, ent->d_name, &sb, AT_SYMLINK_NOFOLLOW) == 0) {
+      if (lstat64(ent_path.c_str(), &sb) == 0) {
 #endif
         if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0) {
           continue;
@@ -465,7 +464,7 @@ uint64_t Dir::Size(const std::string& path, FilterFunction filter_fn) {
 
         switch (sb.st_mode & S_IFMT) {
           case S_IFDIR:
-            result += Size(ent->d_name, filter_fn);
+            result += Size(ent_path, filter_fn);
             break;
           case S_IFREG:
             result += sb.st_size;

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -17,6 +17,7 @@
 
 
 set(OLP_SDK_FUNCTIONAL_TESTS_SOURCES
+    ./olp-cpp-sdk-core/DirTest.cpp
     ./olp-cpp-sdk-core/OlpClientDefaultAsyncHttpTest.cpp
     ./olp-cpp-sdk-dataservice-read/ApiTest.cpp
     ./olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp

--- a/tests/functional/olp-cpp-sdk-core/DirTest.cpp
+++ b/tests/functional/olp-cpp-sdk-core/DirTest.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <olp/core/utils/Dir.h>
+#include <fstream>
+#if !defined(_WIN32) || defined(__MINGW32__)
+#include <unistd.h>
+#else
+#include <windows.h>
+#endif
+
+namespace {
+using Dir = olp::utils::Dir;
+
+#if defined(_WIN32) && !defined(__MINGW32__)
+const char kSeparator[] = "\\";
+#else
+const char kSeparator[] = "/";
+#endif
+
+void CreateFile(const std::string& path, size_t size) {
+  std::ofstream file(path.c_str(), std::ios::out | std::ios::binary);
+  file.seekp(size - 1);
+  file.write("", 1);
+  file.close();
+}
+
+void CreateDirectory(const std::string& path) { Dir::Create(path); }
+
+void CreateSymLink(const std::string& to, const std::string& link) {
+#if !defined(_WIN32) || defined(__MINGW32__)
+  symlink(to.c_str(), link.c_str());
+#else
+  CreateSymbolicLink(to.c_str(), link.c_str(), 0);
+#endif
+}
+
+std::string PathBuild(std::string arg) { return arg; }
+
+template <typename... Ts>
+std::string PathBuild(std::string arg1, std::string arg2, Ts... args) {
+  return PathBuild(std::string(arg1) + kSeparator + std::string(arg2), args...);
+}
+
+}  // namespace
+
+TEST(DirTest, CheckDirSize) {
+  std::string path = PathBuild(Dir::TempDirectory(), "temporary_test_dir");
+  Dir::Remove(path);
+  CreateDirectory(path);
+  {
+    SCOPED_TRACE("Single file");
+    CreateFile(PathBuild(path, "file1"), 10);
+    EXPECT_EQ(Dir::Size(path), 10u);
+  }
+  {
+    SCOPED_TRACE("First level subdirectory");
+    CreateDirectory(PathBuild(path, "sub"));
+    CreateFile(PathBuild(path, "sub", "sub_file1"), 10);
+    EXPECT_EQ(Dir::Size(path), 20u);
+  }
+  {
+    SCOPED_TRACE("Second level subdirectory");
+    CreateDirectory(PathBuild(path, "sub", "subsub"));
+    CreateFile(PathBuild(path, "sub", "subsub", "subsub_file1"), 10);
+    EXPECT_EQ(Dir::Size(path), 30u);
+  }
+  {
+    SCOPED_TRACE("Symbolic links to directory and file");
+    CreateSymLink("sub", PathBuild(path, "sub_lnk"));
+    CreateSymLink("file1", PathBuild(path, "file1_lnk"));
+    EXPECT_EQ(Dir::Size(path), 30u);
+  }
+  {
+    SCOPED_TRACE("Second file in directory and subdirectories");
+    CreateFile(PathBuild(path, "file2"), 10);
+    CreateFile(PathBuild(path, "sub", "sub_file2"), 10);
+    CreateFile(PathBuild(path, "sub", "subsub", "subsub_file2"), 10);
+    EXPECT_EQ(Dir::Size(path), 60u);
+  }
+  Dir::Remove(path);
+}


### PR DESCRIPTION
Dir::Size() method switched from using fstatat64() to lstat64() due
to absence of dirfd() function on QNX.

Fixed broken traversal of
subdirectories in Dir::Size().

New suite DirTest added to functional tests with tests for Dir::Size().

Fixed missing includes.

Relates-To: OCMAMQNX-2
Signed-off-by: Jakub Mirek <ext-jakub.mirek@here.com>
