### PR TITLE
Add LMDB to external libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ option(OLP_SDK_BUILD_EXAMPLES "Enable examples targets" OFF)
 option(OLP_SDK_MSVC_PARALLEL_BUILD_ENABLE "Enable parallel build on MSVC" ON)
 option(OLP_SDK_DISABLE_DEBUG_LOGGING "Disable debug and trace level logging" OFF)
 option(OLP_SDK_ENABLE_DEFAULT_CACHE "Enable default cache implementation" ON)
+option(OLP_SDK_ENABLE_DEFAULT_CACHE_LMDB "Enable default cache implementation based on LMDB" OFF)
 
 # C++ standard version. Minimum supported version is 11.
 set(CMAKE_CXX_STANDARD 11)

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ cmake --build . --target docs
 | `OLP_SDK_MSVC_PARALLEL_BUILD_ENABLE` (Windows Only) | Defaults to `ON`. If enabled, the `/MP` compilation flag is added to build the Data SDK using multiple cores. |
 | `OLP_SDK_DISABLE_DEBUG_LOGGING`| Defaults to `OFF`. If enabled, the debug and trace level log messages are not printed. |
 | `OLP_SDK_ENABLE_DEFAULT_CACHE `| Defaults to `ON`. If enabled, the default cache implementation based on the LevelDB backend is enabled. |
+| `OLP_SDK_ENABLE_DEFAULT_CACHE_LMDB `| Defaults to `OFF`. If enabled, the default cache implementation based on the LMDB backend is enabled. |
 
 ## Use the SDK
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -54,6 +54,9 @@ set(OLP_SDK_CPP_RAPIDJSON_TAG "master")
 set(OLP_SDK_CPP_BOOST_URL "https://github.com/boostorg/boost.git")
 set(OLP_SDK_CPP_BOOST_TAG "boost-1.72.0")
 
+set(OLP_SDK_CPP_LMDB_URL "https://github.com/LMDB/lmdb.git")
+set(OLP_SDK_CPP_LMDB_TAG "LMDB_0.9.29")
+
 # Add external projects
 find_package(GTest QUIET)
 if(NOT TARGET GTest AND NOT GTest_FOUND)
@@ -72,6 +75,15 @@ if(OLP_SDK_ENABLE_DEFAULT_CACHE)
         set(leveldb_DIR ${EXTERNAL_leveldb_DIR} PARENT_SCOPE)
         set(leveldb_INCLUDE_DIR ${EXTERNAL_leveldb_INCLUDE_DIR} PARENT_SCOPE)
         set(Snappy_DIR ${EXTERNAL_Snappy_DIR} PARENT_SCOPE)
+    endif()
+endif()
+
+if(OLD_SDK_ENABLE_DEFAULT_CACHE_LMDB)
+    find_package(lmdb QUIET)
+    if(NOT TARGET lmdb AND NOT lmdb_FOUND)
+        add_subdirectory(lmdb)
+        set(lmdb_DIR ${EXTERNAL_lmdb_DIR} PARENT_SCOPE)
+        set(lmdb_INCLUDE_DIR ${EXTERNAL_lmdb_INCLUDE_DIR} PARENT_SCOPE)
     endif()
 endif()
 

--- a/external/lmdb/CMakeLists-lmdb.txt
+++ b/external/lmdb/CMakeLists-lmdb.txt
@@ -1,0 +1,66 @@
+# Copyright (C) 2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required(VERSION 3.9)
+
+project(lmdb VERSION 0.9.29 LANGUAGES C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+set(LMDB_SOURCE_DIR "libraries/liblmdb")
+
+add_library(lmdb "")
+
+target_sources(lmdb
+  PRIVATE
+    "${PROJECT_SOURCE_DIR}/${LMDB_SOURCE_DIR}/lmdb.h"
+    "${PROJECT_SOURCE_DIR}/${LMDB_SOURCE_DIR}/mdb.c"
+    "${PROJECT_SOURCE_DIR}/${LMDB_SOURCE_DIR}/midl.c"
+    "${PROJECT_SOURCE_DIR}/${LMDB_SOURCE_DIR}/midl.h"
+)
+
+target_include_directories(lmdb
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+include(GNUInstallDirs)
+install(TARGETS lmdb
+    EXPORT lmdbTargets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+install(
+    FILES
+      "${PROJECT_SOURCE_DIR}/${LMDB_SOURCE_DIR}/lmdb.h"
+      "${PROJECT_SOURCE_DIR}/${LMDB_SOURCE_DIR}/midl.h"
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lmdb
+  )
+install(
+    EXPORT lmdbTargets
+    NAMESPACE lmdb::
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/lmdb"
+)
+install(
+    FILES
+        "${PROJECT_SOURCE_DIR}/cmake/lmdbConfig.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/lmdb"
+)

--- a/external/lmdb/CMakeLists.txt
+++ b/external/lmdb/CMakeLists.txt
@@ -1,0 +1,49 @@
+# Copyright (C) 2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+# Download and unpack lmdb at configure time
+configure_file(CMakeLists.txt.lmdb.in download/CMakeLists.txt)
+
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" . ${COMMON_GENERATE_FLAGS}
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/download)
+if(result)
+  message(FATAL_ERROR "CMake step for lmdb failed: ${result}")
+endif()
+
+# Copy CMakeLists
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists-lmdb.txt
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/config/lmdb)
+file(RENAME ${CMAKE_CURRENT_BINARY_DIR}/config/lmdb/CMakeLists-lmdb.txt
+     ${CMAKE_CURRENT_BINARY_DIR}/config/lmdb/CMakeLists.txt)
+
+# Copy lmdbConfig.cmake
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/lmdbConfig.cmake.in
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/config/lmdb/cmake)
+file(RENAME ${CMAKE_CURRENT_BINARY_DIR}/config/lmdb/cmake/lmdbConfig.cmake.in
+     ${CMAKE_CURRENT_BINARY_DIR}/config/lmdb/cmake/lmdbConfig.cmake)
+
+execute_process(COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_BUILD_TYPE}
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/download)
+if(result)
+  message(FATAL_ERROR "Build step for lmdb failed: ${result}")
+endif()
+
+# Provide the dir to the lmdb cmake configuration files
+set(EXTERNAL_lmdb_DIR ${EXTERNAL_BINARY_INSTALL_DIR}/lib/cmake/lmdb PARENT_SCOPE)
+set(EXTERNAL_lmdb_INCLUDE_DIR ${EXTERNAL_BINARY_INSTALL_DIR}/include PARENT_SCOPE)

