### PR TITLE
Add the Equal Jitter backdown strategy

### DIFF
--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(OLP_CPP_SDK_CORE_TESTS_SOURCES
     ./cache/ProtectedKeyListTest.cpp
 
     ./client/ApiLookupClientImplTest.cpp
+    ./client/BackdownStrategyTest.cpp
     ./client/CancellationContextTest.cpp
     ./client/ConditionTest.cpp
     ./client/DefaultLookupEndpointProviderTest.cpp

--- a/olp-cpp-sdk-core/tests/client/BackdownStrategyTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/BackdownStrategyTest.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gtest/gtest.h>
+
+#include <olp/core/client/OlpClientSettings.h>
+
+namespace {
+
+TEST(BackdownStrategy, Assign) {
+  {
+    olp::client::OlpClientSettings settings;
+    settings.retry_settings.backdown_strategy =
+        olp::client::EqualJitterBackdownStrategy(std::chrono::seconds(5));
+  }
+  {
+    olp::client::OlpClientSettings settings;
+    settings.retry_settings.backdown_strategy =
+        olp::client::ExponentialBackdownStrategy();
+  }
+}
+
+TEST(BackdownStrategy, EqualJitter_Cap) {
+  const auto cap = std::chrono::seconds(5);
+  olp::client::EqualJitterBackdownStrategy backdown_strategy(cap);
+  const auto base = std::chrono::milliseconds(200);
+  for (auto retry = 0; retry < 100; ++retry) {
+    const auto wait_time = backdown_strategy(base, retry);
+    EXPECT_LE(wait_time, cap);
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
To avoid requests sent after 0 (or close to 0) milliseconds, backdown
strategy changed to support the Equal Jitter, as described in
https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/

Resolves: OLPEDGE-2574

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>