### PR TITLE
Update docker image for fv job, update scripts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ build_test_linux_fv:
   stage: build
   tags:
   - docker-prod
-  image: ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PERFORMANCE}:${DOCKER_IMAGE_PERFORMANCE_VERSION}
+  image: ${DOCKER_REGISTRY}/${DOCKER_IMAGE_USER}:${DOCKER_IMAGE_USER_VERSION}
   script:
   - $CI_PROJECT_DIR/scripts/linux/fv/gitlab_build_fv.sh
   - $CI_PROJECT_DIR/scripts/linux/fv/gitlab_test_fv.sh

--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-network-test.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-network-test.sh
@@ -45,10 +45,13 @@ do
 done
 
 echo ">>> Installing mock server SSL certificate into OS... >>>"
+#download cert
 curl https://raw.githubusercontent.com/mock-server/mockserver/master/mockserver-core/src/main/resources/org/mockserver/socket/CertificateAuthorityCertificate.pem --output mock-server-cert.pem
-mv mock-server-cert.pem /usr/share/ca-certificates/
-echo "mock-server-cert.pem" >> /etc/ca-certificates.conf
-update-ca-certificates
+#verify cert is in place
+ls -la /usr/share/ca-certificates/mock-server-cert.pem
+cat /etc/ca-certificates.conf
+#install certificate
+sudo update-ca-certificates
 
 echo ">>> Start network tests ... >>>"
 $CI_PROJECT_DIR/build/tests/functional/network/olp-cpp-sdk-functional-network-tests  \

--- a/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test-mock.sh
+++ b/scripts/linux/fv/gitlab-olp-cpp-sdk-functional-test-mock.sh
@@ -43,10 +43,13 @@ do
 done
 
 echo ">>> Installing mock server SSL certificate into OS... >>>"
+#download cert
 curl https://raw.githubusercontent.com/mock-server/mockserver/master/mockserver-core/src/main/resources/org/mockserver/socket/CertificateAuthorityCertificate.pem --output mock-server-cert.pem
-mv mock-server-cert.pem /usr/share/ca-certificates/
-echo "mock-server-cert.pem" >> /etc/ca-certificates.conf
-update-ca-certificates
+#verify cert is in place
+ls -la /usr/share/ca-certificates/mock-server-cert.pem
+cat /etc/ca-certificates.conf
+#install certificate
+sudo update-ca-certificates
 
 echo ">>> Starting Functional Test against Mock Server... >>>"
 $REPO_HOME/build/tests/functional/olp-cpp-sdk-functional-tests \


### PR DESCRIPTION
From now we need docker image with standard user instead of root.
Update fv functional and network test scripts accordingly.

Resolves: OLPEDGE-2683

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>