### PR TITLE
Wrap the leveldb::Env to shared_ptr

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DiskCache.h
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.h
@@ -166,11 +166,12 @@ class DiskCache {
   leveldb::Options CreateOpenOptions(const StorageSettings& settings,
                                      bool is_read_only) const;
 
+  const std::shared_ptr<leveldb::Env> env_;
   std::string disk_cache_path_;
-  std::unique_ptr<leveldb::DB> database_;
   std::unique_ptr<const leveldb::FilterPolicy> filter_policy_;
   std::unique_ptr<SizeCountingEnv> environment_;
   std::unique_ptr<LevelDBLogger> leveldb_logger_;
+  std::unique_ptr<leveldb::DB> database_;
   uint64_t max_size_{kSizeMax};
   bool check_crc_{false};
   bool enforce_immediate_flush_{false};

--- a/olp-cpp-sdk-core/src/cache/DiskCacheEnv.h
+++ b/olp-cpp-sdk-core/src/cache/DiskCacheEnv.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <leveldb/env.h>
 
 namespace olp {
@@ -27,7 +29,7 @@ namespace cache {
 /// The wrapper for a leveldb default environment
 class DiskCacheEnv {
  public:
-  static leveldb::Env* Env();
+  static std::shared_ptr<leveldb::Env> CreateEnv();
 };
 
 }  // namespace cache


### PR DESCRIPTION
Change the static EnvWrapper instance to a wrapped with a smart
pointer, so that we can guaranty that the instance will be alive while
it is needed, even when the `env` was deinitialized at exit.
By this we fix the scenario when the environment is destroyed before
DiskCache in certain use cases.

Resolves: OLPSUP-14933

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>