### PR TITLE
Disable db repair for protected cache.

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -848,9 +848,9 @@ DefaultCache::StorageOpenResult DefaultCacheImpl::SetupProtectedCache() {
     }
   }
 
-  auto status = protected_cache_->Open(settings_.disk_path_protected.get(),
-                                       settings_.disk_path_protected.get(),
-                                       protected_storage_settings, open_mode);
+  auto status = protected_cache_->Open(
+      settings_.disk_path_protected.get(), settings_.disk_path_protected.get(),
+      protected_storage_settings, open_mode, false);
   if (status != OpenResult::Success) {
     OLP_SDK_LOG_ERROR_F(kLogTag, "Failed to open protected cache %s",
                         settings_.disk_path_protected.get().c_str());

--- a/olp-cpp-sdk-core/src/cache/DiskCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.cpp
@@ -190,7 +190,8 @@ void DiskCache::Compact() {
 
 OpenResult DiskCache::Open(const std::string& data_path,
                            const std::string& versioned_data_path,
-                           StorageSettings settings, OpenOptions options) {
+                           StorageSettings settings, OpenOptions options,
+                           bool repair_if_broken) {
   disk_cache_path_ = data_path;
   bool is_read_only = (options & ReadOnly) == ReadOnly;
   if (!olp::utils::Dir::exists(disk_cache_path_)) {
@@ -246,7 +247,7 @@ OpenResult DiskCache::Open(const std::string& data_path,
   }
 
   if (status.IsCorruption() || status.IsIOError()) {
-    if (is_read_only) {
+    if (is_read_only || !repair_if_broken) {
       OLP_SDK_LOG_ERROR_F(
           kLogTag, "Open: cache corrupted, cache_path='%s', error='%s'",
           versioned_data_path.c_str(), status.ToString().c_str());

--- a/olp-cpp-sdk-core/src/cache/DiskCache.h
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.h
@@ -111,7 +111,8 @@ class DiskCache {
   ~DiskCache();
   OpenResult Open(const std::string& data_path,
                   const std::string& versioned_data_path,
-                  StorageSettings settings, OpenOptions options);
+                  StorageSettings settings, OpenOptions options,
+                  bool repair_if_broken = true);
 
   void Close();
   bool Clear();


### PR DESCRIPTION
Now protected cache is opened with rw permissions by default. Repair
must be prohibited, so the user could know the data is corrupted.

Relates-To: OAM-1088
Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>