### PR TITLE
Respect mutable cache open error.

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -814,6 +814,10 @@ DefaultCache::StorageOpenResult DefaultCacheImpl::SetupStorage() {
     result = SetupMutableCache();
   }
 
+  if (result != StorageOpenResult::Success) {
+    return result;
+  }
+
   if (settings_.disk_path_protected) {
     result = SetupProtectedCache();
   }


### PR DESCRIPTION
Result of opening protected cache rewrites result of openning mutable
cache. We will miss error if protected cache is ok.

Relates-To: OAM-1088

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>