### PR TITLE
Delete leveldb::DB object on error

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DiskCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.cpp
@@ -268,12 +268,14 @@ OpenResult DiskCache::Open(const std::string& data_path,
     error_ = NoError{};
   }
 
-  if (is_read_only && !CheckCompactionFinished(*db)) {
+  std::unique_ptr<leveldb::DB> tmp_db{db};
+
+  if (is_read_only && !CheckCompactionFinished(*tmp_db)) {
     OLP_SDK_LOG_ERROR(kLogTag, "Open: interrupted compaction detected");
     return OpenResult::Corrupted;
   }
 
-  database_.reset(db);
+  database_.swap(tmp_db);
 
   return OpenResult::Success;
 }


### PR DESCRIPTION
leveldb do not manage DB objects lifetime by itself. So in case of error
or early return from the Open routine leveldb::DB object should be
removed explicitly

Relates-To: OLPSUP-14088
Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>