### PR TITLE
Disable flawfinder analyser as it doesn't support C++11 syntax

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,7 @@ variables:
   LD_PRELOAD: "/lib/x86_64-linux-gnu/libSegFault.so"
   SEGFAULT_SIGNALS: "all"
   ADB_INSTALL_TIMEOUT: "8"
+  SAST_EXCLUDED_PATHS: "tests, examples, docs, scripts"
 
 stages:
   - build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 image: ${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${DOCKER_IMAGE_VERSION}
 
+# Gitlab SAST scanner jobs which runs on master
 include:
   - template: Security/SAST.gitlab-ci.yml
   - template: Security/Secret-Detection.gitlab-ci.yml
@@ -7,9 +8,12 @@ include:
   - template: Security/Dependency-Scanning.gitlab-ci.yml
 
 variables:
+# Linux
   LD_PRELOAD: "/lib/x86_64-linux-gnu/libSegFault.so"
   SEGFAULT_SIGNALS: "all"
+# Android
   ADB_INSTALL_TIMEOUT: "8"
+# Gitlab SAST scanner
   SAST_EXCLUDED_PATHS: "tests, examples, docs, scripts"
 
 stages:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ variables:
   ADB_INSTALL_TIMEOUT: "8"
 # Gitlab SAST scanner
   SAST_EXCLUDED_PATHS: "tests, examples, docs, scripts"
+  SAST_EXCLUDED_ANALYZERS: "flawfinder"
 
 stages:
   - build

--- a/scripts/macos/psv/azure_macos_build_psv.sh
+++ b/scripts/macos/psv/azure_macos_build_psv.sh
@@ -21,7 +21,7 @@
 mkdir -p build
 cd build
 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-    -OLP_SDK_BUILD_EXAMPLES=ON \
+    -DOLP_SDK_BUILD_EXAMPLES=ON \
     -DBUILD_SHARED_LIBS=ON \
     -DOLP_SDK_ENABLE_TESTING=NO \
     ..


### PR DESCRIPTION
Add exclude dirs for Security jobs, so only
sdk code is being scanned.

Relates-To: OLPEDGE-2506

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>