### PR TITLE
Do not remove protected keys in DefaultCache.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -277,4 +277,4 @@ class CORE_API DefaultCache : public KeyValueCache {
 }  // namespace cache
 }  // namespace olp
 
-#endif // OLP_SDK_ENABLE_DEFAULT_CACHE
+#endif  // OLP_SDK_ENABLE_DEFAULT_CACHE

--- a/olp-cpp-sdk-core/src/cache/DiskCache.h
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.h
@@ -38,6 +38,7 @@
 #include <olp/core/cache/CacheSettings.h>
 #include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiNoResult.h>
 #include <olp/core/client/ApiResponse.h>
 
 namespace leveldb {
@@ -91,10 +92,13 @@ class DiskCache {
   static constexpr uint64_t kSizeMax = std::numeric_limits<uint64_t>::max();
 
   /// No error type
-  struct NoError {};
+  using NoError = client::ApiNoResult;
 
   /// Operation result type
   using OperationOutcome = client::ApiResponse<NoError, client::ApiError>;
+
+  /// Will be used to filter out keys to be removed in case they are protected.
+  using RemoveFilterFunc = std::function<bool(const std::string&)>;
 
   /// Logger that forwards leveldb log messages to our logging framework.
   class LevelDBLogger : public leveldb::Logger {
@@ -140,7 +144,8 @@ class DiskCache {
 
   /// Empty prefix deleted everything from DB. Returns size of removed data.
   bool RemoveKeysWithPrefix(const std::string& prefix,
-                            uint64_t& removed_data_size);
+                            uint64_t& removed_data_size,
+                            const RemoveFilterFunc& filter = nullptr);
 
   /// Check if cache contains data with the key.
   bool Contains(const std::string& key);

--- a/olp-cpp-sdk-core/src/cache/InMemoryCache.h
+++ b/olp-cpp-sdk-core/src/cache/InMemoryCache.h
@@ -47,6 +47,9 @@ class InMemoryCache {
   using TimeProvider = std::function<time_t()>;
   using ModelCacheCostFunc = std::function<std::size_t(const ItemTuple&)>;
 
+  /// Will be used to filter out keys to be removed in case they are protected.
+  using RemoveFilterFunc = std::function<bool(const std::string&)>;
+
   /// Default cache cost based on size.
   struct DefaultCacheCost {
     std::size_t operator()(const ItemTuple& value) const {
@@ -75,7 +78,8 @@ class InMemoryCache {
   void Clear();
 
   bool Remove(const std::string& key);
-  void RemoveKeysWithPrefix(const std::string& key_prefix);
+  void RemoveKeysWithPrefix(const std::string& key_prefix,
+                            const RemoveFilterFunc& filter = nullptr);
   bool Contains(const std::string& key) const;
 
  protected:


### PR DESCRIPTION
When user calls DefaultCache::Remove() and
DefaultCache::RemoveKeysWithPrefix() we should not remove protected
keys. This is now implemented and tested.

Relates-To: OLPEDGE-2521

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>