### PR TITLE
Fix CacheSettings::openOptions not used by cache.

### DIFF
--- a/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.cpp
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <iomanip>
 #include <sstream>
+#include <thread>
 
 #include <rapidjson/document.h>
 #include <rapidjson/istreamwrapper.h>

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -851,7 +851,7 @@ DefaultCache::StorageOpenResult DefaultCacheImpl::SetupMutableCache() {
   mutable_cache_ = std::make_unique<DiskCache>();
   auto status = mutable_cache_->Open(settings_.disk_path_mutable.get(),
                                      settings_.disk_path_mutable.get(),
-                                     storage_settings, OpenOptions::Default);
+                                     storage_settings, settings_.openOptions);
   if (status == OpenResult::Repaired) {
     OLP_SDK_LOG_INFO(kLogTag, "Mutable cache was repaired");
   } else if (status == OpenResult::Fail) {

--- a/olp-cpp-sdk-core/tests/cache/DefaultCacheImplTest.cpp
+++ b/olp-cpp-sdk-core/tests/cache/DefaultCacheImplTest.cpp
@@ -17,8 +17,10 @@
  * License-Filename: LICENSE
  */
 
-#include <gtest/gtest.h>
 #include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
 
 #include <cache/DefaultCacheImpl.h>
 #include <olp/core/utils/Dir.h>

--- a/olp-cpp-sdk-core/tests/cache/DefaultCacheTest.cpp
+++ b/olp-cpp-sdk-core/tests/cache/DefaultCacheTest.cpp
@@ -17,12 +17,12 @@
  * License-Filename: LICENSE
  */
 
-#include <gtest/gtest.h>
-
 #include <chrono>
 #include <fstream>
 #include <string>
 #include <thread>
+
+#include <gtest/gtest.h>
 
 #include <olp/core/cache/CacheSettings.h>
 #include <olp/core/cache/DefaultCache.h>

--- a/olp-cpp-sdk-core/tests/client/OlpClientTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/OlpClientTest.cpp
@@ -17,13 +17,14 @@
  * License-Filename: LICENSE
  */
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-
 #include <chrono>
 #include <future>
 #include <queue>
 #include <string>
+#include <thread>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/OlpClient.h>

--- a/olp-cpp-sdk-core/tests/client/PendingUrlRequestsTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/PendingUrlRequestsTest.cpp
@@ -17,14 +17,15 @@
  * License-Filename: LICENSE
  */
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-
 #include <chrono>
 #include <future>
 #include <queue>
 #include <sstream>
 #include <string>
+#include <thread>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/OlpClient.h>

--- a/olp-cpp-sdk-core/tests/thread/SyncQueueTest.cpp
+++ b/olp-cpp-sdk-core/tests/thread/SyncQueueTest.cpp
@@ -17,11 +17,12 @@
  * License-Filename: LICENSE
  */
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include <atomic>
 #include <chrono>
 #include <thread>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 #include <olp/core/thread/SyncQueue.h>
 
@@ -34,8 +35,7 @@ using SyncQueueIncFifo = olp::thread::SyncQueueFifo<SyncIncType>;
 using SharedQueueType = std::shared_ptr<std::string>;
 using SyncQueueShared = olp::thread::SyncQueueFifo<SharedQueueType>;
 
-using namespace ::testing;
-using namespace std::chrono;
+using milliseconds = std::chrono::milliseconds;
 
 TEST(SyncQueueTest, Initialize) {
   SCOPED_TRACE("Default initialized not closed");
@@ -190,11 +190,12 @@ TEST(SyncQueueTest, ConcurrentUsage) {
   }
 
   // Wait for threads to finish but do not exceed 1min
-  const auto start = system_clock::now();
+  const auto start = std::chrono::system_clock::now();
   auto check_condition = [&]() {
     return counter.load() < kNumThreads &&
-           duration_cast<milliseconds>(system_clock::now() - start).count() <
-               1000u;
+           std::chrono::duration_cast<milliseconds>(
+               std::chrono::system_clock::now() - start)
+                   .count() < 1000u;
   };
 
   while (check_condition()) {
@@ -203,7 +204,7 @@ TEST(SyncQueueTest, ConcurrentUsage) {
 
   // Each thread should have run once, each task executed
   const std::vector<uint32_t> expected(kNumThreads, 1u);
-  EXPECT_THAT(thread_counter, ContainerEq(expected));
+  EXPECT_THAT(thread_counter, ::testing::ContainerEq(expected));
   EXPECT_EQ(kNumThreads, counter.load());
 
   // Close and join all threads

--- a/olp-cpp-sdk-core/tests/thread/ThreadPoolTaskSchedulerTest.cpp
+++ b/olp-cpp-sdk-core/tests/thread/ThreadPoolTaskSchedulerTest.cpp
@@ -17,6 +17,7 @@
  * License-Filename: LICENSE
  */
 
+#include <thread>
 #include <unordered_map>
 
 #include <gmock/gmock.h>

--- a/olp-cpp-sdk-dataservice-read/tests/StreamLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/StreamLayerClientImplTest.cpp
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+#include <thread>
+
 #include <gtest/gtest.h>
 #include <matchers/NetworkUrlMatchers.h>
 #include <mocks/CacheMock.h>

--- a/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientImplTest.cpp
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+#include <thread>
+
 #include <gtest/gtest.h>
 #include <matchers/NetworkUrlMatchers.h>
 #include <mocks/CacheMock.h>

--- a/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+#include <thread>
+
 #include <gtest/gtest.h>
 
 #include <matchers/NetworkUrlMatchers.h>

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-#include "AuthenticationCommonTestFixture.h"
+#include <thread>
 
 #include <gmock/gmock.h>
 
@@ -25,6 +25,7 @@
 #include <olp/core/porting/make_unique.h>
 #include <olp/core/porting/warning_disable.h>
 #include <testutils/CustomParameters.hpp>
+#include "AuthenticationCommonTestFixture.h"
 #include "AuthenticationTestUtils.h"
 #include "TestConstants.h"
 

--- a/tests/functional/olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/AuthenticationCommonTestFixture.cpp
@@ -19,6 +19,8 @@
 
 #include "AuthenticationCommonTestFixture.h"
 
+#include <thread>
+
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>

--- a/tests/functional/olp-cpp-sdk-authentication/DecisionApiTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/DecisionApiTest.cpp
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+#include <thread>
+
 #include <gmock/gmock.h>
 
 #include <olp/authentication/AuthenticationClient.h>

--- a/tests/functional/olp-cpp-sdk-authentication/FacebookAuthenticationTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/FacebookAuthenticationTest.cpp
@@ -17,14 +17,14 @@
  * License-Filename: LICENSE
  */
 
+#include <thread>
+
 #include <olp/core/http/HttpStatusCode.h>
 #include <olp/core/logging/Log.h>
 #include <olp/core/porting/make_unique.h>
 #include "AuthenticationCommonTestFixture.h"
 #include "AuthenticationTestUtils.h"
 #include "TestConstants.h"
-
-using namespace ::olp::authentication;
 
 namespace {
 

--- a/tests/functional/olp-cpp-sdk-authentication/HereAccountOauth2ProductionTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/HereAccountOauth2ProductionTest.cpp
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+#include <thread>
+
 #include <gtest/gtest.h>
 #include <olp/authentication/AuthenticationClient.h>
 #include <olp/authentication/AuthenticationCredentials.h>

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <iostream>
 #include <string>
+#include <thread>
 
 #include <gtest/gtest.h>
 #include <olp/authentication/Settings.h>

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+#include <thread>
+
 #include <gtest/gtest.h>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientTest.cpp
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+#include <thread>
+
 #include <gtest/gtest.h>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+#include <thread>
+
 #include <gtest/gtest.h>
 #include <olp/authentication/TokenProvider.h>
 #include <olp/core/client/ApiError.h>

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVolatileLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVolatileLayerClientTest.cpp
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+#include <thread>
+
 #include <gtest/gtest.h>
 #include <olp/authentication/TokenProvider.h>
 #include <olp/core/client/ApiError.h>

--- a/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+#include <thread>
+
 #include <gmock/gmock.h>
 #include <matchers/NetworkUrlMatchers.h>
 #include <mocks/NetworkMock.h>

--- a/tests/integration/olp-cpp-sdk-core/ApiLookupClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-core/ApiLookupClientTest.cpp
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+#include <thread>
+
 #include <gmock/gmock.h>
 #include <matchers/NetworkUrlMatchers.h>
 #include <mocks/CacheMock.h>

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <numeric>
 #include <string>
+#include <thread>
 
 #include <matchers/NetworkUrlMatchers.h>
 #include <mocks/CacheMock.h>

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientCacheTest.cpp
@@ -20,6 +20,7 @@
 #include "CatalogClientTestBase.h"
 
 #include <regex>
+#include <thread>
 
 #include <gmock/gmock.h>
 #include <matchers/NetworkUrlMatchers.h>

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VolatileLayerClientTest.cpp
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+#include <thread>
+
 #include <gmock/gmock.h>
 #include <matchers/NetworkUrlMatchers.h>
 #include <mocks/NetworkMock.h>

--- a/tests/performance/MemoryTest.cpp
+++ b/tests/performance/MemoryTest.cpp
@@ -19,6 +19,7 @@
 
 #include <chrono>
 #include <memory>
+#include <thread>
 
 #include <gtest/gtest.h>
 #include <olp/core/client/HRN.h>


### PR DESCRIPTION
Mutable cache always created with OpenOptions::Default instead of one
provided by CacheSettings. This makes impossible to enable leveldb crc
check for the cache.

Added somehow missed include needed for std::this_thread::sleep_for.

Relates-To: OAM-1088

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>