### PR TITLE
Change the clients destruction sequence

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -124,8 +124,8 @@ class VersionedLayerClientImpl {
   client::OlpClientSettings settings_;
   std::atomic<int64_t> catalog_version_;
   client::ApiLookupClient lookup_client_;
-  TaskSink task_sink_;
   repository::NamedMutexStorage mutex_storage_;
+  TaskSink task_sink_;
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.h
@@ -79,8 +79,8 @@ class VolatileLayerClientImpl {
   std::string layer_id_;
   client::OlpClientSettings settings_;
   client::ApiLookupClient lookup_client_;
-  TaskSink task_sink_;
   repository::NamedMutexStorage mutex_storage_;
+  TaskSink task_sink_;
 };
 
 }  // namespace read


### PR DESCRIPTION
The mutax_storage instances must be destroyed after task sink, since
the currently running parallel tasks may access it.

Resolves: OLPEDGE-2585

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>