### PR TITLE
Review/add the API doc (`logging`)

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/logging/Appender.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/Appender.h
@@ -24,18 +24,18 @@
 namespace olp {
 namespace logging {
 /**
- * @brief Abstract base class for an appender, which appends a message to the
- * log.
+ * @brief Appends a message to the log.
  *
- * Subclasses should derive from Appender instead of IAppender in order for the
- * type to be automatically registered.
+ * To automatically register the type, base subclasses on
+ * `Appender` instead of `IAppender`.
  */
 class CORE_API IAppender {
  public:
   virtual ~IAppender() = default;
 
   /**
-   * @brief Appends a message using char strings.
+   * @brief Appends the message using char strings.
+   *
    * @param message The message to append.
    */
   virtual IAppender& append(const LogMessage& message) = 0;

--- a/olp-cpp-sdk-core/include/olp/core/logging/Configuration.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/Configuration.h
@@ -30,20 +30,19 @@
 namespace olp {
 namespace logging {
 /**
- * @brief Class for configuring the appenders and loggers available by the
- * logging system.
+ * @brief Configures appenders and loggers available in
+ * the logging system.
  */
 class CORE_API Configuration {
  public:
   /**
-   * @brief Struct containing an appender and a log level that the appender is
-   * enabled with.
+   * @brief Contains an appender and its log level.
    */
   struct AppenderWithLogLevel {
     /**
-     * @brief The log level the appender is enabled with.
+     * @brief The log level of the appender.
      *
-     * Any log levels less than this level will be ignored.
+     * Any log level that is less than this level is ignored.
      */
     logging::Level logLevel;
 
@@ -53,7 +52,8 @@ class CORE_API Configuration {
     std::shared_ptr<IAppender> appender;
 
     /**
-     * @brief Checks to see if the appender is enabled for a log level.
+     * @brief Checks whether the appender is enabled for the log level.
+     *
      * @param level The log level.
      */
     bool isEnabled(logging::Level level) const {
@@ -62,27 +62,30 @@ class CORE_API Configuration {
   };
 
   /**
-   * @brief Typedef for a list of appenders
+   * @brief A typedef for a list of appenders.
    */
   using AppenderList = std::vector<AppenderWithLogLevel>;
 
   /**
-   * @brief Creates a default configuration by adding the DebugAppender and the
-   * ConsoleAppender as appenders.
+   * @brief Creates a default configuration by adding
+   * an instance of `DebugAppender` and `ConsoleAppender` as appenders.
+   *
    * @return The default configuration.
    */
   static Configuration createDefault();
 
   /**
-   * @brief Returns whether or not the configuration is valid.
-   * @return Whether or not the configuration is valid.
+   * @brief Checks whether the configuration is valid.
+   *
+   * @return True if the configuration is valid; false otherwise.
    */
   inline bool isValid() const;
 
   /**
-   * @brief Adds an appender along with its logging level to the configuration.
+   * @brief Adds the appender along with its log level to the configuration.
+   *
    * @param appender The appender to add.
-   * @param level The log level belonging to appender.
+   * @param level The log level of the appender.
    */
   inline Configuration& addAppender(
       std::shared_ptr<IAppender> appender,
@@ -95,7 +98,8 @@ class CORE_API Configuration {
 
   /**
    * @brief Gets the appenders from the configuration.
-   * @return The appenders and belonging log levels.
+   *
+   * @return The appenders and their log levels.
    */
   inline const AppenderList& getAppenders() const;
 

--- a/olp-cpp-sdk-core/include/olp/core/logging/ConsoleAppender.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/ConsoleAppender.h
@@ -28,12 +28,13 @@
 namespace olp {
 namespace logging {
 /**
- * @brief Appender for printing to the console.
+ * @brief An appender that prints messages to the console.
  */
 class CORE_API ConsoleAppender : public IAppender {
  public:
   /**
-   * @brief Constructs this with the message formatter.
+   * @brief Creates a `ConsoleAppender` instance with a message formatter.
+   *
    * @param formatter The message formatter.
    */
   inline explicit ConsoleAppender(
@@ -41,12 +42,14 @@ class CORE_API ConsoleAppender : public IAppender {
 
   /**
    * @brief Gets the message formatter.
+   *
    * @return The message formatter.
    */
   inline const MessageFormatter& getMessageFormatter() const;
 
   /**
    * @brief Sets the message formatter.
+   *
    * @param formatter The message formatter.
    */
   inline ConsoleAppender& setMessageFormatter(MessageFormatter formatter);

--- a/olp-cpp-sdk-core/include/olp/core/logging/DebugAppender.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/DebugAppender.h
@@ -25,14 +25,14 @@
 namespace olp {
 namespace logging {
 /**
- * @brief Appender for printing to the debug output.
+ * @brief An appender that prints messages to the debug output.
  */
 class CORE_API DebugAppender : public IAppender {
  public:
   /**
-   * @brief Returns whether or not the debug appender is implemented for this
-   * platform.
-   * @return Whether or not this is implemented.
+   * @brief Checks whether this platform has the debug appender implemented.
+   *
+   * @return True if this platform has the debug appender; false otherwise.
    */
   static bool isImplemented();
 

--- a/olp-cpp-sdk-core/include/olp/core/logging/FileAppender.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/FileAppender.h
@@ -30,14 +30,15 @@
 namespace olp {
 namespace logging {
 /**
- * @brief Appender for printing to a file.
+ * @brief An appender that prints messages to a file.
  */
 class CORE_API FileAppender : public IAppender {
  public:
   /**
-   * @brief Constructs a file appender.
+   * @brief Creates a `FileAppender` instance.
+   *
    * @param fileName The name of the file to write to.
-   * @param append True to append to an existing file if it exists.
+   * @param append True to append to an existing file; false otherwise.
    * @param formatter The message formatter.
    */
   explicit FileAppender(
@@ -46,31 +47,36 @@ class CORE_API FileAppender : public IAppender {
   ~FileAppender() override;
 
   /**
-   * @brief Returns whether or not the stream is opened and can be written to.
-   * @return True if this is valid.
+   * @brief Checks whether the stream is open and can be written to.
+   *
+   * @return True if the stream is open and can be written to; false otherwise.
    */
   bool isValid() const;
 
   /**
-   * @brief Gets the name of the file this was created with.
+   * @brief Gets the name of the file.
+   *
    * @return The file name.
    */
   inline const std::string& getFileName() const;
 
   /**
-   * @brief Returns whether or not the file is being appended to.
-   * @return True if appending to the file.
+   * @brief Checks whether the file has the appender.
+   *
+   * @return True if the file has the appender; false otherwise.
    */
   inline bool getAppendFile() const;
 
   /**
    * @brief Gets the message formatter.
+   *
    * @return The message formatter.
    */
   inline const MessageFormatter& getMessageFormatter() const;
 
   /**
    * @brief Sets the message formatter.
+   *
    * @param formatter The message formatter.
    */
   inline FileAppender& setMessageFormatter(MessageFormatter formatter);

--- a/olp-cpp-sdk-core/include/olp/core/logging/FilterGroup.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/FilterGroup.h
@@ -33,98 +33,120 @@
 namespace olp {
 namespace logging {
 /**
- * @brief Class that groups together log levels for different tags. This makes
- * it easier to apply groups of level filters together.
+ * @brief Groups together log levels for different tags.
+ *
+ * It helps to apply groups of level filters together.
  */
 class CORE_API FilterGroup {
  public:
   inline FilterGroup();
+
+  /// The default copy constructor.
   FilterGroup(const FilterGroup&) = default;
+
+  /// The default copy assignment operator.
   FilterGroup& operator=(const FilterGroup&) = default;
+
+  /// The default move constructor.
   inline FilterGroup(FilterGroup&& other) noexcept;
+
+  /// The default move assignment operator.
   inline FilterGroup& operator=(FilterGroup&& other) noexcept;
 
   /**
    * @brief Gets the default log level.
-   * @return The default log level, or boost::none if not set.
+   *
+   * @return The default log level or `boost::none` if the level is not set.
    */
   inline boost::optional<Level> getLevel() const;
 
   /**
    * @brief Sets the default log level.
+   *
    * @param level The default log level.
    */
   inline FilterGroup& setLevel(Level level);
 
   /**
-   * @brief Clears the default log level to be unset.
+   * @brief Clears the default log level.
    *
-   * Leaving the default log level unset prevents the default level in Log from
-   * changing when the filter group is applied.
+   * If the default log level is unset, it does not change
+   * when the filter group is applied.
    */
   inline FilterGroup& clearLevel();
 
   /**
-   * @brief Gets the log level for a tag
-   * @param tag The tag to get the log level for.
-   * @return The log level for the tag, or boost::none if not set.
+   * @brief Gets the log level for a tag.
+   *
+   * @param tag The tag for which to get the log level.
+   *
+   * @return The log level for the tag, or `boost::none` if the level is not set.
    */
   inline boost::optional<Level> getLevel(const std::string& tag) const;
 
   /**
    * @brief Sets the log level for a tag.
+   *
    * @param level The log level for a tag.
-   * @param tag The tag to set the level for.
+   * @param tag The tag for which to set the level.
    */
   inline FilterGroup& setLevel(Level level, const std::string& tag);
 
   /**
-   * @brief Clears the log level to be unset for a tag.
+   * @brief Clears the log level for a tag.
    *
-   * Leaving the log level for a tag unset causes it to use the default log
-   * level instead.
+   * If the log level for a tag is unset, the default log
+   * level is used instead.
    */
   inline FilterGroup& clearLevel(const std::string& tag);
 
   /**
-   * @brief Clears the filter group to be unset.
+   * @brief Clears the filter group.
    */
   inline FilterGroup& clear();
 
   /**
    * @brief Loads the filter group from a file.
-   * @param fileName The file to load the configuration from.
-   * @return Whether or not the load was successful. If unsuccessful, this will
-   * be cleared.
+   *
+   * @param fileName The file from which to load the configuration.
+   *
+   * @return True if the load was successful; false otherwise. If unsuccessful,
+   * this is cleared.
    */
   bool load(const std::string& fileName);
 
   /**
    * @brief Loads the filter group from a stream.
    *
-   * The stream is expected contain text data. The format is as follows:
-   *     - Blank lines, or lines that start with # are ignored.
-   *     - Setting the log level for the tag is of the format "tag: level". For
-   * example:
-   *         - mylib: warning
-   *         - theirlib: info
-   *         - otherlib: off
-   *     - Setting the default log level is of the format ": level". For
-   * example: ": error"
-   *     - Whitespace is trimmed and case is ignored for the levels.
+   * The stream should contain text data.
+   * The format of the stream:
+   * - Blank lines or lines that start with "#" are ignored.
+   * - Use the following format for tag log levels: `tag: level`.
+   * For example:
+   *    - `mylib: warning`
+   *    - `theirlib: info`
+   *    - `otherlib: off`
+   * - Use the following format for the default log level: `: level`.
+   * For example: `: error`
+   * - Whitespaces are trimmed.
+   * - The case is ignored for levels.
    *
-   * The filter group will be cleared before the contents of the stream are
+   * The filter groups are cleared before the content of the stream is
    * applied.
-   * @param stream The stream to load the configuration from.
-   * @return Whether or not the load was successful. If unsuccessful, this will
-   * be cleared.
+   *
+   * @param stream The stream from which to load the configuration.
+   *
+   * @return True if the load was successful; false otherwise. If unsuccessful,
+   * this is cleared.
    */
   bool load(std::istream& stream);
 
   /**
-   * @brief Converts string logging level to enum Level format.
-   * @param levelStr string level to convert.
-   * @return Converted level
+   * @brief Converts the string log level to the enum level format.
+   *
+   * @param levelStr The string level to convert.
+   *
+   * @return The converted level.
    */
   static boost::optional<Level> stringToLevel(const std::string& levelStr);
 

--- a/olp-cpp-sdk-core/include/olp/core/logging/Format.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/Format.h
@@ -36,23 +36,27 @@
 namespace olp {
 namespace logging {
 /**
- * @brief Typedef for a time point from the system clock.
+ * @brief A typedef for a time point from the system clock.
  */
 using TimePoint = std::chrono::time_point<std::chrono::system_clock>;
 
 /**
- * @brief Formats a string using a printf style format string.
+ * @brief Formats a string using a printf-style format string.
+ *
  * @param formatStr The format string.
+ *
  * @return The formatted string.
  */
 CORE_API std::string format(const char* formatStr, ...)
     CHECK_PRINTF_FORMAT_STRING(1, 2);
 
 /**
- * @brief Formats a string using a printf style format string with an already
- * created va_list.
+ * @brief Formats a string using a printf-style format string with an already
+ * created `va_list` object.
+ *
  * @param formatStr The format string.
- * @param args The va_list that contains the arguments.
+ * @param args The `va_list` object that contains the arguments.
+ *
  * @return The formatted string.
  */
 CORE_API std::string formatv(const char* formatStr, va_list args);
@@ -61,61 +65,73 @@ CORE_API std::string formatv(const char* formatStr, va_list args);
  * @brief Creates a string for a timestamp using local time with the default
  * format string.
  *
- * The default format string is "%Y-%m-%d %H:%M:%S".
+ * The default format string is `%Y-%m-%d %H:%M:%S`.
+ *
  * @param timestamp The timestamp to format as seconds from epoch.
+ *
  * @return The formatted string.
  */
 CORE_API std::string formatLocalTime(const TimePoint& timestamp);
 
 /**
  * @brief Creates a string for a timestamp using local time.
- * @param timestamp The time stamp to format as seconds from epoch.
- * @param formatStr The format string to use, conforming to strftime.
+ *
+ * @param timestamp The timestamp to format as seconds from epoch.
+ * @param formatStr The format string to use, conforming to `strftime`.
+ *
  * @return The formatted string.
  */
 CORE_API std::string formatLocalTime(const TimePoint& timestamp,
                                     const char* formatStr);
 
 /**
- * @brief Creates a string for a timestamp using UTC time with the default
+ * @brief Creates a string for a timestamp using the UTC time standard with the default
  * format string.
  *
- * The default format string is "%Y-%m-%d %H:%M:%S".
+ * The default format string is `%Y-%m-%d %H:%M:%S`.
+ *
  * @param timestamp The timestamp to format as seconds from epoch.
+ *
  * @return The formatted string.
  */
 CORE_API std::string formatUtcTime(const TimePoint& timestamp);
 
 /**
- * @brief Creates a string for a timestamp using UTC time.
- * @param timestamp The time stamp to format as seconds from epoch.
- * @param formatStr The format string to use, conforming to strftime.
+ * @brief Creates a string for a timestamp using the UTC time standard.
+ *
+ * @param timestamp The timestamp to format as seconds from epoch.
+ * @param formatStr The format string to use, conforming to `strftime`.
+ *
  * @return The formatted string.
  */
 CORE_API std::string formatUtcTime(const TimePoint& timestamp,
                                   const char* formatStr);
 
 /**
- * @brief Class that attempts to format a string to a buffer before falling back
+ * @brief Attempts to format a string to a buffer before falling back
  * to a dynamically allocated string.
  *
- * This can be used to avoid allocating and std::string for smaller strings.
+ * This can be used to avoid allocating `std::string` for smaller strings.
  */
 class CORE_API FormatBuffer {
  public:
   /**
-   * @brief Formats a string using a printf style format string.
+   * @brief Formats a string using a printf-style format string.
+   *
    * @param formatStr The format string.
+   *
    * @return The formatted string.
    */
   const char* format(const char* formatStr, ...)
       CHECK_PRINTF_FORMAT_STRING(2, 3);
 
   /**
-   * @brief Formats a string using a printf style format string with an already
-   * created va_list.
+   * @brief Formats a string using a printf-style format string with an already
+   * created `va_list`.
+   *
    * @param formatStr The format string.
    * @param args The va_list that contains the arguments.
+   *
    * @return The formatted string.
    */
   const char* formatv(const char* formatStr, va_list args);
@@ -124,35 +140,43 @@ class CORE_API FormatBuffer {
    * @brief Creates a string for a timestamp using local time with the default
    * format string.
    *
-   * The default format string is "%Y-%m-%d %H:%M:%S".
+   * The default format string is `%Y-%m-%d %H:%M:%S`.
+   *
    * @param timestamp The timestamp to format as seconds from epoch.
+   *
    * @return The formatted string.
    */
   const char* formatLocalTime(const TimePoint& timestamp);
 
   /**
    * @brief Creates a string for a timestamp using local time.
-   * @param timestamp The time stamp to format as seconds from epoch.
+   *
+   * @param timestamp The timestamp to format as seconds from epoch.
    * @param formatStr The format string to use, conforming to strftime.
+   *
    * @return The formatted string.
    */
   const char* formatLocalTime(const TimePoint& timestamp,
                               const char* formatStr);
 
   /**
-   * @brief Creates a string for a timestamp using UTC time with the default
+   * @brief Creates a string for a timestamp using the UTC time standard with the default
    * format string.
    *
-   * The default format string is "%Y-%m-%d %H:%M:%S".
+   * The default format string is `%Y-%m-%d %H:%M:%S`.
+   *
    * @param timestamp The timestamp to format as seconds from epoch.
+   *
    * @return The formatted string.
    */
   const char* formatUtcTime(const TimePoint& timestamp);
 
   /**
-   * @brief Creates a string for a timestamp using UTC time.
-   * @param timestamp The time stamp to format as seconds from epoch.
+   * @brief Creates a string for a timestamp using the UTC time standard.
+   *
+   * @param timestamp The timestamp to format as seconds from epoch.
    * @param formatStr The format string to use, conforming to strftime.
+   *
    * @return The formatted string.
    */
   const char* formatUtcTime(const TimePoint& timestamp, const char* formatStr);

--- a/olp-cpp-sdk-core/include/olp/core/logging/Log.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/Log.h
@@ -35,11 +35,11 @@
 
 /**
  * @file
- * @brief The file that provides the main interface to the logging library.
+ * @brief Provides the main interface for the logging library.
  */
 
 /**
- * @brief Macro to get the current's function signature for different compilers
+ * @brief Gets the current function signature for different compilers.
  */
 #if __GNUC__ >= 3 || defined(__clang__)
 #define OLP_SDK_LOG_FUNCTION_SIGNATURE __PRETTY_FUNCTION__
@@ -50,14 +50,14 @@
 #endif
 
 /**
- * @brief Log a message using C++ style streams.
+ * @brief Logs a message using C++ style streams.
  *
- * OLP_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
- * this will not check to see if the tag is disabled.
+ * `OLP_SDK_LOGGING_DISABLED` does not disable this functionality.
+ * Additionally, it does not check to see if the tag is disabled.
  *
- * @param level Logging level.
- * @param tag Log component name.
- * @param message The message to log.
+ * @param level The log level.
+ * @param tag The tag for the log component.
+ * @param message The log message.
  */
 #define OLP_SDK_DO_LOG(level, tag, message)                             \
   do {                                                                  \
@@ -70,71 +70,72 @@
   OLP_SDK_CORE_LOOP_ONCE()
 
 /**
- * @brief Log a critical message using C++ style streams.
+ * @brief Logs a "Critical" message using C++ style streams.
  *
- * OLP_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
- * this will not check to see if the tag is disabled.
+ * `OLP_SDK_LOGGING_DISABLED` does not disable this functionality.
+ * Additionally, it does not check to see if the tag is disabled.
  *
- * @param level Logging level.
- * @param tag Log component name.
- * @param message The message to log.
+ * @param level The log level.
+ * @param tag The tag for the log component.
+ * @param message The log message.
  */
 #define OLP_SDK_LOG_CRITICAL(level, tag, message) \
   OLP_SDK_DO_LOG(level, tag, message)
 
 /**
- * @brief Log a critical info message using C++ style streams.
+ * @brief Logs a "Critical info" message using C++ style streams.
  *
- * OLP_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
- * this will not check to see if the tag is disabled.
+ * `OLP_SDK_LOGGING_DISABLED` does not disable this functionality.
+ * Additionally, it does not check to see if the tag is disabled.
  *
- * @param tag Log component name.
- * @param message The message to log.
+ * @param tag The tag for the log component.
+ * @param message The log message.
  */
 #define OLP_SDK_LOG_CRITICAL_INFO(tag, message) \
   OLP_SDK_LOG_CRITICAL(::olp::logging::Level::Info, tag, message)
 
 /**
- * @brief Log a critical warning message using C++ style streams.
+ * @brief Logs a "Critical warning" message using C++ style streams.
  *
- * OLP_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
- * this will not check to see if the tag is disabled.
+ * `OLP_SDK_LOGGING_DISABLED` does not disable this functionality.
+ * Additionally, it does not check to see if the tag is disabled.
  *
- * @param tag Log component name.
- * @param message The message to log.
+ * @param tag The tag for the log component.
+ * @param message The log message.
  */
 #define OLP_SDK_LOG_CRITICAL_WARNING(tag, message) \
   OLP_SDK_LOG_CRITICAL(::olp::logging::Level::Warning, tag, message)
 
 /**
- * @brief Log a critical error message using C++ style streams.
+ * @brief Logs a "Critical error" message using C++ style streams.
  *
- * OLP_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
- * this will not check to see if the tag is disabled.
+ * `OLP_SDK_LOGGING_DISABLED` does not disable this functionality.
+ * Additionally, it does not check to see if the tag is disabled.
  *
- * @param tag Log component name.
- * @param message The message to log.
+ * @param tag The tag for the log component.
+ * @param message The log message.
  */
 #define OLP_SDK_LOG_CRITICAL_ERROR(tag, message) \
   OLP_SDK_LOG_CRITICAL(::olp::logging::Level::Error, tag, message)
 
 /**
- * @brief Log a fatal error message using C++ style streams.
+ * @brief Logs a "Fatal error" message using C++ style streams.
  *
- * OLP_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
- * this will not check to see if the tag is disabled.
+ * `OLP_SDK_LOGGING_DISABLED` does not disable this functionality.
+ * Additionally, it does not check to see if the tag is disabled.
  *
- * @param tag Log component name.
- * @param message The message to log.
+ * @param tag The tag for the log component.
+ * @param message The log message.
  */
 #define OLP_SDK_LOG_FATAL(tag, message) \
   OLP_SDK_LOG_CRITICAL(::olp::logging::Level::Fatal, tag, message)
 
 /**
- * @brief Log a critical fatal error message using C++ style streams, then abort
- * the program.
- * @param tag Log component name.
- * @param message The message to log.
+ * @brief Logs a "Critical fatal error" message using C++ style streams,
+ * and then aborts the program.
+ *
+ * @param tag The tag for the log component.
+ * @param message The log message.
  */
 #define OLP_SDK_LOG_ABORT(tag, message) \
   do {                                  \
@@ -144,13 +145,13 @@
   OLP_SDK_CORE_LOOP_ONCE()
 
 /**
- * @brief Log a message using printf style formatting.
+ * @brief Logs a message using the printf-style formatting.
  *
- * OLP_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
- * this will not check to see if the tag is disabled.
+ * `OLP_SDK_LOGGING_DISABLED` does not disable this functionality.
+ * Additionally, it does not check to see if the tag is disabled.
  *
- * @param level Logging level.
- * @param tag Log component name.
+ * @param level The log level.
+ * @param tag The tag for the log component.
  */
 #define OLP_SDK_DO_LOG_F(level, tag, ...)                                      \
   do {                                                                         \
@@ -162,65 +163,66 @@
   OLP_SDK_CORE_LOOP_ONCE()
 
 /**
- * @brief Log a critical message using printf style formatting.
+ * @brief Logs a "Critical" message using the printf-style formatting.
  *
- * OLP_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
- * this will not check to see if the tag is disabled.
+ * `OLP_SDK_LOGGING_DISABLED` does not disable this functionality.
+ * Additionally, it does not check to see if the tag is disabled.
  *
- * @param level Logging level.
- * @param tag Log component name.
+ * @param level The log level.
+ * @param tag The tag for the log component.
  */
 #define OLP_SDK_LOG_CRITICAL_F(level, tag, ...) \
   OLP_SDK_DO_LOG_F(level, tag, __VA_ARGS__)
 
 /**
- * @brief Log a critical info message using printf style formatting.
+ * @brief Logs a "Critical info" message using the printf-style formatting.
  *
- * OLP_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
- * this will not check to see if the tag is disabled.
+ * `OLP_SDK_LOGGING_DISABLED` does not disable this functionality.
+ * Additionally, it does not check to see if the tag is disabled.
  *
- * @param tag Log component name.
+ * @param tag The tag for the log component.
  */
 #define OLP_SDK_LOG_CRITICAL_INFO_F(tag, ...) \
   OLP_SDK_LOG_CRITICAL_F(::olp::logging::Level::Info, tag, __VA_ARGS__)
 
 /**
- * @brief Log a critical warning message using printf style formatting.
+ * @brief Logs a "Critical warning" message using the printf-style formatting.
  *
- * OLP_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
- * this will not check to see if the tag is disabled.
+ * `OLP_SDK_LOGGING_DISABLED` does not disable this functionality.
+ * Additionally, it does not check to see if the tag is disabled.
  *
- * @param tag Log component name.
+ * @param tag The tag for the log component.
  */
 #define OLP_SDK_LOG_CRITICAL_WARNING_F(tag, ...) \
   OLP_SDK_LOG_CRITICAL_F(::olp::logging::Level::Warning, tag, __VA_ARGS__)
 
 /**
- * @brief Log a critical error message using printf style formatting.
+ * @brief Logs a "Critical error" message using the printf-style formatting.
  *
- * OLP_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
- * this will not check to see if the tag is disabled.
+ * `OLP_SDK_LOGGING_DISABLED` does not disable this functionality.
+ * Additionally, it does not check to see if the tag is disabled.
  *
- * @param tag Log component name.
+ * @param tag The tag for the log component.
  */
 #define OLP_SDK_LOG_CRITICAL_ERROR_F(tag, ...) \
   OLP_SDK_LOG_CRITICAL_F(::olp::logging::Level::Error, tag, __VA_ARGS__)
 
 /**
- * @brief Log a critical fatal error message using printf style formatting.
+ * @brief Logs a "Critical fatal error" message using the printf-style formatting.
  *
- * OLP_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
- * this will not check to see if the tag is disabled.
+ * `OLP_SDK_LOGGING_DISABLED` does not disable this functionality.
+ * Additionally, it does not check to see if the tag is disabled.
  *
- * @param tag Log component name.
+ * @param tag The tag for the log component.
  */
 #define OLP_SDK_LOG_FATAL_F(tag, ...) \
   OLP_SDK_LOG_CRITICAL_F(::olp::logging::Level::Fatal, tag, __VA_ARGS__)
 
 /**
- * @brief Log a critical fatal error message using printf style formatting, then
- * abort the program.
- * @param tag Log component name.
+ * @brief Logs a "Critical fatal error" message using the printf-style formatting,
+ * and then abort sthe program.
+ *
+ * @param tag The tag for the log component.
  */
 #define OLP_SDK_LOG_ABORT_F(tag, ...)      \
   do {                                     \
@@ -237,10 +239,11 @@
 #else
 
 /**
- * @brief Log a message using C++ style streams.
- * @param level Logging level.
- * @param tag Log component name.
- * @param message The message to log.
+ * @brief Logs a message using C++ style streams.
+ *
+ * @param level The log level.
+ * @param tag The tag for the log component.
+ * @param message The log message.
  */
 #define OLP_SDK_LOG(level, tag, message)              \
   do {                                                \
@@ -271,17 +274,19 @@
 
 #else
 /**
- * @brief Log a trace message using C++ style streams.
- * @param tag Log component name.
- * @param message The message to log.
+ * @brief Logs a "Trace" message using C++ style streams.
+ *
+ * @param tag The tag for the log component.
+ * @param message The log message.
  */
 #define OLP_SDK_LOG_TRACE(tag, message) \
   OLP_SDK_LOG(::olp::logging::Level::Trace, tag, message)
 
 /**
- * @brief Log a debug message using C++ style streams.
- * @param tag Log component name.
- * @param message The message to log.
+ * @brief Logs a "Debug" message using C++ style streams.
+ *
+ * @param tag The tag for the log component.
+ * @param message The log message.
  */
 #define OLP_SDK_LOG_DEBUG(tag, message) \
   OLP_SDK_LOG(::olp::logging::Level::Debug, tag, message)
@@ -289,25 +294,28 @@
 #endif  // LOGGING_DISABLE_DEBUG_LEVEL
 
 /**
- * @brief Log an info message using C++ style streams.
- * @param tag Log component name.
- * @param message The message to log.
+ * @brief Logs an "Info" message using C++ style streams.
+ *
+ * @param tag The tag for the log component.
+ * @param message The log message.
  */
 #define OLP_SDK_LOG_INFO(tag, message) \
   OLP_SDK_LOG(::olp::logging::Level::Info, tag, message)
 
 /**
- * @brief Log a warning message using C++ style streams.
- * @param tag Log component name.
- * @param message The message to log.
+ * @brief Logs a "Warning" message using C++ style streams.
+ *
+ * @param tag The tag for the log component.
+ * @param message The log message.
  */
 #define OLP_SDK_LOG_WARNING(tag, message) \
   OLP_SDK_LOG(::olp::logging::Level::Warning, tag, message)
 
 /**
- * @brief Log an error message using C++ style streams.
- * @param tag Log component name.
- * @param message The message to log.
+ * @brief Logs an "Error" message using C++ style streams.
+ *
+ * @param tag The tag for the log component.
+ * @param message The log message.
  */
 #define OLP_SDK_LOG_ERROR(tag, message) \
   OLP_SDK_LOG(::olp::logging::Level::Error, tag, message)
@@ -319,9 +327,10 @@
   OLP_SDK_CORE_LOOP_ONCE()
 #else
 /**
- * @brief Log a message using printf style formatting.
- * @param level Logging level.
- * @param tag Log component name.
+ * @brief Logs a message using the printf style formatting.
+ *
+ * @param level The log level.
+ * @param tag The tag for the log component.
  */
 #define OLP_SDK_LOG_F(level, tag, ...)                \
   do {                                                \
@@ -338,15 +347,17 @@
 #define OLP_SDK_LOG_DEBUG_F(tag, ...) OLP_SDK_CORE_UNUSED(tag, __VA_ARGS__)
 #else
 /**
- * @brief Log a trace message using printf style formatting.
- * @param tag Log component name.
+ * @brief Logs a "Trace" message using the printf style formatting.
+ *
+ * @param tag The tag for the log component.
  */
 #define OLP_SDK_LOG_TRACE_F(tag, ...) \
   OLP_SDK_LOG_F(::olp::logging::Level::Trace, tag, __VA_ARGS__)
 
 /**
- * @brief Log a debug message using printf style formatting.
- * @param tag Log component name.
+ * @brief Logs a "Debug" message using the printf style formatting.
+ *
+ * @param tag The tag for the log component.
  */
 #define OLP_SDK_LOG_DEBUG_F(tag, ...) \
   OLP_SDK_LOG_F(::olp::logging::Level::Debug, tag, __VA_ARGS__)
@@ -354,28 +365,31 @@
 #endif  // LOGGING_DISABLE_DEBUG_LEVEL
 
 /**
- * @brief Log an info message using printf style formatting.
- * @param tag Log component name.
+ * @brief Logs an "Info" message using the printf style formatting.
+ *
+ * @param tag The tag for the log component.
  */
 #define OLP_SDK_LOG_INFO_F(tag, ...) \
   OLP_SDK_LOG_F(::olp::logging::Level::Info, tag, __VA_ARGS__)
 
 /**
- * @brief Log a warning message using printf style formatting.
- * @param tag Log component name.
+ * @brief Logs a "Warning" message using the printf style formatting.
+ *
+ * @param tag The tag for the log component.
  */
 #define OLP_SDK_LOG_WARNING_F(tag, ...) \
   OLP_SDK_LOG_F(::olp::logging::Level::Warning, tag, __VA_ARGS__)
 
 /**
- * @brief Log an error message using printf style formatting.
- * @param tag Log component name.
+ * @brief Logs an "Eror" message using the printf style formatting.
+ *
+ * @param tag The tag for the log component.
  */
 #define OLP_SDK_LOG_ERROR_F(tag, ...) \
   OLP_SDK_LOG_F(::olp::logging::Level::Error, tag, __VA_ARGS__)
 
 /**
- * @brief Namespace for the logging library.
+ * @brief A namespace for the logging library.
  */
 namespace olp {
 namespace logging {
@@ -383,36 +397,40 @@ class Configuration;
 class FilterGroup;
 
 /**
- * @brief The NullLogStream class
- *
- * This is used for disabled logs at compile time
+ * @brief Used for disabled logs at compile time.
  */
 class NullLogStream {
  public:
   template <typename T>
+
+  /**
+   * @brief The stream operator to print or serialize the given log stream.
+   */
   NullLogStream& operator<<(const T&) {
     return *this;
   }
 };
 
 /**
- * @brief Primary interface for logging messages.
+ * @brief A primary interface for log messages.
  */
 class CORE_API Log {
  public:
   /**
-   * @brief Configures the logging system.
+   * @brief Configures the log system.
    *
-   * This will override the previous configuration.
-   * @return False if the configuration is invalid. The configuration will not
-   * be changed in this case.
+   * It overrides the previous configuration.
+   *
+   * @return False if the configuration is invalid.
+   * The configuration does not change in this case.
    */
   static bool configure(Configuration configuration);
 
   /**
    * @brief Gets a copy of the current configuration.
    *
-   * This can be used to add an appender and re-configure the system.
+   * Use it to add an appender and reconfigure the system.
+   *
    * @return A copy of the current configuration.
    */
   static Configuration getConfiguration();
@@ -420,90 +438,109 @@ class CORE_API Log {
   /**
    * @brief Sets the default log level.
    *
-   * No messages below this level will be displayed unless overridden by
+   * No messages below this level are displayed unless overridden by
    * specific log tags.
+   *
    * @param level The log level.
    */
   static void setLevel(Level level);
 
   /**
    * @brief Gets the default log level.
+   *
    * @return The log level.
    */
   static Level getLevel();
 
   /**
-   * @brief Sets the log level for a particular tag. This overrides the default.
+   * @brief Sets the log level for a tag.
+   *
+   * It overrides the default configurations.
+   *
    * @param level The log level.
-   * @param tag Tag for the logging component. If empty, this will set the
+   * @param tag The tag for the log component. If empty, it sets the
    * default level.
    */
   static void setLevel(Level level, const std::string& tag);
 
   /**
-   * @brief Sets the log level for a particular tag. This overrides the default.
+   * @brief Sets the log level for a tag.
+   *
+   * It overrides the default configurations.
+   *
    * @param level The log level.
-   * @param tag Tag for the logging component. If empty, this will set the
+   * @param tag The tag for the log component. If empty, it sets the
    * default level.
    */
   static void setLevel(const std::string& level, const std::string& tag);
 
   /**
-   * @brief Gets the log level for a particular tag.
-   * @param tag Tag for the logging component. If empty, this will get the
+   * @brief Gets the log level for a tag.
+   *
+   * @param tag The tag for the log component. If empty, it sets the
    * default level.
-   * @return The log level for the tag, or core::None if unset.
+   *
+   * @return The log level for the tag or `core::None` if the log level is unset.
    */
   static boost::optional<Level> getLevel(const std::string& tag);
 
   /**
-   * @brief Clears the log level for a particular tag, setting it to use the
-   * default.
-   * @param tag Tag for the logging component.
+   * @brief Clears the log level for a tag and sets it to
+   * the default value.
+   *
+   * @param tag The tag for the log component.
    */
   static void clearLevel(const std::string& tag);
 
   /**
-   * @brief Clears the log levels for all tags, setting them to use the default.
+   * @brief Clears the log levels for all tags and sets them to
+   * the default value.
    */
   static void clearLevels();
 
   /**
    * @brief Applies a filter group.
    *
-   * This will clear all of the log levels for specific tags and replace them
+   * It clears all the log levels for tags and replaces them
    * with the levels set in the filter group. If the default log level is set in
-   * the filter group, this will also be applied.
+   * the filter group, it is also applied.
+   *
    * @param filters The filter group to apply.
    */
   static void applyFilterGroup(const FilterGroup& filters);
 
   /**
-   * @brief Returns whether a specific level is enabled by default.
+   * @brief Checks whether a level is enabled by default.
+   *
    * @param level The log level.
-   * @return Whether or not the log is enabled.
+   *
+   * @return True if the log is enabled; false otherwise.
    */
   static bool isEnabled(Level level);
 
   /**
-   * @brief Returns whether or not a log tag is enabled for a specific level.
-   * @param tag Tag for the logging component.
+   * @brief Checks whether a log tag is enabled for a level.
+   *
+   * @param tag The tag for the log component.
    * @param level The log level.
-   * @return Whether or not the log is enabled.
+   *
+   * @return True if the log is enabled; false otherwise.
    */
   static bool isEnabled(Level level, const std::string& tag);
 
   /**
-   * @brief Logs a message to the registered appenders. Outputting to a specific
-   * appender is dependant on whether the appender is enabled for this specific
-   * level.
-   * @param level Log level
-   * @param tag Tag for the logging component.
-   * @param message The log message
-   * @param file Filename of the log caller
-   * @param line Line of the log caller
-   * @param function Function name of the log caller.
-   * @param fullFunction The fully qualified function name of the log caller.
+   * @brief Logs a message to the registered appenders.
+   *
+   * Outputting to the appender depends on whether
+   * the appender is enabled for this level.
+   *
+   * @param level The log level.
+   * @param tag The tag for the log component.
+   * @param message The log message.
+   * @param file The file that generated the message.
+   * @param line The line in the file where the message was logged.
+   * @param function The function that generated the message.
+   * @param fullFunction The fully qualified function that generated the message.
    */
   static void logMessage(Level level, const std::string& tag,
                          const std::string& message, const char* file,

--- a/olp-cpp-sdk-core/include/olp/core/logging/LogMessage.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/LogMessage.h
@@ -26,17 +26,34 @@
 namespace olp {
 namespace logging {
 /**
- * @brief Structure holding the data used for a log message.
+ * @brief Contains data used for a log message.
  */
 struct CORE_API LogMessage {
+  /// The log level.
   Level level{Level::Off};
+
+  /// The tag for the log component.
   const char* tag{nullptr};
+
+  /// The log message.
   const char* message{nullptr};
+
+  /// The file that generated the message.
   const char* file{nullptr};
+
+  /// The line in the file where the message was logged.
   unsigned int line{0};
+
+  /// The function that generated the message.
   const char* function{nullptr};
+
+  /// The fully qualified function that generated the message.
   const char* fullFunction{nullptr};
+
+  /// The timestamp of the message.
   std::chrono::time_point<std::chrono::system_clock> time{};
+
+  /// The thread ID for the thread that generated the message.
   unsigned long threadId{0};
 };
 

--- a/olp-cpp-sdk-core/include/olp/core/logging/MessageFormatter.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/MessageFormatter.h
@@ -33,14 +33,14 @@
 namespace olp {
 namespace logging {
 /**
- * @brief Utility for specifying how messages are formatted.
+ * @brief Specifies how messages are formatted.
  *
- * This provides a common way to declare any message format, which can be
+ * It provides a common way to declare any message format, which can be
  * re-used across appenders that utilize this class.
  *
  * Example: if you want the message to be set to "LOG: level tag - file:line
- * [time] message", where the file is limited to 30 characters (cutting off on
- * the left), line always prints to 5 characters, and time set to HH:MM in UTC
+ * [time] message" where the file is limited to 30 characters (cutting off on
+ * the left), the line always prints up to 5 characters, and time is set to HH:MM in UTC
  * time:
  *
  * @code
@@ -61,10 +61,10 @@ namespace logging {
 class CORE_API MessageFormatter {
  public:
   /**
-   * @brief A mapping from the log level to the name to use.
+   * @brief Maps the log level to its name.
    *
-   * Cast the log level enum value to size_t to use as an index. Off is not a
-   * valid name.
+   * Casts the log level enum value to `size_t` to use as an index.
+   * `Off` is not a valid name.
    */
   using LevelNameMap = std::array<std::string, levelCount>;
 
@@ -72,30 +72,27 @@ class CORE_API MessageFormatter {
    * @brief The type of the element to print out.
    */
   enum class ElementType {
-    String,   ///< A string literal.
-    Level,    ///< The log level for the message. This is formatted as a string.
-    Tag,      ///< The tag for the message. This is formatted as a string. This
-              ///< element will
-              ///  be ommitted if the tag is null or an empty string.
-    Message,  ///< The message for the log. This is formatted as a string.
-    File,     ///< The file that generated the message. This is formatted as a
+    String,   ///< The string literal.
+    Level,    ///< The log level for the message. It is formatted as a string.
+    Tag,      ///< The tag for the log component. It is formatted as a string. This
+              ///< element is
+              ///  omitted if the tag is null or an empty string.
+    Message,  ///< The log message. It is formatted as a string.
+    File,     ///< The file that generated the message. It is formatted as a
               ///< string.
-    Line,     ///< The line that generated the message. This is formatted as an
-              ///< unsigned int.
-    Function,  ///< The function that generated the message. This is formatted
+    Line,     ///< The line in the file where the message was logged. It is formatted as an
+              ///< unsigned integer.
+    Function,  ///< The function that generated the message. It is formatted
                ///< as a string.
     FullFunction,  ///< The fully qualified function that generated the message.
-                   ///< This is
+                   ///< It is
                    ///  formatted as a string.
-    Time,    ///< The timestamp of the message. This is formatted as a time as
-             ///< with
-             ///  strftime().
-    TimeMs,  ///< The millisecond portion of the timestamp. This is formatted as
-             ///< an
-             ///  unsigned int.
-    ThreadId  ///< The thread ID for the thread that generated the message. This
-              ///< is
-              ///  formatted as an unsigned long.
+    Time,    ///< The timestamp of the message. It is formatted as a time using
+             ///  `strftime()`.
+    TimeMs,  ///< The millisecond portion of the timestamp. It is formatted as
+             ///< an unsigned integer.
+    ThreadId  ///< The thread ID of the thread that generated the message.
+              ///< It is formatted as an unsigned long.
   };
 
   /**
@@ -103,33 +100,57 @@ class CORE_API MessageFormatter {
    */
   struct CORE_API Element {
     /**
-     * @brief Constructs this with the element type.
+     * @brief Creates an `Element` instance with the element type.
      *
-     * The format string will be set automatically based on the type.
+     * The format string is set automatically based on the type.
      *
      * @param type_ The element type.
      */
     explicit Element(ElementType type_);
 
     /**
-     * @brief Constructs this with all of the members.
+     * @brief Creates an `Element` instance with all of the members.
+     *
      * @param type_ The element type.
-     * @param format_ The format string. This is a literal when type_ is
-     * ElementType::String.
+     * @param format_ The format string. It is a literal when `type_` is
+     * `ElementType::String`.
      * @param limit_ The number of characters to limit string types before
-     * passing to the formatter. A negative number will cut off from the
-     * beginning of a string, while a positive number will cut off from the end
-     * of the string. A value of zero will leave the input string untouched.
+     * passing to the formatter. A negative number cuts off from the
+     * beginning of the string. A positive number cuts off from the end
+     * of the string. A value of zero leaves the input string untouched.
      */
     inline Element(ElementType type_, std::string format_, int limit_ = 0);
 
+    /// The default copy constructor.
     Element(const Element&) = default;
+
+    /// The default copy operator.
     Element& operator=(const Element&) = default;
 
+    /// The move operator overload.
     inline Element(Element&& other) noexcept;
+
+    /// The move assignment operator overload.
     inline Element& operator=(Element&& other) noexcept;
 
+    /**
+     * @brief Checks whether the values of two `Element` instances
+     * are the same.
+     *
+     * @param other The other `Element` instance.
+     *
+     * @return True if the values are the same; false otherwise.
+     */
     inline bool operator==(const Element& other) const;
+
+    /**
+     * @brief Checks whether the values of two `Element` instances
+     * are not the same.
+     * 
+     * @param other The other `Element` instance.
+     * 
+     * @return True if the values are not the same; false otherwise.
+     */
     inline bool operator!=(const Element& other) const;
 
     /**
@@ -138,10 +159,10 @@ class CORE_API MessageFormatter {
     ElementType type;
 
     /**
-     * @brief The format string for printing out the element.
+     * @brief The format for printing out the element.
      *
-     * This is used as a literal for ElementType::String without passing through
-     * printf.
+     * It is used as a literal for `ElementType::String` without passing through
+     * `printf`.
      */
     std::string format;
 
@@ -149,44 +170,46 @@ class CORE_API MessageFormatter {
      * @brief The number of characters to limit string types before passing to
      * the formatter.
      *
-     * A negative number will cut off from the beginning of a string, while a
-     * positive number will cut off from the end of the string. A value of zero
-     * will leave the input string untouched.
+     * A negative number cuts off from the beginning of a string.
+     * A positive number cuts off from the end of the string. A value of zero
+     * leaves the input string untouched.
      */
     int limit;
   };
 
   /**
-   * @brief Enum for the timezone when printing timestamps.
+   * @brief The timezone used to print timestamps.
    */
   enum class Timezone {
-    Local,  ///< Print times in local time.
-    Utc     ///< Print times in UTC.
+    Local,  ///< Prints time in the local time standard.
+    Utc     ///< Prints time in the UTC standard.
   };
 
   /**
    * @brief Gets the default level name map.
+   *
    * @return The level name map.
    */
   static const LevelNameMap& defaultLevelNameMap();
 
   /**
-   * @brief Makes the default message formatter.
+   * @brief Creates the default message formatter.
    *
-   * This will be of the format "level tag - message".
+   * Format: "level tag - message".
    */
   static MessageFormatter createDefault();
 
   /**
-   * @brief Default constructor.
+   * @brief The default constructor.
    *
-   * The element list will be empty, the level name map will be set to default,
-   * and the timezone will be set to local.
+   * The element list is empty, the level name map is set to default,
+   * and the timezone is set to local.
    */
   inline MessageFormatter();
 
   /**
-   * @brief Constructs this with the elements, level name mapping, and timezone.
+   * @brief Creates the `MessageFormatter` instance with the elements, level name mapping, and timezone.
+   *
    * @param elements The elements for the formatted message.
    * @param levelNameMap The level name map.
    * @param timezone The timezone for timestamps. Defaults to local time.
@@ -196,51 +219,65 @@ class CORE_API MessageFormatter {
       LevelNameMap levelNameMap = defaultLevelNameMap(),
       Timezone timezone = Timezone::Local);
 
+  /// The default copy constructor.
   MessageFormatter(const MessageFormatter&) = default;
+
+  /// The default copy assignment operator.
   MessageFormatter& operator=(const MessageFormatter&) = default;
 
+  /// The move constructor overload.
   inline MessageFormatter(MessageFormatter&& other) noexcept;
+
+  /// The default move assignment operator overload.
   inline MessageFormatter& operator=(MessageFormatter&& other) noexcept;
 
   /**
    * @brief Gets the elements for the format.
+   *
    * @return The elements.
    */
   inline const std::vector<Element>& getElements() const;
 
   /**
    * @brief Sets the elements for the format.
+   *
    * @param elements The elements.
    */
   inline MessageFormatter& setElements(std::vector<Element> elements);
 
   /**
    * @brief Gets the level name map.
+   *
    * @return The level name map.
    */
   inline const LevelNameMap& getLevelNameMap() const;
 
   /**
    * @brief Sets the level name map.
+   *
    * @param map The level name map.
    */
   inline MessageFormatter& setLevelNameMap(LevelNameMap map);
 
   /**
    * @brief Gets the timezone for timestamps.
+   *
    * @return The timezone.
    */
   inline Timezone getTimezone() const;
 
   /**
    * @brief Sets the timezone for timestamps.
+   *
    * @param timezone The timezone.
    */
   inline MessageFormatter& setTimezone(Timezone timezone);
 
   /**
    * @brief Formats a log message.
+   *
    * @param message The message to format.
+   *
    * @return The formatted message.
    */
   std::string format(const LogMessage& message) const;


### PR DESCRIPTION
In olp-cpp-sdk-core/include/olp/core/logging,
review and modify the existing documentation and add missing
descriptions so that we have fewer errors when building the API ref.

Relates-To: OLPEDGE-1446
Signed-off-by: Halyna Dumych <ext-halyna.dumych@here.com>