### PR TITLE
Remove arbitrary 2s delay on shutdown

### DIFF
--- a/olp-cpp-sdk-core/src/http/android/NetworkAndroid.h
+++ b/olp-cpp-sdk-core/src/http/android/NetworkAndroid.h
@@ -119,13 +119,6 @@ class NetworkAndroid : public Network {
   static void SetJavaVM(JavaVM* vm, jobject application);
 
  private:
-  struct RequestCompletion {
-    RequestCompletion(std::size_t count) : count(count) {}
-
-    std::promise<void> ready;
-    std::size_t count;
-  };
-
   /// Data, which is passed to the JNI as request's data
   struct RequestData {
     RequestData(Network::Callback callback,
@@ -146,7 +139,6 @@ class NetworkAndroid : public Network {
     jobject obj;
     jlong count;
     jlong offset;
-    std::shared_ptr<RequestCompletion> completion;
   };
 
   /// Response data, which is received from HttpClient.java


### PR DESCRIPTION
On devices with slow internet connections this previously introduced a delay of up to two seconds on shutdown. In pathological cases, this could have added up with other Android Activity shutdown operations delays and led to an ANR error.