### PR TITLE
Does not resize output for an empty response

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
@@ -168,7 +168,10 @@ class CORE_API HttpResponse {
    */
   void GetResponse(std::vector<unsigned char>& output) {
     response.seekg(0, std::ios::end);
-    output.resize(response.tellg());
+    const auto pos = response.tellg();
+    if (pos > 0) {
+      output.resize(pos);
+    }
     response.seekg(0, std::ios::beg);
     response.read(reinterpret_cast<char*>(output.data()), output.size());
     response.seekg(0, std::ios::beg);


### PR DESCRIPTION
Adds additional checks to prevent crash and does not
resize an output buffer in case of an empty HttpResponse
with HttpStatusCode::OK

Relates-To: OLPEDGE-2417

Signed-off-by: Iuliia Moroz <ext-iuliia.moroz@here.com>