### PR TITLE
Fix the iOS network race when accessing sessions

### DIFF
--- a/olp-cpp-sdk-core/src/http/ios/OLPHttpClient.mm
+++ b/olp-cpp-sdk-core/src/http/ios/OLPHttpClient.mm
@@ -111,8 +111,8 @@ constexpr auto kLogTag = "OLPHttpClient";
                                                 andURLSession:session
                                                         andId:identifier];
 
-  self.urlSessions[@(identifier)] = session;
   @synchronized(self.tasks) {
+    self.urlSessions[@(identifier)] = session;
     self.tasks[@(identifier)] = task;
   }
 


### PR DESCRIPTION
Make sure that access to urlSessions variable is synchronized.

Resolves-To: OLPSUP-14072

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>