### PR TITLE
Add SignInApple to Authentication API

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 
+#include <olp/authentication/AppleSignInProperties.h>
 #include <olp/authentication/AuthenticationApi.h>
 #include <olp/authentication/AuthenticationCredentials.h>
 #include <olp/authentication/AuthenticationError.h>
@@ -433,6 +434,23 @@ class AUTHENTICATION_API AuthenticationClient {
       const SignInUserCallback& callback);
 
   /**
+   * @brief Signs in with your valid Apple token and requests your user access
+   * token.
+   *
+   * @param sign_in_properties The `AppleSignInProperties` instance.
+   * @param callback The `SignInUserCallback` method that is called when
+   * the user sign-in request is completed. If successful, the returned HTTP
+   * status is 200. If a new account is created as a part of the sign-in
+   * request, and terms must be accepted, the returned HTTP status is 201.
+   * Otherwise, check the response error.
+   *
+   * @return The `CancellationToken` instance that can be used to cancel
+   * the request.
+   */
+  client::CancellationToken SignInApple(AppleSignInProperties properties,
+                                        SignInUserCallback callback);
+
+  /**
    * @brief Signs in with the refresh token.
    *
    * Exchanges the user access token and refresh token for a new user access
@@ -494,7 +512,7 @@ class AUTHENTICATION_API AuthenticationClient {
    * @param credentials The `AuthenticationCredentials` instance.
    * @param reacceptance_token The terms re-acceptance token from the
    * HTTP 412 or HTTP 201 response:
-   * `SignInUserResponse::term_acceptance_token()`.
+   * `SignInUserResult::GetTermAcceptanceToken()`.
    * @param callback The `SignInUserCallback` method that is called when
    * the user sign-in request is completed. If successful, the returned HTTP
    * status is 204. Otherwise, check the response error.

--- a/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
@@ -83,6 +83,11 @@ client::CancellationToken AuthenticationClient::SignInArcGis(
                                 properties, callback);
 }
 
+client::CancellationToken AuthenticationClient::SignInApple(
+    AppleSignInProperties properties, SignInUserCallback callback) {
+  return impl_->SignInApple(std::move(properties), std::move(callback));
+}
+
 client::CancellationToken AuthenticationClient::SignInRefresh(
     const AuthenticationCredentials& credentials,
     const RefreshProperties& properties, const SignInUserCallback& callback) {

--- a/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.h
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.h
@@ -97,6 +97,9 @@ class AuthenticationClientImpl final {
       const FederatedSignInType& type, const FederatedProperties& properties,
       const SignInUserCallback& callback);
 
+  client::CancellationToken SignInApple(AppleSignInProperties properties,
+                                        SignInUserCallback callback);
+
   client::CancellationToken SignInRefresh(
       const AuthenticationCredentials& credentials,
       const RefreshProperties& properties, const SignInUserCallback& callback);
@@ -153,18 +156,22 @@ class AuthenticationClientImpl final {
       const AuthenticationCredentials& credentials,
       client::OlpClient::RequestBodyType body, std::time_t timestamp);
 
+  olp::client::HttpResponse CallAuth(const client::OlpClient& client,
+                                     const std::string& endpoint,
+                                     client::CancellationContext context,
+                                     const std::string& auth_header,
+                                     client::OlpClient::RequestBodyType body);
+
   SignInResult ParseAuthResponse(int status, std::stringstream& auth_response);
 
   SignInUserResult ParseUserAuthResponse(int status,
                                          std::stringstream& auth_response);
 
   template <typename SignInResponseType>
-  boost::optional<SignInResponseType> FindInCache(
-      const AuthenticationCredentials& credentials);
+  boost::optional<SignInResponseType> FindInCache(const std::string& key);
 
   template <typename SignInResponseType>
-  void StoreInCache(const AuthenticationCredentials& credentials,
-                    SignInResponseType);
+  void StoreInCache(const std::string& key, SignInResponseType);
 
   std::string GenerateUid() const;
 

--- a/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
@@ -189,7 +189,8 @@ class CORE_API HttpResponse {
   /**
    * @brief Return the response status.
    *
-   * The response status can either be a
+   * The response status can either be an `ErrorCode` if negative or a
+   * `HttpStatusCode` if positive.
    *
    * @return The response status.
    */

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationMockedResponses.h
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationMockedResponses.h
@@ -93,6 +93,9 @@ const std::string kFacebookSigninResponse = R"JSON(
 const std::string kArcgisSigninResponse = R"JSON(
     {"accessToken":"arcgis_grant_token","tokenType":"bearer","expiresIn":3599,"refreshToken":"5j687leur4njgb4osomifn55p0","userId":"HERE-5fa10eda-39ff-4cbc-9b0c-5acba4685649"}
     )JSON";
+const std::string kAppleSignInResponse = R"JSON(
+    {"accessToken":"apple_grant_token","tokenType":"bearer","expiresIn":3599,"refreshToken":"5j687leur4njgb4osomifn55p0","userId":"HERE-5fa10eda-39ff-4cbc-9b0c-5acba4685649"}
+    )JSON";
 const std::string kSigninUserFirstTimeResponse = R"JSON(
     {"termsReacceptanceToken":"h1.2nIUQOhp7...RfsAVQ==.D3qoGkpNQJm/+64mEcqgJ6ea3eAdBVNBrtzuB...Vmo2Cog/xOw==","url":{"tos":"http://here.com/terms?locale=en-US#mapsTermsDiv","pp":"http://here.com/terms?locale=en-US#privacyPolicyDiv","tosJSON": "http://here.com/terms/?cc=us&lang=en-US&out=json","ppJSON": "http://here.com/privacy/privacy-policy/us/?lang=en-US&out=json"}}
     )JSON";


### PR DESCRIPTION
This is the next step in the Apple Sign-In support.
Using 'AppleSignInProperties' user could sign-in in the HERE services.
Apple id_token will be used as a bearer. For acceptance T&C user still
required to have app_id and app_secret.

Work on this API still in progress thus it may be changed in the future.

Relates-To: OLPEDGE-2483
Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>