### PR TITLE
Merge the same QuadTree requests

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -122,8 +122,9 @@ class PrefetchTilesRepository {
       client::CancellationContext context);
 
  private:
-  client::HRN catalog_;
-  std::string layer_id_;
+  const client::HRN catalog_;
+  const std::string catalog_str_;
+  const std::string layer_id_;
   client::OlpClientSettings settings_;
   client::ApiLookupClient lookup_client_;
   PartitionsCacheRepository cache_repository_;


### PR DESCRIPTION
Merge the same quadtree requests during concurrent GetTile and
PrefetchTiles API requests. Later this approach will be replaced
with merging inside OlpClient.

Resolves: OLPSUP-13676

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>