### PR TITLE
Add codecov bash script as artifact

### DIFF
--- a/.github/workflows/psv_pipelines.yml
+++ b/.github/workflows/psv_pipelines.yml
@@ -32,6 +32,11 @@ jobs:
     - name: Run unit and integration tests. Report coverage to CodeCov. 
       run: ./scripts/linux/psv/test_psv.sh
       shell: bash
+    - name: Archive code coverage script
+      uses: actions/upload-artifact@v2
+      with:
+        name: codecov-script
+        path: codecov_upload_bash_*.sh
 
   psv-linux-gcc-build-no-cache:
     name: PSV / Linux gcc 7.5 / OLP_SDK_ENABLE_DEFAULT_CACHE=OFF

--- a/scripts/linux/psv/test_psv.sh
+++ b/scripts/linux/psv/test_psv.sh
@@ -42,4 +42,22 @@ echo ">>> Integration Test ... >>>"
 $CPP_TEST_SOURCE_INTEGRATION/olp-cpp-sdk-integration-tests \
     --gtest_output="xml:olp-cpp-sdk-integration-tests-report.xml"
 
-bash <(curl -s https://codecov.io/bash)
+# CodeCov verification stage:
+# https://docs.codecov.io/docs/about-the-codecov-bash-uploader#validating-the-bash-script
+curl -fLso codecov https://codecov.io/bash;
+VERSION=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
+# Loop for 3 types of SHA sums
+for i in 1 256 512
+do
+  shasum -a $i -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM" | grep -w "codecov")
+done
+
+
+curl -S -L --connect-timeout 5 --retry 6 -s https://codecov.io/bash -o codecov_upload_bash_$(date +%s).sh
+cp $(ls codecov_upload_bash_*.sh) codecov_upload_bash.sh
+# Execute CodeCov scanner
+ls -la *.xml
+bash codecov_upload_bash.sh -Z -X fix "$@"
+
+
+#bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Needed for securing this workflow.
On PR we also change approach to load data to codecov.
Updates are based on CodeCov docs.

Relates-To: OLPEDGE-2553

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>