--- a/external/lmdb/CMakeLists.txt.lmdb.in
+++ b/external/lmdb/CMakeLists.txt.lmdb.in
@@ -1,0 +1,36 @@
+# Copyright (C) 2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required(VERSION 3.9)
+
+project(lmdb-download NONE)
+
+include(ExternalProject)
+
+ExternalProject_Add(lmdb
+  GIT_REPOSITORY    @OLP_SDK_CPP_LMDB_URL@
+  GIT_TAG           @OLP_SDK_CPP_LMDB_TAG@
+  GIT_SHALLOW       1
+  INSTALL_DIR       "@EXTERNAL_BINARY_INSTALL_DIR@"
+  PATCH_COMMAND     "${CMAKE_COMMAND}" -E copy_directory "${CMAKE_CURRENT_BINARY_DIR}/config/lmdb" "${CMAKE_CURRENT_BINARY_DIR}/download/lmdb-prefix/src/lmdb/."
+  CMAKE_ARGS        @COMMON_PLATFORM_FLAGS@
+                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                    -DCMAKE_BUILD_TYPE=@CMAKE_BUILD_TYPE@
+                    -DCMAKE_SYSTEM_PREFIX_PATH=<INSTALL_DIR>
+                    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+  TEST_COMMAND      ""
+)

--- a/external/lmdb/lmdbConfig.cmake.in
+++ b/external/lmdb/lmdbConfig.cmake.in
@@ -1,0 +1,18 @@
+# Copyright (C) 2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+include("${CMAKE_CURRENT_LIST_DIR}/lmdbTargets.cmake")

--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -28,6 +28,10 @@ if(OLP_SDK_ENABLE_DEFAULT_CACHE)
     find_package(leveldb REQUIRED)
 endif()
 
+if(OLD_SDK_ENABLE_DEFAULT_CACHE_LMDB)
+    find_package(lmdb REQUIRED)
+endif()
+
 configure_file(./include/olp/core/Config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/olp/core/Config.h)
 
 include(configs/ConfigNetwork.cmake)
@@ -372,6 +376,10 @@ if(OLP_SDK_ENABLE_DEFAULT_CACHE)
     set(OLP_SDK_CORE_SOURCES ${OLP_SDK_CORE_SOURCES} ${OLP_SDK_CACHE_SOURCES})
 endif()
 
+if(OLP_SDK_ENABLE_DEFAULT_CACHE_LMDB)
+    # TODO: include LMDB cache implementation source files here
+endif()
+
 add_library(${PROJECT_NAME} ${OLP_SDK_CORE_SOURCES} ${OLP_SDK_CORE_HEADERS})
 
 if (OLP_SDK_DISABLE_DEBUG_LOGGING)
@@ -425,6 +433,17 @@ if(OLP_SDK_ENABLE_DEFAULT_CACHE)
     target_link_libraries(${PROJECT_NAME}
         PRIVATE
             leveldb::leveldb
+    )
+endif()
+
+if(OLD_SDK_ENABLE_DEFAULT_CACHE_LMDB)
+    target_include_directories(${PROJECT_NAME}
+        PUBLIC
+            $<BUILD_INTERFACE:${lmdb_INCLUDE_DIR}>
+    )
+    target_link_libraries(${PROJECT_NAME}
+        PRIVATE
+            lmdb::lmdb
     )
 endif()
 


### PR DESCRIPTION
lmdb is added to external libraries. CMakeLists.txt.lmdb.in and
lmdbConfig.cmake.in was created for lmdb.
Changes in olp-cpp-sdk-core and external CMakeLists.txt was made.
Added OLP_SDK_ENABLE_DEFAULT_CACHE_LMDB option to be able to
enable/disable build of lmdb. README.md was changed with
description of a new flag.

Resolves: OLPEDGE-2645

Signed-off-by: Yevhen Krasilnyk <bebetia@ukr.net>