### PR TITLE
Revert "Merges same requests in sync CallApi (#1166)"

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
@@ -135,7 +135,6 @@ class CORE_API HttpResponse {
       // solution as a second step.
       response.str(other.response.str());
     }
-    network_statistics_ = other.GetNetworkStatistics();
   }
 
   /**
@@ -151,7 +150,6 @@ class CORE_API HttpResponse {
       status = other.status;
       response << other.response.rdbuf();
       headers = other.headers;
-      network_statistics_ = other.GetNetworkStatistics();
     }
 
     return *this;

--- a/olp-cpp-sdk-core/src/client/OlpClient.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,6 @@ struct RequestSettings {
   std::chrono::milliseconds accumulated_wait_time{0};
   std::chrono::milliseconds current_backdown_period{0};
   const std::chrono::milliseconds max_wait_time{0};
-  olp::client::NetworkStatistics accumulated_statistics;
 };
 }  // namespace
 
@@ -89,6 +88,10 @@ HttpResponse ToHttpResponse(const http::NetworkResponse& response) {
 HttpResponse ToHttpResponse(const http::SendOutcome& outcome) {
   return {static_cast<int>(outcome.GetErrorCode()),
           http::ErrorCodeToString(outcome.GetErrorCode())};
+}
+
+bool StatusSuccess(int status) {
+  return status >= 0 && status < http::HttpStatusCode::BAD_REQUEST;
 }
 
 bool CaseInsensitiveCompare(const std::string& str1, const std::string& str2) {
@@ -134,13 +137,15 @@ void ExecuteSingleRequest(const std::shared_ptr<http::Network>& network,
         request, response_body,
         [=](const http::NetworkResponse& response) {
           auto status = response.GetStatus();
+          if (!StatusSuccess(status)) {
+            response_body->str(
+                response.GetError().empty()
+                    ? "Error occurred, please check HTTP status code"
+                    : response.GetError());
+          }
 
-          HttpResponse http_response{status, std::move(*response_body),
-                                     std::move(*headers)};
-          http_response.SetNetworkStatistics(
-              {response.GetBytesUploaded(), response.GetBytesDownloaded()});
-
-          callback(response.GetRequestId(), std::move(http_response));
+          callback(response.GetRequestId(),
+                   {status, std::move(*response_body), std::move(*headers)});
         },
         [=](std::string key, std::string value) {
           headers->emplace_back(std::move(key), std::move(value));
@@ -153,7 +158,6 @@ void ExecuteSingleRequest(const std::shared_ptr<http::Network>& network,
     }
 
     id = send_outcome.GetRequestId();
-
     return CancellationToken([=] { network->Cancel(id); });
   };
 
@@ -177,7 +181,6 @@ NetworkCallbackType GetRetryCallback(
     const NetworkRequestPtr& request) {
   return [=](const http::RequestId request_id, HttpResponse response) mutable {
     ++settings->current_try;
-    settings->accumulated_statistics += response.GetNetworkStatistics();
 
     if (CheckRetryCondition(*settings, retry_settings, response)) {
       // Response is either successull or retries count/time expired
@@ -187,10 +190,8 @@ NetworkCallbackType GetRetryCallback(
             "Wrong response received, pending_request=%" PRIu64
             ", request_id=%" PRIu64,
             pending_request->GetRequestId(), request_id);
+        return;
       }
-
-      // Set accumulated statistics for all retries
-      response.SetNetworkStatistics(settings->accumulated_statistics);
 
       if (merge) {
         const auto& url = request->GetUrl();
@@ -250,9 +251,79 @@ http::NetworkRequest::HttpVerb GetHttpVerb(const std::string& verb) {
   return http::NetworkRequest::HttpVerb::GET;
 }
 
+HttpResponse SendRequest(const http::NetworkRequest& request,
+                         const olp::client::OlpClientSettings& settings,
+                         const olp::client::RetrySettings& retry_settings,
+                         client::CancellationContext context) {
+  struct ResponseData {
+    Condition condition;
+    http::NetworkResponse response{kCancelledErrorResponse};
+    http::Headers headers;
+  };
+
+  auto response_data = std::make_shared<ResponseData>();
+  auto response_body = std::make_shared<std::stringstream>();
+  http::SendOutcome outcome{http::ErrorCode::CANCELLED_ERROR};
+  const auto timeout = std::chrono::seconds(retry_settings.timeout);
+
+  context.ExecuteOrCancelled(
+      [&]() {
+        outcome = settings.network_request_handler->Send(
+            request, response_body,
+            [response_data](http::NetworkResponse response) {
+              response_data->response = std::move(response);
+              response_data->condition.Notify();
+            },
+            [response_data](std::string key, std::string value) {
+              response_data->headers.emplace_back(std::move(key),
+                                                  std::move(value));
+            });
+
+        if (!outcome.IsSuccessful()) {
+          OLP_SDK_LOG_WARNING_F(kLogTag,
+                                "SendRequest: sending request failed, url=%s",
+                                request.GetUrl().c_str());
+          return CancellationToken();
+        }
+
+        auto request_handler = settings.network_request_handler;
+        auto request_id = outcome.GetRequestId();
+
+        return CancellationToken([=]() {
+          request_handler->Cancel(request_id);
+          response_data->condition.Notify();
+        });
+      },
+      [&]() { response_data->condition.Notify(); });
+
+  if (!outcome.IsSuccessful()) {
+    return ToHttpResponse(outcome);
+  }
+
+  if (!response_data->condition.Wait(timeout)) {
+    OLP_SDK_LOG_WARNING_F(kLogTag, "Request %" PRIu64 " timed out!",
+                          outcome.GetRequestId());
+    context.CancelOperation();
+    return ToHttpResponse(kTimeoutErrorResponse);
+  }
+
+  if (context.IsCancelled()) {
+    return ToHttpResponse(kCancelledErrorResponse);
+  }
+
+  HttpResponse response{response_data->response.GetStatus(),
+                        std::move(*response_body),
+                        std::move(response_data->headers)};
+
+  response.SetNetworkStatistics(GetStatistics(response_data->response));
+
+  return response;
+}
+
 bool IsPending(const PendingUrlRequestPtr& request) {
   // A request is pending when it already triggered a Network call
-  return request && request->IsPending();
+  return request &&
+         request->GetRequestId() != PendingUrlRequest::kInvalidRequestId;
 }
 
 }  // namespace
@@ -466,7 +537,7 @@ HttpResponse OlpClient::OlpClientImpl::CallApi(
     std::string path, std::string method,
     OlpClient::ParametersType query_params,
     OlpClient::ParametersType header_params,
-    OlpClient::ParametersType forms_params,
+    OlpClient::ParametersType /*forms_params*/,
     OlpClient::RequestBodyType post_body, std::string content_type,
     CancellationContext context) const {
   if (!settings_.network_request_handler) {
@@ -474,41 +545,95 @@ HttpResponse OlpClient::OlpClientImpl::CallApi(
                         "Network request handler is empty.");
   }
 
-  struct ResponseData {
-    Condition condition;
-    HttpResponse response = ToHttpResponse(kCancelledErrorResponse);
-  };
+  const auto& retry_settings = settings_.retry_settings;
+  auto network_settings =
+      http::NetworkSettings()
+          .WithTransferTimeout(retry_settings.timeout)
+          .WithConnectionTimeout(retry_settings.timeout)
+          .WithProxySettings(
+              settings_.proxy_settings.value_or(http::NetworkProxySettings()));
 
-  auto response_data = std::make_shared<ResponseData>();
+  auto network_request = http::NetworkRequest(
+      utils::Url::Construct(GetBaseUrl(), path, query_params));
 
-  auto callback = [=](HttpResponse http_response) {
-    response_data->response = std::move(http_response);
-    response_data->condition.Notify();
-  };
+  network_request.WithVerb(GetHttpVerb(method))
+      .WithBody(std::move(post_body))
+      .WithSettings(std::move(network_settings));
 
-  context.ExecuteOrCancelled(
-      [&]() -> client::CancellationToken {
-        auto token = CallApi(path, method, query_params, header_params,
-                             forms_params, post_body, content_type, callback);
-        return CancellationToken([=] {
-          token.Cancel();
-          response_data->condition.Notify();
-        });
-      },
-      [=]() { response_data->condition.Notify(); });
-
-  // We have to wait settings_.retry_settings.timeout for the initial request.
-  // And double this time for retries.
-  const auto timeout =
-      std::chrono::seconds(settings_.retry_settings.timeout *
-                           (settings_.retry_settings.max_attempts ? 2 : 1));
-  if (!response_data->condition.Wait(timeout)) {
-    context.CancelOperation();
-    return ToHttpResponse(kTimeoutErrorResponse);
+  for (const auto& header : default_headers_) {
+    network_request.WithHeader(header.first, header.second);
   }
 
-  return response_data->response;
-}  // namespace client
+  std::string custom_user_agent;
+  for (const auto& header : header_params) {
+    // Merge all User-Agent headers into one header.
+    // This is required for (at least) iOS network implementation,
+    // which uses headers dictionary without any duplicates.
+    // User agents entries are usually separated by a whitespace, e.g.
+    // Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Firefox/47.0
+    if (CaseInsensitiveCompare(header.first, http::kUserAgentHeader)) {
+      custom_user_agent += header.second + std::string(" ");
+    } else {
+      network_request.WithHeader(header.first, header.second);
+    }
+  }
+
+  custom_user_agent += http::kOlpSdkUserAgent;
+  network_request.WithHeader(http::kUserAgentHeader, custom_user_agent);
+
+  if (!content_type.empty()) {
+    network_request.WithHeader(http::kContentTypeHeader, content_type);
+  }
+
+  auto backdown_period =
+      std::chrono::milliseconds(retry_settings.initial_backdown_period);
+
+  AddBearer(query_params.empty(), network_request);
+
+  auto response =
+      SendRequest(network_request, settings_, retry_settings, context);
+
+  NetworkStatistics accumulated_statistics = response.GetNetworkStatistics();
+
+  // Make sure that we don't wait longer than `timeout` in retry settings
+  auto accumulated_wait_time = backdown_period;
+  const auto max_wait_time =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::seconds(retry_settings.timeout));
+  for (int i = 1; i <= retry_settings.max_attempts && !context.IsCancelled() &&
+                  accumulated_wait_time < max_wait_time;
+       i++) {
+    if (StatusSuccess(response.status)) {
+      return response;
+    }
+
+    if (!retry_settings.retry_condition(response)) {
+      return response;
+    }
+
+    // do the periodical sleep and check for cancellation status in between.
+    auto duration_to_sleep =
+        std::min(backdown_period, max_wait_time - accumulated_wait_time);
+    accumulated_wait_time += duration_to_sleep;
+
+    while (duration_to_sleep.count() > 0 && !context.IsCancelled()) {
+      const auto sleep_ms =
+          std::min(std::chrono::milliseconds(1000), duration_to_sleep);
+      std::this_thread::sleep_for(sleep_ms);
+      duration_to_sleep -= sleep_ms;
+    }
+
+    backdown_period = CalculateNextWaitTime(retry_settings, i);
+    response = SendRequest(network_request, settings_, retry_settings, context);
+
+    // In case we retry, accumulate the stats
+    accumulated_statistics += response.GetNetworkStatistics();
+  }
+
+  response.SetNetworkStatistics(accumulated_statistics);
+
+  return response;
+}
 
 OlpClient::OlpClient() : impl_(std::make_shared<OlpClientImpl>()){};
 OlpClient::OlpClient(const OlpClientSettings& settings, std::string base_url)

