### PR TITLE
Add merging of same requests in sync OlpClient:CallApi()

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
@@ -135,6 +135,7 @@ class CORE_API HttpResponse {
       // solution as a second step.
       response.str(other.response.str());
     }
+    network_statistics_ = other.GetNetworkStatistics();
   }
 
   /**
@@ -150,6 +151,7 @@ class CORE_API HttpResponse {
       status = other.status;
       response << other.response.rdbuf();
       headers = other.headers;
+      network_statistics_ = other.GetNetworkStatistics();
     }
 
     return *this;

--- a/olp-cpp-sdk-core/src/client/PendingUrlRequests.h
+++ b/olp-cpp-sdk-core/src/client/PendingUrlRequests.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,6 +89,13 @@ class PendingUrlRequest {
 
   /// Will be called when the Network response arrives.
   void OnRequestCompleted(HttpResponse response);
+
+  /// Returns request's status. It is 'true' for merged requests or for requests
+  /// that are waiting for the Network callback
+  bool IsPending() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return http_request_id_ != kInvalidRequestId || callbacks_.size() > 1u;
+  }
 
  private:
   /// Keeping the class thread safe.

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -28,7 +28,6 @@
 #include <olp/core/logging/Log.h>
 #include "CatalogRepository.h"
 #include "DataCacheRepository.h"
-#include "NamedMutex.h"
 #include "PartitionsCacheRepository.h"
 #include "PartitionsRepository.h"
 #include "generated/api/BlobApi.h"
@@ -130,14 +129,6 @@ BlobApi::DataResponse DataRepository::GetBlobData(
 
   if (!data_handle) {
     return {{client::ErrorCode::PreconditionFailed, "Data handle is missing"}};
-  }
-
-  NamedMutex mutex(catalog_.ToString() + layer + *data_handle);
-  std::unique_lock<NamedMutex> lock(mutex, std::defer_lock);
-
-  // If we are not planning to go online or access the cache, do not lock.
-  if (fetch_option != CacheOnly && fetch_option != OnlineOnly) {
-    lock.lock();
   }
 
   repository::DataCacheRepository repository(

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
@@ -230,18 +230,20 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyFound) {
 
 TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled1) {
   olp::client::CancellationContext context;
+  std::thread cancel_thread;
 
   auto request = read::CatalogVersionRequest();
 
   std::promise<bool> cancelled;
 
   ON_CALL(*network_, Send(IsGetRequest(kLookupMetadata), _, _, _, _))
-      .WillByDefault([&context](olp::http::NetworkRequest,
-                                olp::http::Network::Payload,
-                                olp::http::Network::Callback,
-                                olp::http::Network::HeaderCallback,
-                                olp::http::Network::DataCallback) {
-        std::thread([&context]() { context.CancelOperation(); }).detach();
+      .WillByDefault([&context, &cancel_thread](
+                         olp::http::NetworkRequest, olp::http::Network::Payload,
+                         olp::http::Network::Callback,
+                         olp::http::Network::HeaderCallback,
+                         olp::http::Network::DataCallback) {
+        cancel_thread =
+            std::thread([&context]() { context.CancelOperation(); });
 
         constexpr auto unused_request_id = 5;
         return olp::http::SendOutcome(unused_request_id);
@@ -262,6 +264,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled1) {
   repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetLatestVersion(request, context);
 
+  cancel_thread.join();
+
   ASSERT_FALSE(response.IsSuccessful());
   EXPECT_EQ(olp::client::ErrorCode::Cancelled,
             response.GetError().GetErrorCode());
@@ -269,6 +273,7 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled1) {
 
 TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled2) {
   olp::client::CancellationContext context;
+  std::thread cancel_thread;
 
   auto request = read::CatalogVersionRequest();
 
@@ -278,11 +283,13 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled2) {
                                         kResponseLookupMetadata));
 
   ON_CALL(*network_, Send(IsGetRequest(kLatestCatalogVersion), _, _, _, _))
-      .WillByDefault([&](olp::http::NetworkRequest, olp::http::Network::Payload,
+      .WillByDefault([&context, &cancel_thread](
+                         olp::http::NetworkRequest, olp::http::Network::Payload,
                          olp::http::Network::Callback,
                          olp::http::Network::HeaderCallback,
                          olp::http::Network::DataCallback) {
-        std::thread([&]() { context.CancelOperation(); }).detach();
+        cancel_thread =
+            std::thread([&context]() { context.CancelOperation(); });
 
         constexpr auto unused_request_id = 10;
         return olp::http::SendOutcome(unused_request_id);
@@ -291,6 +298,8 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled2) {
   ApiLookupClient lookup_client(kHrn, settings_);
   repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetLatestVersion(request, context);
+
+  cancel_thread.join();
 
   ASSERT_FALSE(response.IsSuccessful());
   EXPECT_EQ(olp::client::ErrorCode::Cancelled,
@@ -491,18 +500,20 @@ TEST_F(CatalogRepositoryTest, GetCatalogCancelledBeforeExecution) {
 
 TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled1) {
   olp::client::CancellationContext context;
+  std::thread cancel_thread;
 
   auto request = read::CatalogRequest();
 
   std::promise<bool> cancelled;
 
   ON_CALL(*network_, Send(IsGetRequest(kUrlLookupConfig), _, _, _, _))
-      .WillByDefault([&context](olp::http::NetworkRequest,
-                                olp::http::Network::Payload,
-                                olp::http::Network::Callback,
-                                olp::http::Network::HeaderCallback,
-                                olp::http::Network::DataCallback) {
-        std::thread([&context]() { context.CancelOperation(); }).detach();
+      .WillByDefault([&context, &cancel_thread](
+                         olp::http::NetworkRequest, olp::http::Network::Payload,
+                         olp::http::Network::Callback,
+                         olp::http::Network::HeaderCallback,
+                         olp::http::Network::DataCallback) {
+        cancel_thread =
+            std::thread([&context]() { context.CancelOperation(); });
 
         constexpr auto unused_request_id = 5;
         return olp::http::SendOutcome(unused_request_id);
@@ -523,6 +534,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled1) {
   repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetCatalog(request, context);
 
+  cancel_thread.join();
+
   ASSERT_FALSE(response.IsSuccessful());
   EXPECT_EQ(olp::client::ErrorCode::Cancelled,
             response.GetError().GetErrorCode());
@@ -530,6 +543,7 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled1) {
 
 TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled2) {
   olp::client::CancellationContext context;
+  std::thread cancel_thread;
 
   auto request = read::CatalogRequest();
 
@@ -539,11 +553,13 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled2) {
                                         kResponseLookupConfig));
 
   ON_CALL(*network_, Send(IsGetRequest(kUrlConfig), _, _, _, _))
-      .WillByDefault([&](olp::http::NetworkRequest, olp::http::Network::Payload,
+      .WillByDefault([&context, &cancel_thread](
+                         olp::http::NetworkRequest, olp::http::Network::Payload,
                          olp::http::Network::Callback,
                          olp::http::Network::HeaderCallback,
                          olp::http::Network::DataCallback) {
-        std::thread([&]() { context.CancelOperation(); }).detach();
+        cancel_thread =
+            std::thread([&context]() { context.CancelOperation(); });
 
         constexpr auto unused_request_id = 10;
         return olp::http::SendOutcome(unused_request_id);
@@ -552,6 +568,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled2) {
   ApiLookupClient lookup_client(kHrn, settings_);
   repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetCatalog(request, context);
+
+  cancel_thread.join();
 
   ASSERT_FALSE(response.IsSuccessful());
   EXPECT_EQ(olp::client::ErrorCode::Cancelled,

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,13 +202,13 @@ class AuthenticationClientTest : public ::testing::Test {
               if (payload) {
                 *payload << data;
               }
-              callback(olp::http::NetworkResponse()
-                           .WithRequestId(request_id)
-                           .WithStatus(http));
+
               if (data_callback) {
                 auto raw = const_cast<char*>(data.c_str());
                 data_callback(reinterpret_cast<uint8_t*>(raw), 0, data.size());
               }
+
+              callback(olp::http::NetworkResponse().WithStatus(http));
 
               return olp::http::SendOutcome(request_id);
             });
@@ -349,17 +349,20 @@ TEST_F(AuthenticationClientTest, SignInClientUseWrongLocalTime) {
         if (payload) {
           *payload << kResponseWrongTimestamp;
         }
-        callback(olp::http::NetworkResponse()
-                     .WithRequestId(request_id)
-                     .WithStatus(olp::http::HttpStatusCode::UNAUTHORIZED));
+
         if (data_callback) {
           auto raw = const_cast<char*>(kResponseWrongTimestamp.c_str());
           data_callback(reinterpret_cast<uint8_t*>(raw), 0,
                         kResponseWrongTimestamp.size());
         }
+
         if (header_callback) {
           header_callback(kDate, kDateHeader);
         }
+
+        callback(olp::http::NetworkResponse()
+                     .WithRequestId(request_id)
+                     .WithStatus(olp::http::HttpStatusCode::UNAUTHORIZED));
 
         return olp::http::SendOutcome(request_id);
       })


### PR DESCRIPTION
Merges same requests in sync OlpClient:CallApi

Originally sync & async CallApi implementations were different:

-async merged same requests (added callbacks to the PendingUrlTasks);

-sync simply sent a request as is. To prevent concurrent sync
requests the workaround with the NamedMutex was used.

This commit improves the sync CallApi. Now it triggers internally
async implementation.
So same requests will add callbacks to the PendingUrlTasks for
any CallApi calls, and NamedMutex workaround does not need in
most cases (the only exception is ApiClientLookup::LookupApi).

Relates-To: OLPEDGE-2417

Signed-off-by: Iuliia Moroz <ext-iuliia.moroz@here.com>