### PR TITLE
Add RetrySettings for authentication

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationSettings.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationSettings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 #include <string>
 
 #include <olp/authentication/AuthenticationApi.h>
+#include <olp/core/client/RetrySettings.h>
 #include <olp/core/http/NetworkProxySettings.h>
 #include <boost/optional.hpp>
 
@@ -89,6 +90,12 @@ struct AUTHENTICATION_API AuthenticationSettings {
    * authentication server.
    */
   bool use_system_time{true};
+
+  /**
+   * @brief A collection of settings that controls how failed requests should be
+   * treated.
+   */
+  client::RetrySettings retry_settings;
 };
 
 }  // namespace authentication

--- a/olp-cpp-sdk-authentication/include/olp/authentication/Settings.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/Settings.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 
+#include <olp/core/client/RetrySettings.h>
 #include <olp/core/http/NetworkProxySettings.h>
 
 #include "AuthenticationApi.h"
@@ -98,6 +99,12 @@ struct AUTHENTICATION_API Settings {
    * authentication server.
    */
   bool use_system_time{true};
+
+  /**
+   * @brief A collection of settings that controls how failed requests should be
+   * treated.
+   */
+  client::RetrySettings retry_settings;
 };
 
 }  // namespace authentication

--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenProvider.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenProvider.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,9 +119,9 @@ class TokenProvider {
 
     /// @copydoc TokenProvider::operator()()
     std::string operator()() const {
-      return GetResponse().IsSuccessful()
-                 ? GetResponse().GetResult().GetAccessToken()
-                 : "";
+      auto response = GetResponse();
+      return response.IsSuccessful() ? response.GetResult().GetAccessToken()
+                                     : "";
     }
 
     /// @copydoc TokenProvider::GetErrorResponse()

--- a/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -264,8 +264,7 @@ client::OlpClient CreateOlpClient(
   settings.network_request_handler = auth_settings.network_request_handler;
   settings.authentication_settings = authentication_settings;
   settings.proxy_settings = auth_settings.network_proxy_settings;
-  settings.retry_settings.backdown_strategy =
-      client::ExponentialBackdownStrategy();
+  settings.retry_settings = auth_settings.retry_settings;
 
   if (!retry) {
     settings.retry_settings.max_attempts = 0;

--- a/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ AuthenticationSettings ConvertSettings(Settings settings) {
   auth_settings.network_request_handler = settings.network_request_handler;
   auth_settings.token_endpoint_url = settings.token_endpoint_url;
   auth_settings.use_system_time = settings.use_system_time;
+  auth_settings.retry_settings = settings.retry_settings;
   return auth_settings;
 }
 }  // namespace

--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -81,6 +81,7 @@ set(OLP_SDK_CLIENT_HEADERS
     ./include/olp/core/client/OlpClientSettings.h
     ./include/olp/core/client/OlpClientSettingsFactory.h
     ./include/olp/core/client/PendingRequests.h
+    ./include/olp/core/client/RetrySettings.h
     ./include/olp/core/client/TaskContext.h
 )
 
@@ -253,11 +254,11 @@ set(OLP_SDK_CLIENT_SOURCES
     ./src/client/HRN.cpp
     ./src/client/OlpClient.cpp
     ./src/client/OlpClientFactory.cpp
-    ./src/client/OlpClientSettings.cpp
     ./src/client/OlpClientSettingsFactory.cpp
     ./src/client/PendingRequests.cpp
     ./src/client/PendingUrlRequests.h
     ./src/client/PendingUrlRequests.cpp
+    ./src/client/RetrySettings.cpp
     ./src/client/Tokenizer.h
 )
 

--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,11 +26,11 @@
 
 #include <boost/optional.hpp>
 
-#include <olp/core/client/BackdownStrategy.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/DefaultLookupEndpointProvider.h>
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/HttpResponse.h>
+#include <olp/core/client/RetrySettings.h>
 #include <olp/core/http/Network.h>
 
 namespace olp {
@@ -60,11 +60,6 @@ using NetworkAsyncCallback = std::function<void(HttpResponse)>;
  * Used to cancel the asynchronous network operation.
  */
 using NetworkAsyncCancel = std::function<void()>;
-
-/**
- * @brief The default retry condition that disables retries.
- */
-CORE_API bool DefaultRetryCondition(const olp::client::HttpResponse& response);
 
 /**
  * @brief A set of settings that manages the `TokenProviderCallback` and
@@ -144,63 +139,6 @@ struct CORE_API AuthenticationSettings {
    * details.
    */
   boost::optional<TokenProviderCancelCallback> cancel;
-};
-
-/**
- * @brief A collection of settings that controls how failed requests should be
- * treated by the Data SDK.
- *
- * For example, it specifies whether the failed request should be retried, how
- * long Data SDK needs to wait for the next retry attempt, the number of maximum
- * retries, and so on.
- *
- * You can customize all of these settings. The settings are used internally by
- * the `OlpClient` class.
- */
-struct CORE_API RetrySettings {
-  /**
-   * @brief Calculates the number of retry timeouts based on
-   * the initial backdown duration and retries count.
-   */
-  using BackdownStrategy = std::function<std::chrono::milliseconds(
-      std::chrono::milliseconds, size_t)>;
-
-  /**
-   * @brief Checks whether the retry is desired.
-   *
-   * @see `HttpResponse` for more details.
-   */
-  using RetryCondition = std::function<bool(const HttpResponse&)>;
-
-  /**
-   * @brief The number of attempts.
-   *
-   * The default value is 3.
-   */
-  int max_attempts = 3;
-
-  /**
-   * @brief The connection timeout limit (in seconds).
-   */
-  int timeout = 60;
-
-  /**
-   * @brief The period between the error and the first retry attempt (in
-   * milliseconds).
-   */
-  int initial_backdown_period = 200;
-
-  /**
-   * @brief The backdown strategy.
-   *
-   * Defines the delay between retries on a failed request.
-   */
-  BackdownStrategy backdown_strategy = ExponentialBackdownStrategy();
-
-  /**
-   * @brief Evaluates responses to determine if the retry should be attempted.
-   */
-  RetryCondition retry_condition = DefaultRetryCondition;
 };
 
 /**

--- a/olp-cpp-sdk-core/include/olp/core/client/RetrySettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/RetrySettings.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <chrono>
+#include <functional>
+
+#include <olp/core/client/BackdownStrategy.h>
+#include <olp/core/client/HttpResponse.h>
+
+namespace olp {
+namespace client {
+
+/**
+ * @brief The default retry condition that disables retries.
+ */
+CORE_API bool DefaultRetryCondition(const olp::client::HttpResponse& response);
+
+/**
+ * @brief A collection of settings that controls how failed requests should be
+ * treated by the Data SDK.
+ *
+ * For example, it specifies whether the failed request should be retried, how
+ * long Data SDK needs to wait for the next retry attempt, the number of maximum
+ * retries, and so on.
+ *
+ * You can customize all of these settings. The settings are used internally by
+ * the `OlpClient` class.
+ */
+struct CORE_API RetrySettings {
+  /**
+   * @brief Calculates the number of retry timeouts based on
+   * the initial backdown duration and retries count.
+   */
+  using BackdownStrategy = std::function<std::chrono::milliseconds(
+      std::chrono::milliseconds, size_t)>;
+
+  /**
+   * @brief Checks whether the retry is desired.
+   *
+   * @see `HttpResponse` for more details.
+   */
+  using RetryCondition = std::function<bool(const HttpResponse&)>;
+
+  /**
+   * @brief The number of attempts.
+   *
+   * The default value is 3.
+   */
+  int max_attempts = 3;
+
+  /**
+   * @brief The connection timeout limit (in seconds).
+   */
+  int timeout = 60;
+
+  /**
+   * @brief The period between the error and the first retry attempt (in
+   * milliseconds).
+   */
+  int initial_backdown_period = 200;
+
+  /**
+   * @brief The backdown strategy.
+   *
+   * Defines the delay between retries on a failed request.
+   */
+  BackdownStrategy backdown_strategy = ExponentialBackdownStrategy();
+
+  /**
+   * @brief Evaluates responses to determine if the retry should be attempted.
+   */
+  RetryCondition retry_condition = DefaultRetryCondition;
+};
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/client/RetrySettings.cpp
+++ b/olp-cpp-sdk-core/src/client/RetrySettings.cpp
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-#include "olp/core/client/OlpClientSettings.h"
+#include "olp/core/client/RetrySettings.h"
 
 #include <random>
 


### PR DESCRIPTION
olp::authentication::AuthenticationSettings and olp::authentication::Settings
structs are extended with RetrySettings.

AuthentificationClientImpl now uses user defined retry settings instead of hardcoded values.

Fixed double token request bug in TokenProvider.

Relates-To: OLPEDGE-2634, OLPSUP-15460

Signed-off-by: Mykola Malik <ext-mykola.malik@here.com>