### PR TITLE
Extend Network.h abstract API Doxygen for Cancel.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/http/Network.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/Network.h
@@ -92,10 +92,26 @@ class CORE_API Network {
                            DataCallback data_callback = nullptr) = 0;
 
   /**
-   * @brief Cancels the request using `RequestId`.
+   * @brief Cancels the request associated with the given `RequestId`.
    *
-   * When the request is canceled, the user receives a final `Callback` with
-   * an appropriate `NetworkResponse` marked as canceled.
+   * When the request is canceled, the user receives a final callback with
+   * an appropriate `NetworkResponse` marked as canceled as illustrated in the
+   * following code snippet:
+   *
+   * @code
+   *
+   * auto response =
+   *     http::NetworkResponse()
+   *         .WithRequestId(id)
+   *         .WithBytesDownloaded(download_bytes)
+   *         .WithBytesUploaded(upload_bytes)
+   *         .WithStatus(static_cast<int>(http::ErrorCode::CANCELLED_ERROR))
+   *         .WithError("Cancelled");
+   *
+   * @endcode
+   *
+   * @note If the provided `RequestId` does not match any pending requests, no
+   * operations will be performed, and no callbacks will be called.
    *
    * @param[in] id The unique ID of the request that you want to cancel.
    */


### PR DESCRIPTION
The current Doxygen description for the API Network::Cancel() did not
state clearly how the cancelled NetworkResponse will look like.
This commit adds the missing description with an example code snippet
to illustrate how the response will look like so that the user can
check the appropriate parameters properly.

Resolves: #1246

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>