### PR TITLE
Reduce extra quads count for prefetch.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -98,9 +98,12 @@ class PrefetchTilesRepository {
   SubQuadsResult FilterTilesByList(const PrefetchTilesRequest& request,
                                    SubQuadsResult tiles);
 
+  client::NetworkStatistics LoadAggregatedSubQuads(
+      geo::TileKey tile, const SubQuadsResult& tiles, std::int64_t version,
+      client::CancellationContext context);
+
   SubQuadsResponse GetVersionedSubQuads(geo::TileKey tile, int32_t depth,
                                         std::int64_t version,
-                                        bool aggregation_enabled,
                                         client::CancellationContext context);
 
   SubQuadsResponse GetVolatileSubQuads(geo::TileKey tile, int32_t depth,


### PR DESCRIPTION
In case of sparse data we load additional quads, but current algorithm
looks on slice root instead of requested tiles when decides to load
extra metadata. In some cases that is not correct because for all
requested tiles bundles are not that far away.

Volatile client doesn't load extra quads, thus, only versioned client
changed.

Also added the test to cover the issue.

Resolves: OLPEDGE-2454

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>