### PR TITLE
Abort PrefetchTiles/Data with error on cache issue

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/ApiError.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiError.h
@@ -56,6 +56,17 @@ class CORE_API ApiError {
     return ApiError(ErrorCode::NetworkConnection, description);
   }
 
+  /**
+   * @brief Creates the `ApiError` instance with the precondition failed error
+   * code and description.
+   * @param description The optional description.
+   * @return The `ApiError` instance.
+   */
+  static ApiError PreconditionFailed(
+      const char* description = "Precondition failed") {
+    return ApiError(ErrorCode::PreconditionFailed, description);
+  }
+
   ApiError() = default;
 
   /**

--- a/olp-cpp-sdk-core/include/olp/core/client/ApiNoResult.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiNoResult.h
@@ -19,6 +19,9 @@
 
 #pragma once
 
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiResponse.h>
+
 namespace olp {
 namespace client {
 
@@ -28,6 +31,9 @@ namespace client {
  * Example: the HTTP 200 response with no response body.
  */
 class ApiNoResult {};
+
+/// The alias to the response without result.
+using ApiNoResponse = ApiResponse<ApiNoResult, ApiError>;
 
 }  // namespace client
 }  // namespace olp

--- a/olp-cpp-sdk-core/include/olp/core/client/ErrorCode.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ErrorCode.h
@@ -85,7 +85,12 @@ enum class ErrorCode {
   /**
    * The network connection error.
    */
-  NetworkConnection
+  NetworkConnection,
+
+  /**
+   * A failed cache IO operation.
+   */
+  CacheIO
 };
 
 }  // namespace client

