### PR TITLE
Apply flush flag to leveldb operations

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DiskCache.h
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.h
@@ -165,6 +165,7 @@ class DiskCache {
   std::unique_ptr<LevelDBLogger> leveldb_logger_;
   uint64_t max_size_{kSizeMax};
   bool check_crc_{false};
+  bool enforce_immediate_flush_{false};
   /// Used to sync database_->CompactRange() calls.
   std::atomic<bool> compacting_{false};
   /// Used to asynchronously call database_->CompactRange().


### PR DESCRIPTION
Set WriteOptions::sync flag to CacheSettings::enforce_immidiate_flush.
This fixes the issue when some data is lost when mutable cache is
closed and then open a protected.

Relates-To: OLPSUP-13397

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>