### PR TITLE
Refactor the NamedMutex class

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
@@ -32,8 +32,6 @@
 #include "generated/api/ResourcesApi.h"
 #include "repositories/ApiCacheRepository.h"
 
-#include "repositories/NamedMutex.h"
-
 namespace olp {
 namespace dataservice {
 namespace read {
@@ -59,9 +57,9 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApi(
     const client::HRN& catalog,
     client::CancellationContext cancellation_context, std::string service,
     std::string service_version, FetchOptions options,
-    client::OlpClientSettings settings) {
+    client::OlpClientSettings settings, repository::NamedMutexStorage storage) {
   // This mutex is required to avoid concurrent requests to online.
-  repository::NamedMutex mutex(catalog.ToString());
+  repository::NamedMutex mutex(storage, catalog.ToString());
   std::unique_lock<repository::NamedMutex> lock(mutex, std::defer_lock);
 
   // If we are not planning to go online or access the cache, do not lock.

--- a/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.h
+++ b/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.h
@@ -28,6 +28,7 @@
 #include <olp/core/client/OlpClient.h>
 #include "generated/model/Api.h"
 #include "olp/dataservice/read/FetchOptions.h"
+#include "repositories/NamedMutex.h"
 
 namespace olp {
 namespace dataservice {
@@ -45,7 +46,8 @@ class ApiClientLookup {
       const client::HRN& catalog,
       client::CancellationContext cancellation_context, std::string service,
       std::string service_version, FetchOptions options,
-      client::OlpClientSettings settings);
+      client::OlpClientSettings settings,
+      repository::NamedMutexStorage storage = repository::NamedMutexStorage());
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -36,6 +36,7 @@
 #include <olp/dataservice/read/Types.h>
 #include <boost/optional.hpp>
 #include "TaskSink.h"
+#include "repositories/NamedMutex.h"
 
 namespace olp {
 namespace thread {
@@ -124,6 +125,7 @@ class VersionedLayerClientImpl {
   std::atomic<int64_t> catalog_version_;
   client::ApiLookupClient lookup_client_;
   TaskSink task_sink_;
+  repository::NamedMutexStorage mutex_storage_;
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
@@ -28,8 +28,8 @@
 #include <olp/dataservice/read/PartitionsRequest.h>
 #include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/Types.h>
-
 #include "TaskSink.h"
+#include "repositories/NamedMutex.h"
 
 namespace olp {
 
@@ -80,6 +80,7 @@ class VolatileLayerClientImpl {
   client::OlpClientSettings settings_;
   client::ApiLookupClient lookup_client_;
   TaskSink task_sink_;
+  repository::NamedMutexStorage mutex_storage_;
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
@@ -27,6 +27,7 @@
 #include "olp/dataservice/read/DataRequest.h"
 #include "olp/dataservice/read/Types.h"
 
+#include "NamedMutex.h"
 #include "generated/api/BlobApi.h"
 
 namespace olp {
@@ -38,7 +39,8 @@ namespace repository {
 class DataRepository final {
  public:
   DataRepository(client::HRN catalog, client::OlpClientSettings settings,
-                 client::ApiLookupClient client);
+                 client::ApiLookupClient client,
+                 NamedMutexStorage storage = NamedMutexStorage());
 
   DataResponse GetVersionedTile(const std::string& layer_id,
                                 const TileRequest& request, int64_t version,
@@ -62,6 +64,7 @@ class DataRepository final {
   client::HRN catalog_;
   client::OlpClientSettings settings_;
   client::ApiLookupClient lookup_client_;
+  NamedMutexStorage storage_;
 };
 
 }  // namespace repository

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -35,6 +35,7 @@
 #include "olp/dataservice/read/PartitionsRequest.h"
 #include "olp/dataservice/read/Types.h"
 
+#include "NamedMutex.h"
 #include "PartitionsCacheRepository.h"
 
 namespace olp {
@@ -53,7 +54,8 @@ class PartitionsRepository {
  public:
   PartitionsRepository(client::HRN catalog, std::string layer,
                        client::OlpClientSettings settings,
-                       client::ApiLookupClient client);
+                       client::ApiLookupClient client,
+                       NamedMutexStorage storage = NamedMutexStorage());
 
   PartitionsResponse GetVersionedPartitions(
       const read::PartitionsRequest& request, std::int64_t version,
@@ -104,6 +106,7 @@ class PartitionsRepository {
   client::OlpClientSettings settings_;
   client::ApiLookupClient lookup_client_;
   PartitionsCacheRepository cache_;
+  NamedMutexStorage storage_;
 };
 }  // namespace repository
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -31,6 +31,7 @@
 #include <olp/core/geo/tiling/TileKey.h>
 #include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/model/Partitions.h>
+#include "NamedMutex.h"
 #include "PartitionsCacheRepository.h"
 #include "generated/model/Index.h"
 
@@ -54,7 +55,8 @@ class PrefetchTilesRepository {
   PrefetchTilesRepository(
       client::HRN catalog, const std::string& layer_id,
       client::OlpClientSettings settings, client::ApiLookupClient client,
-      boost::optional<std::string> billing_tag = boost::none);
+      boost::optional<std::string> billing_tag = boost::none,
+      NamedMutexStorage mutex_storage = NamedMutexStorage());
 
   /**
    * @brief Given tile keys, return all related tile keys that are between
@@ -129,6 +131,7 @@ class PrefetchTilesRepository {
   client::ApiLookupClient lookup_client_;
   PartitionsCacheRepository cache_repository_;
   boost::optional<std::string> billing_tag_;
+  NamedMutexStorage storage_;
 };
 
 }  // namespace repository

--- a/olp-cpp-sdk-dataservice-read/tests/ApiClientLookupTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/ApiClientLookupTest.cpp
@@ -267,12 +267,14 @@ TEST(ApiClientLookupTest, LookupApiConcurrent) {
   const auto threads_count = 5;
   std::vector<std::thread> threads;
 
+  read::repository::NamedMutexStorage named_mutexes;
+
   for (auto i = 0; i < threads_count; i++) {
     threads.emplace_back([=]() {
       client::CancellationContext context;
       auto response = read::ApiClientLookup::LookupApi(
           catalog_hrn, context, service_name, service_version,
-          read::FetchOptions::OnlineIfNotFound, settings);
+          read::FetchOptions::OnlineIfNotFound, settings, named_mutexes);
     });
   }
 


### PR DESCRIPTION
Refactor the NamedMutex class to avoid using the static global mutex
and storage. Instead, introduce a NamedMutexStorage class as a
temporary solution to avoid crashes and secure the API requests merge
functionality, until the proper implementation is enabled. The storage
is initialized per VersionedLayerClient and VolatileLayerClient.

Resolves: OLPSUP-14327

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>