### PR TITLE
README: Update copyright to the current year

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ For details, see <a href="https://github.com/heremaps/here-data-sdk-cpp/blob/mas
 
 ## LICENSE
 
-Copyright (C) 2019–2020 HERE Europe B.V.
+Copyright (C) 2019–2021 HERE Europe B.V.
 
 For license details, see the <a href="https://github.com/heremaps/here-data-sdk-cpp/blob/master/LICENSE" target="_blank">LICENSE</a> file in the root of this project.
 


### PR DESCRIPTION
Copyrights should always be [year of first creation]-[year of last
modification].

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>