### PR TITLE
Fix the issue when the nonce is reused for retry

### DIFF
--- a/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.h
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.h
@@ -48,10 +48,11 @@ using SignUpProperties = AuthenticationClient::SignUpProperties;
 using RefreshProperties = AuthenticationClient::RefreshProperties;
 
 using SignInClientCallback = AuthenticationClient::SignInClientCallback;
+using SignInClientResponse = AuthenticationClient::SignInClientResponse;
 using SignInUserCallback = AuthenticationClient::SignInUserCallback;
+using SignInUserResponse = AuthenticationClient::SignInUserResponse;
 using SignUpCallback = AuthenticationClient::SignUpCallback;
 using SignOutUserCallback = AuthenticationClient::SignOutUserCallback;
-using SignInClientResponse = AuthenticationClient::SignInClientResponse;
 
 using TimeResponse = Response<time_t>;
 using TimeCallback = Callback<time_t>;
@@ -133,33 +134,43 @@ class AuthenticationClientImpl final {
 
   client::OlpClient::RequestBodyType GenerateClientBody(
       const SignInProperties& properties);
-  http::NetworkRequest::RequestBodyType GenerateUserBody(
+  client::OlpClient::RequestBodyType GenerateUserBody(
       const UserProperties& properties);
-  http::NetworkRequest::RequestBodyType GenerateFederatedBody(
+  client::OlpClient::RequestBodyType GenerateFederatedBody(
       const FederatedSignInType, const FederatedProperties& properties);
-  http::NetworkRequest::RequestBodyType GenerateRefreshBody(
+  client::OlpClient::RequestBodyType GenerateRefreshBody(
       const RefreshProperties& properties);
-  http::NetworkRequest::RequestBodyType GenerateSignUpBody(
+  client::OlpClient::RequestBodyType GenerateSignUpBody(
       const SignUpProperties& properties);
-  http::NetworkRequest::RequestBodyType GenerateAcceptTermBody(
+  client::OlpClient::RequestBodyType GenerateAcceptTermBody(
       const std::string& reacceptance_token);
   client::OlpClient::RequestBodyType GenerateAuthorizeBody(
       AuthorizeRequest properties);
 
   olp::client::HttpResponse CallAuth(
-      const client::OlpClient& client, client::CancellationContext context,
+      const client::OlpClient& client, const std::string& endpoint,
+      client::CancellationContext context,
       const AuthenticationCredentials& credentials,
-      const SignInProperties& properties, std::time_t timestamp);
+      client::OlpClient::RequestBodyType body, std::time_t timestamp);
+
   SignInResult ParseAuthResponse(int status, std::stringstream& auth_response);
-  SignInClientResponse FindSingInResponseInCache(
-      int status, const std::string& error_message,
+
+  SignInUserResult ParseUserAuthResponse(int status,
+                                         std::stringstream& auth_response);
+
+  template <typename SignInResponseType>
+  boost::optional<SignInResponseType> FindInCache(
       const AuthenticationCredentials& credentials);
+
+  template <typename SignInResponseType>
+  void StoreInCache(const AuthenticationCredentials& credentials,
+                    SignInResponseType);
 
   std::string GenerateUid() const;
 
   client::CancellationToken HandleUserRequest(
       const AuthenticationCredentials& credentials, const std::string& endpoint,
-      const http::NetworkRequest::RequestBodyType& request_body,
+      const client::OlpClient::RequestBodyType& request_body,
       const SignInUserCallback& callback);
 
   std::shared_ptr<SignInCacheType> client_token_cache_;

--- a/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.h
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.h
@@ -78,9 +78,10 @@ inline client::CancellationToken AddTask(
 /*
  * @brief Search in headers date header and return parsed time.
  * @param headers http headers.
- * @return time_t time from headers.
+ * @return optional time_t time from headers.
  */
-std::time_t GetTimestampFromHeaders(const http::Headers& headers);
+boost::optional<std::time_t> GetTimestampFromHeaders(
+    const http::Headers& headers);
 
 /*
  * @brief Parse json document to IntrospectAppResult type.
@@ -131,11 +132,15 @@ std::time_t ParseTime(const std::string& value);
  * authentication settings which could be used for future requests.
  * @param auth_settings authentication settings.
  * @param authentication_settings olp client authentication settings.
+ * @param retry a flag that is used to disable retries the client will make for
+ * requests. For sign in requests we should disable retry since we should not
+ * retry requests with the same nonce value.
  * @return result olp client.
  */
 client::OlpClient CreateOlpClient(
     const AuthenticationSettings& auth_settings,
-    boost::optional<client::AuthenticationSettings> authentication_settings);
+    boost::optional<client::AuthenticationSettings> authentication_settings,
+    bool retry = true);
 
 /*
  * @brief Generate authorization header.

--- a/olp-cpp-sdk-core/include/olp/core/client/ApiError.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiError.h
@@ -36,6 +36,26 @@ namespace client {
  */
 class CORE_API ApiError {
  public:
+  /**
+   * @brief Creates the `ApiError` instance with the cancelled error code and
+   * description.
+   * @param description The optional description.
+   * @return The `ApiError` instance.
+   */
+  static ApiError Cancelled(const char* description = "Cancelled") {
+    return ApiError(ErrorCode::Cancelled, description);
+  }
+
+  /**
+   * @brief Creates the `ApiError` instance with the network connection error
+   * code and description.
+   * @param description The optional description.
+   * @return The `ApiError` instance.
+   */
+  static ApiError NetworkConnection(const char* description = "Offline") {
+    return ApiError(ErrorCode::NetworkConnection, description);
+  }
+
   ApiError() = default;
 
   /**
@@ -70,7 +90,7 @@ class CORE_API ApiError {
    * @param http_status_code The HTTP status code returned by the server.
    * @param message The text message of the error.
    */
-  ApiError(int http_status_code, std::string message = "") // NOLINT
+  ApiError(int http_status_code, std::string message = "")  // NOLINT
       : error_code_(http::HttpStatusCode::GetErrorCode(http_status_code)),
         http_status_code_(http_status_code),
         message_(std::move(message)),


### PR DESCRIPTION
The retry functionality moved from OlpClient to the 
AuthenticationClientImpl. This enables the client to generate a new
Authentication header with a new nonce for each retry request.
Adapt SignIn methods to use sync API.
Add a fallback for a wrong timestamp for user sign-in methods.
Added static methods to ApiError class, used to create common
ApiError instances.

Relates-To: OLPSUP-13370

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>