### PR TITLE
Fixing commit checker script to exclude newline

### DIFF
--- a/scripts/misc/commit_checker.sh
+++ b/scripts/misc/commit_checker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (C) 2020 HERE Europe B.V.
+# Copyright (C) 2020-2021 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,15 +26,15 @@
 echo "`git log --pretty=format:'%B' -2 | sed '1d' | sed '1d' `" >> commit.log
 
 # Counting number of lines in file
-num_lines=`wc -l commit.log| cut -d'c' -f1` 
+num_lines=`wc -l commit.log | cut -d'c' -f1`
 
 # Loop for every line in file
 for (( line=1; line<=${num_lines}; line++ ))
 do
-    current_line_len=`cat commit.log| sed -n ${line}p |wc -m | sed 's/\ \ \ \ \ \ /''/g' `
+    current_line_len=`cat commit.log | sed -n ${line}p | tr -d '\n\r' | wc -m | sed 's/\ \ \ \ \ \ /''/g' `
     if [ $line -eq 1 ] && [ ${current_line_len} -gt 50 ] ; then
         echo ""
-        echo "ERROR: Title is ${current_line_len} length, so it's too long for title. Expect less than 50 chars !"
+        echo "ERROR: Title is ${current_line_len} length, so it's too long for title. Expect less than or equal to 50 chars !"
         echo ""
         cat commit.log
         echo "----------------------------------------------"
@@ -42,7 +42,7 @@ do
         cat scripts/misc/commit_message_recom.txt
         exit 6
     fi
-    if [ $line -eq 2 ] && [ ${current_line_len} -ne 1 ] ; then
+    if [ $line -eq 2 ] && [ ${current_line_len} -ne 0 ] ; then
         echo ""
         echo "ERROR: Second line in Commit Message is not zero length !"
         echo ""
@@ -52,7 +52,7 @@ do
         cat scripts/misc/commit_message_recom.txt
         exit 5
     fi
-    if [ "$line" -eq 3 ] && ( [ "$current_line_len" -le 2 ] || [ -n "$(cat commit.log | sed -n ${line}p | grep 'See also: ')" ] || [ -n "$(cat commit.log | sed -n ${line}p | grep 'Relates-To: ')" ] || [ -n "$(cat commit.log | sed -n ${line}p | grep 'Resolves: ')" ] ) ; then
+    if [ "$line" -eq 3 ] && ( [ "$current_line_len" -le 1 ] || [ -n "$(cat commit.log | sed -n ${line}p | grep 'See also: ')" ] || [ -n "$(cat commit.log | sed -n ${line}p | grep 'Relates-To: ')" ] || [ -n "$(cat commit.log | sed -n ${line}p | grep 'Resolves: ')" ] ) ; then
         echo ""
         echo "ERROR: No details added to commit message besides title and ticket reference!"
         echo ""
@@ -64,7 +64,7 @@ do
     fi
     if [ ${current_line_len} -gt 72 ] ; then
         echo ""
-        echo "ERROR: ${current_line_len} chars in ${line}-th line is too long. Any line length must be less than 72 chars !"
+        echo "ERROR: ${current_line_len} chars in ${line}-th line is too long. Any line length must be less than or equal to 72 chars !"
         echo ""
         cat commit.log
         echo "----------------------------------------------"


### PR DESCRIPTION
Current implementation takes newline symbols (\n, \r) into account
during evaluation of the line length

Relates-To: OLPEDGE-2411
Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>