### PR TITLE
Include <algorithm> in BackdownStrategy.h since it is used there.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/BackdownStrategy.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/BackdownStrategy.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <chrono>
 #include <random>
 


### PR DESCRIPTION
This file uses std::min() and thus should include the <algorithm> header with provices this function.

Relates-To: OLPEDGE-2597

Signed-off-by: Johannes Stille <johannes.stille@here.com>