### PR TITLE
Use the server time correctly

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
@@ -611,7 +611,7 @@ class AUTHENTICATION_API AuthenticationClient {
                                          UserAccountInfoCallback callback);
 
  private:
-  std::unique_ptr<AuthenticationClientImpl> impl_;
+  std::shared_ptr<AuthenticationClientImpl> impl_;
 };
 
 }  // namespace authentication

--- a/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
@@ -27,13 +27,12 @@
 #include "olp/core/client/ApiError.h"
 #include "olp/core/client/CancellationToken.h"
 #include "olp/core/client/ErrorCode.h"
-#include "olp/core/porting/make_unique.h"
 
 namespace olp {
 namespace authentication {
 
 AuthenticationClient::AuthenticationClient(AuthenticationSettings settings)
-    : impl_(std::make_unique<AuthenticationClientImpl>(std::move(settings))) {}
+    : impl_(std::make_shared<AuthenticationClientImpl>(std::move(settings))) {}
 
 AuthenticationClient::~AuthenticationClient() = default;
 

--- a/olp-cpp-sdk-authentication/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-authentication/tests/CMakeLists.txt
@@ -31,7 +31,8 @@ if (ANDROID OR IOS)
 
     target_link_libraries(${OLP_SDK_AUTHENTICATION_TESTS_LIB}
     PRIVATE
-        gtest
+        gmock
+        olp-cpp-sdk-tests-common
         olp-cpp-sdk-authentication
     )
 
@@ -64,7 +65,8 @@ else()
 
     target_link_libraries(olp-cpp-sdk-authentication-tests
         PRIVATE
-            gtest_main
+            gmock_main
+            olp-cpp-sdk-tests-common
             olp-cpp-sdk-authentication
     )
 

--- a/olp-cpp-sdk-core/include/olp/core/client/ApiResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiResponse.h
@@ -98,6 +98,13 @@ class ApiResponse {
    */
   inline const ErrorType& GetError() const { return error_; }
 
+  /**
+   * @brief Operator to check the status of the request attempt.
+   *
+   * @return True if the request is successfully completed; false otherwise.
+   */
+  inline explicit operator bool() const { return IsSuccessful(); }
+
  private:
   ResultType result_{};
   ErrorType error_{};


### PR DESCRIPTION
Fix the various APIs in authentication component to use the server
time when the `use_system_time` option is false.

Server time is now incremented on retry.

Add a bool operator to ApiResponse class, a shortcut to IsSuccessful.

Relates-To: OLPSUP-14833

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>