### PR TITLE
Use SDK leveldb environment

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DiskCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.cpp
@@ -187,6 +187,8 @@ OpenResult DiskCache::Open(const std::string& data_path,
           DiskCacheEnv::Env(), versioned_data_path,
           settings.enforce_immediate_flush);
       open_options.env = environment_.get();
+    } else {
+      open_options.env = DiskCacheEnv::Env();
     }
   } else {
     environment_ = std::make_unique<ReadOnlyEnv>(DiskCacheEnv::Env());

--- a/olp-cpp-sdk-core/src/cache/DiskCacheEnv.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCacheEnv.cpp
@@ -65,7 +65,7 @@ int MaxOpenFiles() {
 class Limiter {
  public:
   // Limit maximum number of resources to |max_acquires|.
-  Limiter(int max_acquires) : acquires_allowed_(max_acquires) {}
+  explicit Limiter(int max_acquires) : acquires_allowed_(max_acquires) {}
 
   Limiter(const Limiter&) = delete;
   Limiter operator=(const Limiter&) = delete;


### PR DESCRIPTION
When the max cache size is not set, SDK use the leveldb default env,
SDK needs to replace it with its own in order to disable mmap usage.
Fix the Limiter class constructor warning.

Relates-To: OLPSUP-13838
Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>