### PR TITLE
Correct Dir::FileExist() method for windows.

### DIFF
--- a/olp-cpp-sdk-core/src/utils/Dir.cpp
+++ b/olp-cpp-sdk-core/src/utils/Dir.cpp
@@ -381,14 +381,9 @@ bool Dir::FileExists(const std::string& file_path) {
   const TCHAR* syspath = file_path.c_str();
 #endif  // _UNICODE
 
-  // Returns RET_OK, only if it finds directory
+  // If file not found attributes are 'INVALID_FILE_ATTRIBUTES'
   DWORD attributes = GetFileAttributes(syspath);
-
-  if (attributes == INVALID_FILE_ATTRIBUTES) {
-    return false;
-  }
-
-  return (attributes & FILE_ATTRIBUTE_NORMAL) != 0;
+  return attributes != INVALID_FILE_ATTRIBUTES;
 
 #else  // _WIN32
 


### PR DESCRIPTION
WinApi GetFileAttributes() returns INVALID_FILE_ATTRIBUTES if file not
found. We must use the constant to decide is file exist or not.

Relates-To: OAM-1154
Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>