### PR TITLE
Do not clear cache path on error

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -838,7 +838,6 @@ DefaultCache::StorageOpenResult DefaultCacheImpl::SetupProtectedCache() {
                         settings_.disk_path_protected.get().c_str());
 
     protected_cache_.reset();
-    settings_.disk_path_protected = boost::none;
     return ToStorageOpenResult(status);
   }
 
@@ -859,7 +858,6 @@ DefaultCache::StorageOpenResult DefaultCacheImpl::SetupMutableCache() {
                         settings_.disk_path_mutable.get().c_str());
 
     mutable_cache_.reset();
-    settings_.disk_path_mutable = boost::none;
     return StorageOpenResult::OpenDiskPathFailure;
   }
 


### PR DESCRIPTION
Currently failed cache open leads to removing cache path what interfere
with the idea of cache repair process (either removal or proper fixing)
since we're using the same cache setting during whole cache lifetime

Relates-To: OAM-1088
Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>