### PR TITLE
Fix crash during compaction on closed DiskCache

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DiskCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.cpp
@@ -151,7 +151,7 @@ bool DiskCache::Clear() {
 void DiskCache::Compact() {
   // Lets make sure that the parallel thread which is running the compact is not
   // doing it already. We don't need two at the same time.
-  if (!compacting_.exchange(true)) {
+  if (database_ && !compacting_.exchange(true)) {
     OLP_SDK_LOG_INFO(kLogTag, "Compact: Compacting database started");
     database_->CompactRange(nullptr, nullptr);
     compacting_ = false;


### PR DESCRIPTION
If DiskCache has been closed already but compaction is called explicitly
the SIGSEGV would occur

Relates-To: OAM-1016
Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>