### PR TITLE
Change protected cache behavior

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/CacheSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/CacheSettings.h
@@ -148,11 +148,18 @@ struct CORE_API CacheSettings {
   /**
    * @brief The path to the protected (read-only) cache.
    *
-   * This cache is used as a primary cache for lookup. `DefaultCache` opens this
-   * cache in the read-only mode and does not write to it if
-   * `disk_path_mutable` is empty. Use this cash if you want to have a stable
-   * fallback state or offline data that you can always access regardless of
-   * the network state.
+   * This cache will be used as the primary source for data lookup. The
+   * `DefaultCache` will try to open this cache in the r/w mode to make sure the
+   * database can perform on-open optimizations like write-ahead logging (WAL)
+   * committing or compaction. In case we do not have permission to write on
+   * the provided path, or user set explicitly ReadOnly in the
+   * `CacheSettings::openOptions`, the protected cache will be opened in r/o
+   * mode. In both cases the database will not be opened and user will receive a
+   * `ProtectedCacheCorrupted` from `DefaultCache::Open` in case the database
+   * has after open still an un-commited WAL, is uncompressed or cannot
+   * guarantee a normal operation and RAM usage. Use this cache if you want to
+   * have a stable fallback state or offline data that you can always access
+   * regardless of the network state.
    */
   boost::optional<std::string> disk_path_protected = boost::none;
 };

--- a/olp-cpp-sdk-core/include/olp/core/utils/Dir.h
+++ b/olp-cpp-sdk-core/include/olp/core/utils/Dir.h
@@ -124,6 +124,17 @@ class CORE_API Dir {
    * @return The calculated size.
    */
   static uint64_t Size(const std::string& path, FilterFunction filter_fn = {});
+
+  /**
+   * @brief Checks if the current application and user has a read only access to
+   * given path.
+   *
+   * @param path The path to check for read only access.
+   *
+   * @return True if current application and user has read only access to the
+   * path.
+   */
+  static bool IsReadOnly(const std::string& path);
 };
 
 }  // namespace utils

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -28,6 +28,7 @@
 
 #include "olp/core/logging/Log.h"
 #include "olp/core/porting/make_unique.h"
