### PR TITLE
Fix performance script reporting.

### DIFF
--- a/scripts/linux/nv/gitlab_test_performance.sh
+++ b/scripts/linux/nv/gitlab_test_performance.sh
@@ -79,9 +79,8 @@ git clone --depth=1 https://github.com/brendangregg/FlameGraph
 # test names
 t1=short_test_disk_cache
 t2=short_test_memory_cache
-t3=short_test_null_cache
 
-for archive_name in PrefetchPartitionsFromVersionedLayer.$t1 PrefetchPartitionsFromVersionedLayer.$t2 PrefetchPartitionsFromVersionedLayer.$t3 ReadNPartitionsFromVersionedLayer.$t1 ReadNPartitionsFromVersionedLayer.$t2 ReadNPartitionsFromVersionedLayer.$t3
+for archive_name in PrefetchPartitionsFromVersionedLayer.$t1 PrefetchPartitionsFromVersionedLayer.$t2 ReadNPartitionsFromVersionedLayer.$t1 ReadNPartitionsFromVersionedLayer.$t2
 do
     heaptrack_print --print-leaks \
       --print-flamegraph heaptrack/flamegraph_${archive_name}.data \


### PR DESCRIPTION
The script refers to the old "short_test_null_cache" test flavor and
fails.

Resolves: OLPEDGE-2479

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>