--- a/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
@@ -49,7 +49,7 @@ OlpClientSettingsFactory::CreateDefaultNetworkRequestHandler(
 std::unique_ptr<cache::KeyValueCache>
 OlpClientSettingsFactory::CreateDefaultCache(cache::CacheSettings settings) {
 #ifdef OLP_SDK_ENABLE_DEFAULT_CACHE
-  auto cache = std::make_unique<cache::DefaultCache>(std::move(settings));
+  auto cache = std::make_unique<cache::DefaultCache>(settings);
   auto error = cache->Open();
   if (error == cache::DefaultCache::StorageOpenResult::OpenDiskPathFailure) {
     OLP_SDK_LOG_FATAL_F(

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
@@ -135,7 +135,7 @@ class DATASERVICE_READ_API PartitionsRequest final {
    */
   inline PartitionsRequest& WithBillingTag(
       boost::optional<std::string> billingTag) {
-    billing_tag_ = billingTag;
+    billing_tag_ = std::move(billingTag);
     return *this;
   }
 

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchPartitionsRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PrefetchPartitionsRequest.h
@@ -47,7 +47,7 @@ class DATASERVICE_READ_API PrefetchPartitionsRequest final {
    *
    * When the list is empty, the GetPartitions method will download the whole
    * layer metadata. Additionally, a single request supports up to 100
-   * partitions. If partitions list has more than 100, it will be splitted
+   * partitions. If partitions list has more than 100, it will be split
    * internally to multiple requests.
    *
    * @param partitions The list of partitions to request.
@@ -92,7 +92,7 @@ class DATASERVICE_READ_API PrefetchPartitionsRequest final {
    */
   inline PrefetchPartitionsRequest& WithBillingTag(
       boost::optional<std::string> billing_tag) {
-    billing_tag_ = billing_tag;
+    billing_tag_ = std::move(billing_tag);
     return *this;
   }
 
@@ -147,7 +147,7 @@ class DATASERVICE_READ_API PrefetchPartitionsRequest final {
       out << "@" << version.get();
     }
     out << "^" << partition_ids_.size();
-    if (partition_ids_.size() > 0) {
+    if (!partition_ids_.empty()) {
       out << "[" << partition_ids_.front() << ", ...]";
     }
     if (GetBillingTag()) {

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiNoResult.h>
 #include <olp/core/client/ApiResponse.h>
 
 #include <olp/dataservice/read/AggregatedDataResult.h>

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.h
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <memory>
 
+#include <olp/core/client/ApiNoResult.h>
 #include <olp/core/client/HRN.h>
 #include <olp/dataservice/read/model/Data.h>
 #include <boost/optional.hpp>
@@ -42,8 +43,9 @@ class DataCacheRepository final {
 
   ~DataCacheRepository() = default;
 
-  void Put(const model::Data& data, const std::string& layer_id,
-           const std::string& data_handle);
+  client::ApiNoResponse Put(const model::Data& data,
+                            const std::string& layer_id,
+                            const std::string& data_handle);
 
   boost::optional<model::Data> Get(const std::string& layer_id,
                                    const std::string& data_handle);

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
@@ -49,16 +49,19 @@ class DataRepository final {
   BlobApi::DataResponse GetVersionedData(const std::string& layer_id,
                                          const DataRequest& request,
                                          int64_t version,
-                                         client::CancellationContext context);
+                                         client::CancellationContext context,
+                                         bool fail_on_cache_error = false);
 
   BlobApi::DataResponse GetVolatileData(const std::string& layer_id,
                                         const DataRequest& request,
-                                        client::CancellationContext context);
+                                        client::CancellationContext context,
+                                        bool fail_on_cache_error = false);
 
   BlobApi::DataResponse GetBlobData(const std::string& layer,
                                     const std::string& service,
                                     const DataRequest& request,
-                                    client::CancellationContext context);
+                                    client::CancellationContext context,
+                                    bool fail_on_cache_error = false);
 
  private:
   client::HRN catalog_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <memory>
 
+#include <olp/core/client/ApiNoResult.h>
 #include <olp/core/client/HRN.h>
 #include <olp/dataservice/read/PartitionsRequest.h>
 #include <olp/dataservice/read/model/Partitions.h>
@@ -46,9 +47,10 @@ class PartitionsCacheRepository final {
 
   ~PartitionsCacheRepository() = default;
 
-  void Put(const model::Partitions& partitions,
-           const boost::optional<int64_t>& version,
-           const boost::optional<time_t>& expiry, bool layer_metadata = false);
+  client::ApiNoResponse Put(const model::Partitions& partitions,
+                            const boost::optional<int64_t>& version,
+                            const boost::optional<time_t>& expiry,
+                            bool layer_metadata = false);
 
   model::Partitions Get(const std::vector<std::string>& partition_ids,
                         const boost::optional<int64_t>& version);
@@ -61,8 +63,9 @@ class PartitionsCacheRepository final {
 
   boost::optional<model::LayerVersions> Get(int64_t catalog_version);
 
-  void Put(geo::TileKey tile_key, int32_t depth, const QuadTreeIndex& quad_tree,
-           const boost::optional<int64_t>& version);
+  client::ApiNoResponse Put(geo::TileKey tile_key, int32_t depth,
+                            const QuadTreeIndex& quad_tree,
+                            const boost::optional<int64_t>& version);
 
   bool Get(geo::TileKey tile_key, int32_t depth,
            const boost::optional<int64_t>& version, QuadTreeIndex& tree);

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -67,7 +67,7 @@ class PartitionsRepository {
 
   QueryApi::PartitionsExtendedResponse GetVersionedPartitionsExtendedResponse(
       const read::PartitionsRequest& request, std::int64_t version,
-      client::CancellationContext context);
+      client::CancellationContext context, bool fail_on_cache_error = false);
 
   PartitionsResponse GetPartitionById(const DataRequest& request,
                                       boost::optional<int64_t> version,
@@ -99,7 +99,8 @@ class PartitionsRepository {
       const read::PartitionsRequest& request,
       boost::optional<std::int64_t> version,
       client::CancellationContext context,
-      boost::optional<time_t> expiry = boost::none);
+      boost::optional<time_t> expiry = boost::none,
+      bool fail_on_cache_error = false);
 
   const client::HRN catalog_;
   const std::string layer_id_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -159,7 +159,7 @@ RootTilesForRequest PrefetchTilesRepository::GetSlicedTiles(
 
     auto it = root_tiles_depth.insert({root_tile, max_level - min_level});
     // element already exist, update depth with max value
-    if (it.second == false) {
+    if (!it.second) {
       it.first->second = std::max(it.first->second, max_level - min_level);
     }
     // if depth is greater than kMaxQuadTreeIndexDepth, need to split
@@ -436,7 +436,10 @@ PrefetchTilesRepository::DownloadVersionedQuadTree(
   }
 
   // add to cache
-  cache_repository_.Put(tile, depth, tree, version);
+  const auto put_result = cache_repository_.Put(tile, depth, tree, version);
+  if (!put_result.IsSuccessful()) {
+    return {put_result.GetError(), quad_tree.GetNetworkStatistics()};
+  }
 
   return {std::move(tree), quad_tree.GetNetworkStatistics()};
 }

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -20,18 +20,19 @@ set(OLP_SDK_TESTS_COMMON_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/mocks/NetworkMock.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mocks/CacheMock.h
     ${CMAKE_CURRENT_SOURCE_DIR}/ApiDefaultResponses.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/ReadDefaultResponses.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/WriteDefaultResponses.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/KeyValueCacheTestable.h
     ${CMAKE_CURRENT_SOURCE_DIR}/PlatformUrlsGenerator.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/ReadDefaultResponses.h
     ${CMAKE_CURRENT_SOURCE_DIR}/ResponseGenerator.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/WriteDefaultResponses.h
 )
 
 set(OLP_SDK_TESTS_COMMON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/mocks/CacheMock.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mocks/NetworkMock.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ApiDefaultResponses.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ReadDefaultResponses.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/PlatformUrlsGenerator.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ReadDefaultResponses.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ResponseGenerator.cpp
 )
 

--- a/tests/common/KeyValueCacheTestable.h
+++ b/tests/common/KeyValueCacheTestable.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <olp/core/cache/KeyValueCache.h>
+
+class KeyValueCacheTestable : public olp::cache::KeyValueCache {
+ public:
+  explicit KeyValueCacheTestable(
+      std::shared_ptr<olp::cache::KeyValueCache> base_cache)
+      : base_cache_{std::move(base_cache)} {}
+
+  bool Put(const std::string& key, const boost::any& value,
+           const olp::cache::Encoder& encoder, time_t expiry) override {
+    return base_cache_->Put(key, value, encoder, expiry);
+  }
+
+  bool Put(const std::string& key, const ValueTypePtr value,
+           time_t expiry) override {
+    return base_cache_->Put(key, value, expiry);
+  }
+
+  boost::any Get(const std::string& key,
+                 const olp::cache::Decoder& encoder) override {
+    return base_cache_->Get(key, encoder);
+  }
+
+  ValueTypePtr Get(const std::string& key) override {
+    return base_cache_->Get(key);
+  }
+
+  bool Remove(const std::string& key) override {
+    return base_cache_->Remove(key);
+  }
+
+  bool RemoveKeysWithPrefix(const std::string& prefix) override {
+    return base_cache_->RemoveKeysWithPrefix(prefix);
+  }
+
+  bool Contains(const std::string& key) const override {
+    return base_cache_->Contains(key);
+  }
+
+  bool Protect(const KeyListType& keys) override {
+    return base_cache_->Protect(keys);
+  }
+
+  bool Release(const KeyListType& keys) override {
+    return base_cache_->Release(keys);
+  }
+
+  bool IsProtected(const std::string& key) const override {
+    return base_cache_->IsProtected(key);
+  }
+
+ protected:
+  std::shared_ptr<olp::cache::KeyValueCache> base_cache_;
+};
+
+struct CacheWithPutErrors : public KeyValueCacheTestable {
+  using KeyValueCacheTestable::KeyValueCacheTestable;
+
+  bool Put(const std::string&, const boost::any&, const olp::cache::Encoder&,
+           time_t) override {
+    return false;
+  }
+
+  bool Put(const std::string&, const ValueTypePtr, time_t) override {
+    return false;
+  }
+};


### PR DESCRIPTION
All prefetch operations are required to have properly working cache.
Thus any cache related issue should led to the failed request

Relates-To: OLPEDGE-2552
Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>