+#include "olp/core/utils/Dir.h"
 
 namespace {
 using CacheType = olp::cache::DefaultCache::CacheType;
@@ -832,9 +833,24 @@ DefaultCache::StorageOpenResult DefaultCacheImpl::SetupProtectedCache() {
   StorageSettings protected_storage_settings;
   protected_storage_settings.max_file_size = 32 * 1024 * 1024;
 
-  auto status = protected_cache_->Open(
-      settings_.disk_path_protected.get(), settings_.disk_path_protected.get(),
-      protected_storage_settings, OpenOptions::ReadOnly);
+  // In case user requested read-write acccess we will try to open protected
+  // cache as read-write also to prevent high RAM usage when cache is recovering
+  // from uncompacted close.
+  OpenOptions open_mode = settings_.openOptions;
+  bool is_read_only = (settings_.openOptions & ReadOnly) == ReadOnly;
+  if (!is_read_only) {
+    if (utils::Dir::IsReadOnly(settings_.disk_path_protected.get())) {
+      OLP_SDK_LOG_INFO_F(kLogTag,
+                         "R/W permission missing, opening protected cache in "
+                         "r/o mode, disk_path_protected='%s'",
+                         settings_.disk_path_protected.get().c_str());
+      open_mode = static_cast<OpenOptions>(open_mode | OpenOptions::ReadOnly);
+    }
+  }
+
+  auto status = protected_cache_->Open(settings_.disk_path_protected.get(),
+                                       settings_.disk_path_protected.get(),
+                                       protected_storage_settings, open_mode);
   if (status != OpenResult::Success) {
     OLP_SDK_LOG_ERROR_F(kLogTag, "Failed to open protected cache %s",
                         settings_.disk_path_protected.get().c_str());

--- a/olp-cpp-sdk-core/tests/cache/DefaultCacheImplTest.cpp
+++ b/olp-cpp-sdk-core/tests/cache/DefaultCacheImplTest.cpp
@@ -37,7 +37,7 @@ class DefaultCacheImplTest : public ::testing::Test {
  public:
   void SetUp() override {
     // Restore permissions in case if cache_path_ is not writable
-    helpers::MakeDirectoryContentReadonly(cache_path_, false);
+    helpers::MakeDirectoryAndContentReadonly(cache_path_, false);
   }
 
   void TearDown() override { olp::utils::Dir::Remove(cache_path_); }
@@ -974,7 +974,7 @@ TEST_F(DefaultCacheImplTest, ReadOnlyPartitionForProtectedCache) {
   cache1.Close();
 
   // Make readonly
-  ASSERT_TRUE(helpers::MakeDirectoryContentReadonly(cache_path_, true));
+  ASSERT_TRUE(helpers::MakeDirectoryAndContentReadonly(cache_path_, true));
 
   cache::CacheSettings settings2;
   settings2.disk_path_protected = cache_path_;
@@ -985,7 +985,7 @@ TEST_F(DefaultCacheImplTest, ReadOnlyPartitionForProtectedCache) {
   const auto value = cache2.Get(key);
   EXPECT_NE(nullptr, value.get());
   cache2.Close();
-  helpers::MakeDirectoryContentReadonly(cache_path_, false);
+  helpers::MakeDirectoryAndContentReadonly(cache_path_, false);
 }
 
 TEST_F(DefaultCacheImplTest, ProtectTestWithoutMutableCache) {

--- a/olp-cpp-sdk-core/tests/cache/Helpers.h
+++ b/olp-cpp-sdk-core/tests/cache/Helpers.h
@@ -30,5 +30,5 @@ namespace helpers {
  *
  * @return \c true if any file with the given path exists, \c false otherwise.
  */
-bool MakeDirectoryContentReadonly(const std::string& path, bool readonly);
+bool MakeDirectoryAndContentReadonly(const std::string& path, bool readonly);
 }  // namespace helpers

--- a/tests/functional/olp-cpp-sdk-core/DirTest.cpp
+++ b/tests/functional/olp-cpp-sdk-core/DirTest.cpp
@@ -60,6 +60,25 @@ std::string PathBuild(std::string arg1, std::string arg2, Ts... args) {
   return PathBuild(std::string(arg1) + kSeparator + std::string(arg2), args...);
 }
 
+bool SetRights(const std::string& path, bool readonly) {
+#if !defined(_WIN32) || defined(__MINGW32__)
+  mode_t mode;
+  if (readonly) {
+    mode = S_IRUSR | S_IRGRP | S_IROTH;
+  } else {
+    mode = S_IRUSR | S_IWUSR | S_IXUSR;
+  }
+  mode = mode | S_IRGRP | S_IROTH;
+  return chmod(path.c_str(), mode) == 0;
+#else
+  DWORD attributes = GetFileAttributes(path.c_str());
+  attributes = readonly ? attributes | FILE_ATTRIBUTE_READONLY
+                        : attributes & ~FILE_ATTRIBUTE_READONLY;
+  BOOL result = SetFileAttributesA(path.c_str(), attributes);
+  return result != 0;
+#endif
+}
+
 }  // namespace
 
 TEST(DirTest, CheckDirSize) {
@@ -97,4 +116,34 @@ TEST(DirTest, CheckDirSize) {
     EXPECT_EQ(Dir::Size(path), 60u);
   }
   Dir::Remove(path);
+}
+
+TEST(DirTest, IsReadOnlyTest) {
+  std::string path = PathBuild(Dir::TempDirectory(), "temporary_test_dir");
+  Dir::Remove(path);
+  CreateDirectory(path);
+  {
+    SCOPED_TRACE("Directory access right test");
+    EXPECT_FALSE(Dir::IsReadOnly(path));
+  }
+  {
+    SCOPED_TRACE("File access right test");
+    auto file_path = PathBuild(path, "file1");
+    CreateFile(file_path, 1);
+    EXPECT_FALSE(Dir::IsReadOnly(file_path));
+  }
+  {
+    SCOPED_TRACE("Check read only directory");
+    ASSERT_TRUE(SetRights(path, true));
+    EXPECT_TRUE(Dir::IsReadOnly(path));
+    ASSERT_TRUE(SetRights(path, false));
+  }
+  {
+    SCOPED_TRACE("Check read only file");
+    auto file_path = PathBuild(path, "file1");
+    CreateFile(file_path, 1);
+    ASSERT_TRUE(SetRights(file_path, true));
+    EXPECT_TRUE(Dir::IsReadOnly(file_path));
+    ASSERT_TRUE(SetRights(file_path, false));
+  }
 }


### PR DESCRIPTION
* Change protected cache behavior such that it tries to open
  in ReadWrite mode in case when user passed default open options
  to cache settings. If path can be opened as ReadWrite protected
  cache will be opened as ReadWrite otherwise it wil lbe opened in
  ReadOnly mode. This is done to reduce compaction times for leveldb.
* Additional logic was added that will return corruption error
  in case that there is more than 4 L0 leveldb files in protected
  cache.

Resolves: OAM-1116

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>