### PR TITLE
Don't send request if bearer token is empty.

### DIFF
--- a/olp-cpp-sdk-core/tests/client/OlpClientTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/OlpClientTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1635,6 +1635,25 @@ TEST_P(OlpClientTest, ApiKey) {
       call_wrapper_->CallApi("here.com", "GET", {}, {}, {}, nullptr, {});
 
   future.wait();
+  testing::Mock::VerifyAndClearExpectations(network.get());
+}
+
+TEST_P(OlpClientTest, EmptyBearerToken) {
+  // Make token provider generate empty strings. We expect no network requests
+  // made in this case.
+  auto authentication_settings = olp::client::AuthenticationSettings();
+  authentication_settings.provider = []() { return std::string(""); };
+  auto network = network_;
+  client_settings_.authentication_settings = authentication_settings;
+  client_.SetSettings(client_settings_);
+
+  EXPECT_CALL(*network, Send(_, _, _, _, _)).Times(0);
+
+  auto response =
+      call_wrapper_->CallApi("here.com", "GET", {}, {}, {}, nullptr, {});
+  EXPECT_EQ(response.GetStatus(),
+            static_cast<int>(http::ErrorCode::AUTHORIZATION_ERROR));
+
   testing::Mock::VerifyAndClearExpectations(network.get());
 }
 

--- a/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientGetDataTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientGetDataTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,7 @@ TEST_F(VersionedLayerClientGetDataTest, GetDataFromPartitionAsync) {
   auto partition = std::to_string(0);
   const auto data = mockserver::ReadDefaultResponses::GenerateData();
   {
+    mock_server_client_->MockAuth();
     mock_server_client_->MockLookupResourceApiResponse(
         mockserver::ApiDefaultResponses::GenerateResourceApisResponse(
             kTestHrn));


### PR DESCRIPTION
If during authorization error happened, token will be empty. We don't
propagate error, but at least request should not be sent in this case.

Relates-To: OLPEDGE-2607
Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>