### PR TITLE
Add OLP server start before running perf test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ weekly_perf_reports:
   script:
     - mkdir -p reports .public
     - $CI_PROJECT_DIR/scripts/linux/weekly/gitlab_build_perf_tests.sh
-    - python3 $CI_PROJECT_DIR/scripts/linux/weekly/run_performance_test_metrics.py
+    - $CI_PROJECT_DIR/scripts/linux/weekly/gitlab_run_perf_test_metrics.sh
     - cat $CI_PROJECT_DIR/scripts/linux/weekly/reports/index.html >> .public/index.html && cat $CI_PROJECT_DIR/scripts/linux/weekly/performance_tests.json >> .public/performance_tests.json
     - if $(ls $CI_PROJECT_DIR/reports/*.xml &>/dev/null); then tar -czvf ${CI_JOB_NAME}_test_reports.tar.gz $CI_PROJECT_DIR/reports ; fi;
     - $CI_PROJECT_DIR/scripts/misc/artifactory_upload.sh edge-sdks/sdk-for-cpp/releases/test-reports/$CI_JOB_NAME/$CI_JOB_ID/${CI_JOB_NAME}_test_reports.tar.gz $CI_PROJECT_DIR/${CI_JOB_NAME}_test_reports.tar.gz

--- a/scripts/linux/weekly/gitlab_run_perf_test_metrics.sh
+++ b/scripts/linux/weekly/gitlab_run_perf_test_metrics.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -ex
+#
+# Copyright (C) 2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+# Script run olp-cpp-sdk-performance-tests with metrics collecting
+
+# For core dump backtrace
+ulimit -c unlimited
+
+# Start local server
+node tests/utils/olp_server/server.js & export SERVER_PID=$!
+
+# Node can start server in 1 second, but not faster.
+# Add waiter for server to be started. No other way to solve that.
+# Curl returns code 1 - means server still down. Curl returns 0 when server is up
+RC=1
+while [[ ${RC} -ne 0 ]];
+do
+        set +e
+        curl -s http://localhost:3000
+        RC=$?
+        sleep 0.2
+        set -e
+done
+echo ">>> Local Server started for further performance test ... >>>"
+
+# Measure Disk I/O and CPU/RAM
+# Run test with metrics collector
+python3 $CI_PROJECT_DIR/scripts/linux/weekly/run_performance_test_metrics.py
+
+# Terminate the OLP server
+kill -TERM $SERVER_PID
+
+wait

--- a/scripts/linux/weekly/performance_tests.json
+++ b/scripts/linux/weekly/performance_tests.json
@@ -9,7 +9,8 @@
           "max_mem",
           "avg_mem",
           "max_cpu",
-          "avg_cpu"
+          "avg_cpu",
+          "total_written_to_disk_bytes"
         ]
       }
     ],
@@ -32,6 +33,13 @@
             "values": [
               {"Maximum": "max_mem"},
               {"Average": "avg_mem"}
+            ]
+          },
+          {
+            "name": "Disk usage",
+            "units": "MB",
+            "values": [
+              {"Total": "total_written_to_disk_mb"}
             ]
           }
         ]

--- a/scripts/linux/weekly/run_performance_test_metrics.py
+++ b/scripts/linux/weekly/run_performance_test_metrics.py
@@ -292,8 +292,8 @@ def main():
     all_metrics = {}
     calculate_cpu_and_memory(args.test_exec, test_infos, all_metrics)
 
-    # Needed for more complicated measurements in future
-    #run_all_tests(args.test_exec, test_infos, all_metrics)
+    # Needed for more complicated measurements which are collected in tests itself
+    run_all_tests(args.test_exec, test_infos, all_metrics)
 
     pprint.pprint(all_metrics)
 


### PR DESCRIPTION
Add new bash script which:
- start olp mock server
- verify it's started
- start performance test execution.
Currently test is running without olp server,
but errors are as warnings

Relates-To: OLPEDGE-1771

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>