### PR TITLE
Remove pessimizing move (as complained about by GCC)

### DIFF
--- a/olp-cpp-sdk-authentication/src/ResponseFromJsonBuilder.h
+++ b/olp-cpp-sdk-authentication/src/ResponseFromJsonBuilder.h
@@ -115,7 +115,7 @@ class ResponseFromJsonBuilder {
                               kTargetTypeName.c_str(), field.first.c_str());
       }
 
-      return std::move(result);
+      return result;
     }
 
    private:


### PR DESCRIPTION
std::move()'ing a local variable prevents copy elision, which would be
faster than std::move() itself.