--- a/olp-cpp-sdk-core/src/client/PendingUrlRequests.h
+++ b/olp-cpp-sdk-core/src/client/PendingUrlRequests.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,13 +89,6 @@ class PendingUrlRequest {
 
   /// Will be called when the Network response arrives.
   void OnRequestCompleted(HttpResponse response);
-
-  /// Returns request's status. It is 'true' for merged requests or for requests
-  /// that are waiting for the Network callback
-  bool IsPending() const {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return http_request_id_ != kInvalidRequestId || callbacks_.size() > 1u;
-  }
 
  private:
   /// Keeping the class thread safe.

--- a/olp-cpp-sdk-core/tests/client/ApiLookupClientImplTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/ApiLookupClientImplTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -316,18 +316,17 @@ TEST_F(ApiLookupClientImplTest, LookupApi) {
   {
     SCOPED_TRACE("Network request cancelled by user");
     client::CancellationContext context;
-    std::thread cancel_job;
     EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
         .Times(1)
-        .WillOnce([&](olp::http::NetworkRequest /*request*/,
+        .WillOnce([=, &context](
+                      olp::http::NetworkRequest /*request*/,
                       olp::http::Network::Payload /*payload*/,
                       olp::http::Network::Callback /*callback*/,
                       olp::http::Network::HeaderCallback /*header_callback*/,
                       olp::http::Network::DataCallback /*data_callback*/)
                       -> olp::http::SendOutcome {
           // spawn a 'user' response of cancelling
-          cancel_job =
-              std::thread([=, &context]() { context.CancelOperation(); });
+          std::thread([&context]() { context.CancelOperation(); }).detach();
 
           // note no network response thread spawns
 
@@ -339,7 +338,6 @@ TEST_F(ApiLookupClientImplTest, LookupApi) {
     client::ApiLookupClientImpl client(catalog_hrn, settings_);
     auto response = client.LookupApi(service_name, service_version,
                                      client::FetchOptions::OnlineOnly, context);
-    cancel_job.join();
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(), client::ErrorCode::Cancelled);

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -28,6 +28,7 @@
 #include <olp/core/logging/Log.h>
 #include "CatalogRepository.h"
 #include "DataCacheRepository.h"
+#include "NamedMutex.h"
 #include "PartitionsCacheRepository.h"
 #include "PartitionsRepository.h"
 #include "generated/api/BlobApi.h"
@@ -129,6 +130,14 @@ BlobApi::DataResponse DataRepository::GetBlobData(
 
   if (!data_handle) {
     return {{client::ErrorCode::PreconditionFailed, "Data handle is missing"}};
+  }
+
+  NamedMutex mutex(catalog_.ToString() + layer + *data_handle);
+  std::unique_lock<NamedMutex> lock(mutex, std::defer_lock);
+
+  // If we are not planning to go online or access the cache, do not lock.
+  if (fetch_option != CacheOnly && fetch_option != OnlineOnly) {
+    lock.lock();
   }
 
   repository::DataCacheRepository repository(

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -27,6 +27,7 @@
 #include <olp/core/client/Condition.h>
 #include <olp/core/logging/Log.h>
 #include "CatalogRepository.h"
+#include "NamedMutex.h"
 #include "generated/api/MetadataApi.h"
 #include "generated/api/QueryApi.h"
 #include "olp/dataservice/read/CatalogRequest.h"
@@ -92,6 +93,16 @@ repository::PartitionResponse FindPartition(
 
   return std::move(aggregated_partition);
 }
+
+std::string HashPartitions(
+    const read::PartitionsRequest::PartitionIds& partitions) {
+  size_t seed = 0;
+  for (const auto& partition : partitions) {
+    boost::hash_combine(seed, partition);
+  }
+  return std::to_string(seed);
+}
+
 }  // namespace
 
 namespace olp {
@@ -156,6 +167,18 @@ PartitionsRepository::GetPartitionsExtendedResponse(
   const auto catalog_str = catalog_.ToCatalogHRNString();
 
   const auto& partition_ids = request.GetPartitionIds();
+
+  // Temporary workaround for merging the same requests. Should be removed after
+  // OlpClient could handle that.
+  const auto detail =
+      partition_ids.empty() ? "" : HashPartitions(partition_ids);
+  NamedMutex mutex(catalog_str + layer_id_ + detail);
+  std::unique_lock<NamedMutex> lock(mutex, std::defer_lock);
+
+  // If we are not planning to go online or access the cache, do not lock.
+  if (fetch_option != CacheOnly && fetch_option != OnlineOnly) {
+    lock.lock();
+  }
 
   if (fetch_option != OnlineOnly && fetch_option != CacheWithUpdate) {
     auto cached_partitions = cache_.Get(request, version);
@@ -243,6 +266,14 @@ PartitionsResponse PartitionsRepository::GetPartitionById(
   const auto request_key =
       catalog_.ToString() + request.CreateKey(layer_id_, version);
 
+  NamedMutex mutex(request_key);
+  std::unique_lock<repository::NamedMutex> lock(mutex, std::defer_lock);
+
+  // If we are not planning to go online or access the cache, do not lock.
+  if (fetch_option != CacheOnly && fetch_option != OnlineOnly) {
+    lock.lock();
+  }
+
   std::chrono::seconds timeout{settings_.retry_settings.timeout};
   const auto key = request.CreateKey(layer_id_, version);
 
@@ -317,6 +348,14 @@ QuadTreeIndexResponse PartitionsRepository::GetQuadTreeIndexForTile(
 
   const auto& root_tile_key = tile_key.ChangedLevelBy(-kAggregateQuadTreeDepth);
   const auto root_tile_here = root_tile_key.ToHereTile();
+
+  NamedMutex mutex(catalog_.ToString() + layer_id_ + root_tile_here + "Index");
+  std::unique_lock<NamedMutex> lock(mutex, std::defer_lock);
+
+  // If we are not planning to go online or access the cache, do not lock.
+  if (fetch_option != CacheOnly && fetch_option != OnlineOnly) {
+    lock.lock();
+  }
 
   // Look for QuadTree covering the tile in the cache
   if (fetch_option != OnlineOnly && fetch_option != CacheWithUpdate) {

--- a/olp-cpp-sdk-dataservice-read/tests/ApiClientLookupTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/ApiClientLookupTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,10 +135,9 @@ TEST(ApiClientLookupTest, LookupApi) {
         .WillOnce([=](olp::http::NetworkRequest /*request*/,
                       olp::http::Network::Payload /*payload*/,
                       olp::http::Network::Callback /*callback*/,
-                      olp::http::Network::HeaderCallback
-                      /*header_callback*/,
-                      olp::http::Network::DataCallback
-                      /*data_callback*/) -> olp::http::SendOutcome {
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/)
+                      -> olp::http::SendOutcome {
           return olp::http::SendOutcome(olp::http::ErrorCode::CANCELLED_ERROR);
         });
 
@@ -159,10 +158,9 @@ TEST(ApiClientLookupTest, LookupApi) {
         .WillOnce([=](olp::http::NetworkRequest /*request*/,
                       olp::http::Network::Payload /*payload*/,
                       olp::http::Network::Callback /*callback*/,
-                      olp::http::Network::HeaderCallback
-                      /*header_callback*/,
-                      olp::http::Network::DataCallback
-                      /*data_callback*/) -> olp::http::SendOutcome {
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/)
+                      -> olp::http::SendOutcome {
           // note no network response thread spawns
           constexpr auto unused_request_id = 12;
           return olp::http::SendOutcome(unused_request_id);
@@ -181,20 +179,17 @@ TEST(ApiClientLookupTest, LookupApi) {
   {
     SCOPED_TRACE("Network request cancelled by user");
     client::CancellationContext context;
-    std::thread cancel_thread;
     EXPECT_CALL(*network, Send(IsGetRequest(lookup_url), _, _, _, _))
         .Times(1)
-        .WillOnce([&context, &cancel_thread](
+        .WillOnce([=, &context](
                       olp::http::NetworkRequest /*request*/,
                       olp::http::Network::Payload /*payload*/,
                       olp::http::Network::Callback /*callback*/,
-                      olp::http::Network::HeaderCallback
-                      /*header_callback*/,
-                      olp::http::Network::DataCallback
-                      /*data_callback*/) -> olp::http::SendOutcome {
+                      olp::http::Network::HeaderCallback /*header_callback*/,
+                      olp::http::Network::DataCallback /*data_callback*/)
+                      -> olp::http::SendOutcome {
           // spawn a 'user' response of cancelling
-          cancel_thread =
-              std::thread([&context]() { context.CancelOperation(); });
+          std::thread([&context]() { context.CancelOperation(); }).detach();
 
           // note no network response thread spawns
 
@@ -206,8 +201,6 @@ TEST(ApiClientLookupTest, LookupApi) {
     auto response = read::ApiClientLookup::LookupApi(
         catalog_hrn, context, service_name, service_version,
         read::FetchOptions::OnlineOnly, settings);
-
-    cancel_thread.join();
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(),

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
@@ -230,20 +230,18 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyFound) {
 
 TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled1) {
   olp::client::CancellationContext context;
-  std::thread cancel_thread;
 
   auto request = read::CatalogVersionRequest();
 
   std::promise<bool> cancelled;
 
   ON_CALL(*network_, Send(IsGetRequest(kLookupMetadata), _, _, _, _))
-      .WillByDefault([&context, &cancel_thread](
-                         olp::http::NetworkRequest, olp::http::Network::Payload,
-                         olp::http::Network::Callback,
-                         olp::http::Network::HeaderCallback,
-                         olp::http::Network::DataCallback) {
-        cancel_thread =
-            std::thread([&context]() { context.CancelOperation(); });
+      .WillByDefault([&context](olp::http::NetworkRequest,
+                                olp::http::Network::Payload,
+                                olp::http::Network::Callback,
+                                olp::http::Network::HeaderCallback,
+                                olp::http::Network::DataCallback) {
+        std::thread([&context]() { context.CancelOperation(); }).detach();
 
         constexpr auto unused_request_id = 5;
         return olp::http::SendOutcome(unused_request_id);
@@ -264,8 +262,6 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled1) {
   repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetLatestVersion(request, context);
 
-  cancel_thread.join();
-
   ASSERT_FALSE(response.IsSuccessful());
   EXPECT_EQ(olp::client::ErrorCode::Cancelled,
             response.GetError().GetErrorCode());
@@ -273,7 +269,6 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled1) {
 
 TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled2) {
   olp::client::CancellationContext context;
-  std::thread cancel_thread;
 
   auto request = read::CatalogVersionRequest();
 
@@ -283,13 +278,11 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled2) {
                                         kResponseLookupMetadata));
 
   ON_CALL(*network_, Send(IsGetRequest(kLatestCatalogVersion), _, _, _, _))
-      .WillByDefault([&context, &cancel_thread](
-                         olp::http::NetworkRequest, olp::http::Network::Payload,
+      .WillByDefault([&](olp::http::NetworkRequest, olp::http::Network::Payload,
                          olp::http::Network::Callback,
                          olp::http::Network::HeaderCallback,
                          olp::http::Network::DataCallback) {
-        cancel_thread =
-            std::thread([&context]() { context.CancelOperation(); });
+        std::thread([&]() { context.CancelOperation(); }).detach();
 
         constexpr auto unused_request_id = 10;
         return olp::http::SendOutcome(unused_request_id);
@@ -298,8 +291,6 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyUserCancelled2) {
   ApiLookupClient lookup_client(kHrn, settings_);
   repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetLatestVersion(request, context);
-
-  cancel_thread.join();
 
   ASSERT_FALSE(response.IsSuccessful());
   EXPECT_EQ(olp::client::ErrorCode::Cancelled,
@@ -500,20 +491,18 @@ TEST_F(CatalogRepositoryTest, GetCatalogCancelledBeforeExecution) {
 
 TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled1) {
   olp::client::CancellationContext context;
-  std::thread cancel_thread;
 
   auto request = read::CatalogRequest();
 
   std::promise<bool> cancelled;
 
   ON_CALL(*network_, Send(IsGetRequest(kUrlLookupConfig), _, _, _, _))
-      .WillByDefault([&context, &cancel_thread](
-                         olp::http::NetworkRequest, olp::http::Network::Payload,
-                         olp::http::Network::Callback,
-                         olp::http::Network::HeaderCallback,
-                         olp::http::Network::DataCallback) {
-        cancel_thread =
-            std::thread([&context]() { context.CancelOperation(); });
+      .WillByDefault([&context](olp::http::NetworkRequest,
+                                olp::http::Network::Payload,
+                                olp::http::Network::Callback,
+                                olp::http::Network::HeaderCallback,
+                                olp::http::Network::DataCallback) {
+        std::thread([&context]() { context.CancelOperation(); }).detach();
 
         constexpr auto unused_request_id = 5;
         return olp::http::SendOutcome(unused_request_id);
@@ -534,8 +523,6 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled1) {
   repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetCatalog(request, context);
 
-  cancel_thread.join();
-
   ASSERT_FALSE(response.IsSuccessful());
   EXPECT_EQ(olp::client::ErrorCode::Cancelled,
             response.GetError().GetErrorCode());
@@ -543,7 +530,6 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled1) {
 
 TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled2) {
   olp::client::CancellationContext context;
-  std::thread cancel_thread;
 
   auto request = read::CatalogRequest();
 
@@ -553,13 +539,11 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled2) {
                                         kResponseLookupConfig));
 
   ON_CALL(*network_, Send(IsGetRequest(kUrlConfig), _, _, _, _))
-      .WillByDefault([&context, &cancel_thread](
-                         olp::http::NetworkRequest, olp::http::Network::Payload,
+      .WillByDefault([&](olp::http::NetworkRequest, olp::http::Network::Payload,
                          olp::http::Network::Callback,
                          olp::http::Network::HeaderCallback,
                          olp::http::Network::DataCallback) {
-        cancel_thread =
-            std::thread([&context]() { context.CancelOperation(); });
+        std::thread([&]() { context.CancelOperation(); }).detach();
 
         constexpr auto unused_request_id = 10;
         return olp::http::SendOutcome(unused_request_id);
@@ -568,8 +552,6 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyUserCancelled2) {
   ApiLookupClient lookup_client(kHrn, settings_);
   repository::CatalogRepository repository(kHrn, settings_, lookup_client);
   auto response = repository.GetCatalog(request, context);
-
-  cancel_thread.join();
 
   ASSERT_FALSE(response.IsSuccessful());
   EXPECT_EQ(olp::client::ErrorCode::Cancelled,

--- a/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
@@ -248,17 +248,13 @@ TEST_F(DataRepositoryTest, GetBlobDataInProgressCancel) {
                                    kUrlResponseLookup));
 
   olp::client::CancellationContext context;
-  std::thread cancel_thread;
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(kUrlBlobData269), _, _, _, _))
       .WillOnce(
-          [&context, &cancel_thread](
-              olp::http::NetworkRequest, olp::http::Network::Payload,
+          [&](olp::http::NetworkRequest, olp::http::Network::Payload,
               olp::http::Network::Callback, olp::http::Network::HeaderCallback,
               olp::http::Network::DataCallback) -> olp::http::SendOutcome {
-            cancel_thread =
-                std::thread([&context]() { context.CancelOperation(); });
-
+            std::thread([&]() { context.CancelOperation(); }).detach();
             constexpr auto unused_request_id = 12;
             return olp::http::SendOutcome(unused_request_id);
           });
@@ -272,8 +268,6 @@ TEST_F(DataRepositoryTest, GetBlobDataInProgressCancel) {
   ApiLookupClient lookup_client(hrn, *settings_);
   DataRepository repository(hrn, *settings_, lookup_client);
   auto response = repository.GetBlobData(kLayerId, kService, request, context);
-
-  cancel_thread.join();
 
   ASSERT_EQ(response.GetError().GetErrorCode(),
             olp::client::ErrorCode::Cancelled);
@@ -408,18 +402,14 @@ TEST_F(DataRepositoryTest, GetVersionedDataTileInProgressCancel) {
                                    kUrlResponseLookup));
 
   olp::client::CancellationContext context;
-  std::thread cancel_thread;
 
   EXPECT_CALL(*network_mock_,
               Send(IsGetRequest(kUrlQueryTreeIndex), _, _, _, _))
       .WillOnce(
-          [&context, &cancel_thread](
-              olp::http::NetworkRequest, olp::http::Network::Payload,
+          [&](olp::http::NetworkRequest, olp::http::Network::Payload,
               olp::http::Network::Callback, olp::http::Network::HeaderCallback,
               olp::http::Network::DataCallback) -> olp::http::SendOutcome {
-            cancel_thread =
-                std::thread([&context]() { context.CancelOperation(); });
-
+            std::thread([&]() { context.CancelOperation(); }).detach();
             constexpr auto unused_request_id = 12;
             return olp::http::SendOutcome(unused_request_id);
           });
@@ -436,8 +426,6 @@ TEST_F(DataRepositoryTest, GetVersionedDataTileInProgressCancel) {
   DataRepository repository(hrn, *settings_, lookup_client);
   auto response =
       repository.GetVersionedTile(kLayerId, request, version, context);
-
-  cancel_thread.join();
 
   ASSERT_EQ(response.GetError().GetErrorCode(),
             olp::client::ErrorCode::Cancelled);

--- a/olp-cpp-sdk-dataservice-write/tests/StreamLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/StreamLayerClientImplTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,53 +143,6 @@ class StreamLayerClientImplTest : public ::testing::Test {
 
     network_.reset();
     cache_.reset();
-  }
-
-  void CheckCancelOnRequest(const std::string& request_url,
-                            const std::string& response_body = "") {
-    auto data = std::make_shared<std::vector<unsigned char>>(1, 'a');
-    auto request =
-        model::PublishDataRequest().WithData(data).WithLayerId(kLayerName);
-
-    auto settings = settings_;
-    settings.cache = client::OlpClientSettingsFactory::CreateDefaultCache({});
-
-    MockStreamLayerClientImpl client{kHrn, write::StreamLayerClientSettings{},
-                                     settings};
-
-    EXPECT_CALL(*network_, Cancel(_)).Times(1);
-
-    auto cancel_context = std::make_shared<client::CancellationContext>();
-    auto cancel_request = [cancel_context](olp::http::NetworkRequest,
-                                           olp::http::Network::Payload,
-                                           olp::http::Network::Callback,
-                                           olp::http::Network::HeaderCallback,
-                                           olp::http::Network::DataCallback) {
-      std::thread([cancel_context]() { cancel_context->CancelOperation(); })
-          .detach();
-
-      constexpr auto unused_request_id = 5;
-      return olp::http::SendOutcome(unused_request_id);
-    };
-
-    if (response_body.empty()) {
-      EXPECT_CALL(*network_, Send(IsPostRequest(request_url), _, _, _, _))
-          .WillOnce(cancel_request);
-    } else {
-      EXPECT_CALL(*network_, Send(IsGetRequest(request_url), _, _, _, _))
-          .WillOnce(cancel_request)
-          .WillRepeatedly(
-              ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                     olp::http::HttpStatusCode::OK),
-                                 response_body));
-    }
-
-    auto response =
-        client.PublishDataLessThanTwentyMib(request, *cancel_context);
-
-    EXPECT_FALSE(response.IsSuccessful());
-    EXPECT_EQ(olp::client::ErrorCode::Cancelled,
-              response.GetError().GetErrorCode());
   }
 
   std::shared_ptr<CacheMock> cache_;
@@ -388,18 +341,17 @@ TEST_F(StreamLayerClientImplTest, FaliedPublishDataLessThanTwentyMib) {
 }
 
 TEST_F(StreamLayerClientImplTest, CancelPublishDataLessThanTwentyMib) {
+  auto data = std::make_shared<std::vector<unsigned char>>(1, 'a');
+  auto request =
+      model::PublishDataRequest().WithData(data).WithLayerId(kLayerName);
+
+  auto settings = settings_;
+  settings.cache = client::OlpClientSettingsFactory::CreateDefaultCache({});
+
+  MockStreamLayerClientImpl client{kHrn, write::StreamLayerClientSettings{},
+                                   settings};
   {
     SCOPED_TRACE("Cancelled before publish call");
-
-    auto data = std::make_shared<std::vector<unsigned char>>(1, 'a');
-    auto request =
-        model::PublishDataRequest().WithData(data).WithLayerId(kLayerName);
-
-    auto settings = settings_;
-    settings.cache = client::OlpClientSettingsFactory::CreateDefaultCache({});
-
-    MockStreamLayerClientImpl client{kHrn, write::StreamLayerClientSettings{},
-                                     settings};
 
     client::CancellationContext cancel_context;
     cancel_context.CancelOperation();
@@ -412,6 +364,22 @@ TEST_F(StreamLayerClientImplTest, CancelPublishDataLessThanTwentyMib) {
               response.GetError().GetErrorCode());
   }
 
+  EXPECT_CALL(*network_, Cancel(_)).Times(4);
+
+  auto cancel_context = std::make_shared<client::CancellationContext>();
+  auto cancel_request = [cancel_context](olp::http::NetworkRequest,
+                                         olp::http::Network::Payload,
+                                         olp::http::Network::Callback,
+                                         olp::http::Network::HeaderCallback,
+                                         olp::http::Network::DataCallback) {
+    std::thread([cancel_context]() {
+      cancel_context->CancelOperation();
+    }).detach();
+
+    constexpr auto unused_request_id = 5;
+    return olp::http::SendOutcome(unused_request_id);
+  };
+
   // Current expectations on NetworkMock will first cancel a response
   // and after each subsequent request with same URL will return correct
   // response. So, no need to clear mock expectations after each scoped trace,
@@ -419,25 +387,78 @@ TEST_F(StreamLayerClientImplTest, CancelPublishDataLessThanTwentyMib) {
   {
     SCOPED_TRACE("Cancelled on getting a config");
 
-    CheckCancelOnRequest(kConfigRequestUrl, kConfigHttpResponse);
+    EXPECT_CALL(*network_, Send(IsGetRequest(kConfigRequestUrl), _, _, _, _))
+        .WillOnce(cancel_request)
+        .WillRepeatedly(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                   olp::http::HttpStatusCode::OK),
+                               kConfigHttpResponse));
+
+    auto response =
+        client.PublishDataLessThanTwentyMib(request, *cancel_context);
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+              response.GetError().GetErrorCode());
+
+    *cancel_context = client::CancellationContext{};
   }
 
   {
     SCOPED_TRACE("Cancelled on retrieving a catalog");
 
-    CheckCancelOnRequest(kGetCatalogRequest, kGetCatalogResponse);
+    EXPECT_CALL(*network_, Send(IsGetRequest(kGetCatalogRequest), _, _, _, _))
+        .WillOnce(cancel_request)
+        .WillRepeatedly(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                   olp::http::HttpStatusCode::OK),
+                               kGetCatalogResponse));
+
+    auto response =
+        client.PublishDataLessThanTwentyMib(request, *cancel_context);
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+              response.GetError().GetErrorCode());
+
+    *cancel_context = client::CancellationContext{};
   }
 
   {
     SCOPED_TRACE("Cancelled on retrieving the ingest API");
 
-    CheckCancelOnRequest(kIngestRequestUrl, kIngestHttpResponse);
+    EXPECT_CALL(*network_, Send(IsGetRequest(kIngestRequestUrl), _, _, _, _))
+        .WillOnce(cancel_request)
+        .WillRepeatedly(
+            ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                   olp::http::HttpStatusCode::OK),
+                               kIngestHttpResponse));
+
+    auto response =
+        client.PublishDataLessThanTwentyMib(request, *cancel_context);
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+              response.GetError().GetErrorCode());
+
+    *cancel_context = client::CancellationContext{};
   }
 
   {
     SCOPED_TRACE("Cancelled on posting data via ingest API");
 
-    CheckCancelOnRequest(kPostIngestDataRequest);
+    EXPECT_CALL(*network_,
+                Send(IsPostRequest(kPostIngestDataRequest), _, _, _, _))
+        .WillOnce(cancel_request);
+
+    auto response =
+        client.PublishDataLessThanTwentyMib(request, *cancel_context);
+
+    EXPECT_FALSE(response.IsSuccessful());
+    EXPECT_EQ(olp::client::ErrorCode::Cancelled,
+              response.GetError().GetErrorCode());
+
+    *cancel_context = client::CancellationContext{};
   }
 }
 
@@ -749,7 +770,7 @@ TEST_F(StreamLayerClientImplTest, QueueAndFlush) {
   auto response = client->Flush(model::FlushRequest()).GetFuture().get();
   EXPECT_EQ(response.size(), kBatchSize);
   std::unordered_set<std::string> trace_ids;
-  for (const auto& r : response) {
+  for (const auto &r : response) {
     EXPECT_TRUE(r.IsSuccessful());
     trace_ids.insert(r.GetResult().GetTraceID());
   }

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,13 +202,13 @@ class AuthenticationClientTest : public ::testing::Test {
               if (payload) {
                 *payload << data;
               }
-
+              callback(olp::http::NetworkResponse()
+                           .WithRequestId(request_id)
+                           .WithStatus(http));
               if (data_callback) {
                 auto raw = const_cast<char*>(data.c_str());
                 data_callback(reinterpret_cast<uint8_t*>(raw), 0, data.size());
               }
-
-              callback(olp::http::NetworkResponse().WithStatus(http));
 
               return olp::http::SendOutcome(request_id);
             });
@@ -349,20 +349,17 @@ TEST_F(AuthenticationClientTest, SignInClientUseWrongLocalTime) {
         if (payload) {
           *payload << kResponseWrongTimestamp;
         }
-
+        callback(olp::http::NetworkResponse()
+                     .WithRequestId(request_id)
+                     .WithStatus(olp::http::HttpStatusCode::UNAUTHORIZED));
         if (data_callback) {
           auto raw = const_cast<char*>(kResponseWrongTimestamp.c_str());
           data_callback(reinterpret_cast<uint8_t*>(raw), 0,
                         kResponseWrongTimestamp.size());
         }
-
         if (header_callback) {
           header_callback(kDate, kDateHeader);
         }
-
-        callback(olp::http::NetworkResponse()
-                     .WithRequestId(request_id)
-                     .WithStatus(olp::http::HttpStatusCode::UNAUTHORIZED));
 
         return olp::http::SendOutcome(request_id);
       })

--- a/tests/integration/olp-cpp-sdk-core/ApiLookupClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-core/ApiLookupClientTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -296,35 +296,29 @@ TEST_F(ApiLookupClientTest, LookupApi) {
 
   {
     SCOPED_TRACE("Network request cancelled by user");
-
     client::CancellationContext context;
-    std::thread cancel_thread;
-
     EXPECT_CALL(*network_, Send(IsGetRequest(lookup_url), _, _, _, _))
         .Times(1)
-        .WillOnce([&context, &cancel_thread](
-                      http::NetworkRequest /*request*/,
-                      http::Network::Payload /*payload*/,
-                      http::Network::Callback /*callback*/,
-                      http::Network::HeaderCallback /*header_callback*/,
-                      http::Network::DataCallback /*data_callback*/)
-                      -> http::SendOutcome {
-          // spawn a 'user' response of cancelling
-          cancel_thread =
-              std::thread([&context]() { context.CancelOperation(); });
+        .WillOnce(
+            [=, &context](http::NetworkRequest /*request*/,
+                          http::Network::Payload /*payload*/,
+                          http::Network::Callback /*callback*/,
+                          http::Network::HeaderCallback /*header_callback*/,
+                          http::Network::DataCallback /*data_callback*/)
+                -> http::SendOutcome {
+              // spawn a 'user' response of cancelling
+              std::thread([&context]() { context.CancelOperation(); }).detach();
 
-          // note no network response thread spawns
+              // note no network response thread spawns
 
-          constexpr auto unused_request_id = 12;
-          return http::SendOutcome(unused_request_id);
-        });
+              constexpr auto unused_request_id = 12;
+              return http::SendOutcome(unused_request_id);
+            });
     EXPECT_CALL(*network_, Cancel(_)).Times(1).WillOnce(Return());
 
     client::ApiLookupClient client(catalog_hrn, settings_);
     auto response = client.LookupApi(service_name, service_version,
                                      client::FetchOptions::OnlineOnly, context);
-
-    cancel_thread.join();
 
     EXPECT_FALSE(response.IsSuccessful());
     EXPECT_EQ(response.GetError().GetErrorCode(), client::ErrorCode::Cancelled);


### PR DESCRIPTION
This reverts commit 0d9351d8c4cbc4365bdcaca4aa1a156c80d1fb93.

Changes have to be reworked. Now they cause a sleep in network thread
on retry and have some issues on merge

Relates-To: OLPEDGE-2417

Signed-off-by: Iuliia Moroz <ext-iuliia.moroz@here.com>