### PR TITLE
Fix possible underflow in TokenResult

### DIFF
--- a/olp-cpp-sdk-authentication/src/TokenResult.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenResult.cpp
@@ -31,7 +31,9 @@ TokenResult::TokenResult(std::string access_token, time_t expiry_time,
       expiry_time_(expiry_time),
       http_status_(http_status),
       error_(std::move(error)) {
-  expires_in_ = std::chrono::seconds(expiry_time_ - std::time(nullptr));
+  const auto now = std::time(nullptr);
+  expires_in_ =
+      std::chrono::seconds(expiry_time_ > now ? (expiry_time_ - now) : 0);
 }
 
 TokenResult::TokenResult(std::string access_token,


### PR DESCRIPTION
Fix possible underflow in TokenResult

Resolves: OLPEDGE-2628

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>