### PR TITLE
Possibility to read the local catalogs added

### DIFF
--- a/olp-cpp-sdk-core/src/client/DefaultLookupEndpointProvider.cpp
+++ b/olp-cpp-sdk-core/src/client/DefaultLookupEndpointProvider.cpp
@@ -27,13 +27,14 @@ std::string DefaultLookupEndpointProvider::operator()(
   constexpr struct {
     const char* partition;
     const char* url;
-  } kDatastoreServerUrl[4] = {
+  } kDatastoreServerUrl[5] = {
       {"here", "https://api-lookup.data.api.platform.here.com/lookup/v1"},
       {"here-dev",
        "https://api-lookup.data.api.platform.sit.here.com/lookup/v1"},
       {"here-cn", "https://api-lookup.data.api.platform.hereolp.cn/lookup/v1"},
       {"here-cn-dev",
-       "https://api-lookup.data.api.platform.in.hereolp.cn/lookup/v1"}};
+       "https://api-lookup.data.api.platform.in.hereolp.cn/lookup/v1"},
+      {"local", "http://localhost:31005/lookup/v1"}};
 
   for (const auto& it : kDatastoreServerUrl) {
     if (partition == it.partition)

--- a/olp-cpp-sdk-core/tests/client/DefaultLookupEndpointProviderTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/DefaultLookupEndpointProviderTest.cpp
@@ -33,7 +33,8 @@ TEST(DefaultLookupEndpointProviderTest, ParenthesisOperator) {
        "https://api-lookup.data.api.platform.sit.here.com/lookup/v1"},
       {"here-cn", "https://api-lookup.data.api.platform.hereolp.cn/lookup/v1"},
       {"here-cn-dev",
-       "https://api-lookup.data.api.platform.in.hereolp.cn/lookup/v1"}};
+       "https://api-lookup.data.api.platform.in.hereolp.cn/lookup/v1"},
+      {"local", "http://localhost:31005/lookup/v1"}};
 
   auto provider = client::DefaultLookupEndpointProvider();
 


### PR DESCRIPTION
This allows developers to be able to visually inspect
locally compiled test catalog of a small region
during feature development or bugfixing.

Resolves: HARP-16305

Signed-off-by: Ostap <ostapkl@gmail.com>