### PR TITLE
Free an WinHttp request after an error.

### DIFF
--- a/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.h
+++ b/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.h
@@ -71,7 +71,7 @@ class NetworkWinHttp : public Network {
     RequestId request_id;
     int status;
     bool completed;
-    bool cancelled;
+    bool error;
 
     std::uint64_t bytes_uploaded;
     std::uint64_t bytes_downloaded;


### PR DESCRIPTION
It seems that in NetworkWinHttp, the previous code only sets the "complete" flag on the Request when all data has been received (line 786). And only with the "completed" flag, the Request gets closed (line 962). So after an error, the request is never completed and thus blocked forever.

Trying to fix this by replacing the unused "cancelling" flag by an "error" flag and then harvesting requests in error state as well.

This has been tested manually up to now only for the case of connecting to an unused port of an existing server (where we get positive information that connection is not possible).