### PR TITLE
Mark inoperable cache as corrupted

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
@@ -60,9 +60,10 @@ class CORE_API DefaultCache : public KeyValueCache {
    * @brief The storage open result type.
    */
   enum StorageOpenResult {
-    Success,             /*!< The operation succeeded. */
-    OpenDiskPathFailure, /*!< The disk cache failure. */
-    NotReady             /*!< The DefaultCache is closed. */
+    Success,                 /*!< The operation succeeded. */
+    OpenDiskPathFailure,     /*!< The disk cache failure. */
+    ProtectedCacheCorrupted, /*!< The protected disk cache is corrupted. */
+    NotReady                 /*!< The DefaultCache is closed. */
   };
 
   /**
@@ -140,6 +141,10 @@ class CORE_API DefaultCache : public KeyValueCache {
    * operation in parallel for the time of the compacting operation. Be aware
    * that automatic asynchronous compacting operation is triggered internally
    * once the database size exceeds the CacheSettings::max_disk_storage size.
+   *
+   * @note After the compaction is finished the cache is checked on level-0 file
+   * presence. If there are still some files present another round of compaction
+   * is performed.
    */
   void Compact();
 

--- a/olp-cpp-sdk-core/src/cache/DiskCache.h
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.h
@@ -19,8 +19,8 @@
 
 #pragma once
 
-#include <time.h>
 #include <atomic>
+#include <ctime>
 #include <functional>
 #include <limits>
 #include <map>
@@ -55,6 +55,8 @@ class SizeCountingEnv;
 enum class OpenResult {
   /// Opening the store failed. Use openError() for details.
   Fail,
+  /// The store was corrupted or store compaction was interrupted.
+  Corrupted,
   /// The store was corrupted and has been repaired. Internal integrity might be
   /// broken.
   Repaired,
@@ -138,7 +140,7 @@ class DiskCache {
   /// scans.
   std::unique_ptr<leveldb::Iterator> NewIterator(leveldb::ReadOptions options);
 
-  /// Allow batch writting so that we can delete and write multiple values at
+  /// Allow batch writing so that we can delete and write multiple values at
   /// the same time.
   OperationOutcome ApplyBatch(std::unique_ptr<leveldb::WriteBatch> batch);
 


### PR DESCRIPTION
Cache could become inoperable due to several reasons:
- interrupted compaction leads to files on level-0, and this leads to
excessive memory usage during read operations;
- different IO errors for protected cache couldn't be solved with RepairDb
due to read-only nature of this cache (for mutable cache there will be
an attempt to repair it);

Do not remove corrupted cache and just notify a user about it.

Relates-To: OLPSUP-14088
Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>