### PR TITLE
Add missed includes.

### DIFF
--- a/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
+++ b/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
@@ -19,11 +19,13 @@
 
 #include "NetworkWinHttp.h"
 
+#include <algorithm>
 #include <cassert>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "olp/core/http/HttpStatusCode.h"

--- a/olp-cpp-sdk-dataservice-read/src/PrefetchTilesHelper.h
+++ b/olp-cpp-sdk-dataservice-read/src/PrefetchTilesHelper.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <memory>
 #include <utility>
 #include <vector>

--- a/olp-cpp-sdk-dataservice-read/src/QueryMetadataJob.h
+++ b/olp-cpp-sdk-dataservice-read/src/QueryMetadataJob.h
@@ -19,7 +19,9 @@
 
 #pragma once
 
+#include <algorithm>
 #include <iterator>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/olp-cpp-sdk-dataservice-read/src/StreamLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/StreamLayerClientImpl.cpp
@@ -19,8 +19,12 @@
 
 #include "StreamLayerClientImpl.h"
 
+#include <algorithm>
 #include <iterator>
 #include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <olp/core/cache/DefaultCache.h>
 #include <olp/core/client/CancellationContext.h>
@@ -371,7 +375,7 @@ client::CancellableFuture<PollResponse> StreamLayerClientImpl::Poll() {
   });
 
   return olp::client::CancellableFuture<PollResponse>(std::move(cancel_token),
-                                                        std::move(promise));
+                                                      std::move(promise));
 }
 
 client::CancellationToken StreamLayerClientImpl::Seek(

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -19,7 +19,12 @@
 
 #include "VolatileLayerClientImpl.h"
 
+#include <algorithm>
 #include <iterator>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <olp/core/cache/DefaultCache.h>
 #include <olp/core/client/CancellationContext.h>

--- a/tests/common/ResponseGenerator.cpp
+++ b/tests/common/ResponseGenerator.cpp
@@ -19,6 +19,7 @@
 
 #include "ResponseGenerator.h"
 
+#include <algorithm>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Some files that use for_each and transform have missed <algorithm>
in includes.

Relates-To: OLPEDGE-2614

Signed-off-by: Iuliia Moroz <ext-iuliia.moroz@here.com>