### PR TITLE
Add new token_provider to AuthenticationSettings

### DIFF
--- a/examples/ProtectedCacheExample.cpp
+++ b/examples/ProtectedCacheExample.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ int RunExampleReadWithCache(const AccessKey& access_key,
   // Setup AuthenticationSettings with a default token provider that will
   // retrieve an OAuth 2.0 token from OLP.
   olp::client::AuthenticationSettings auth_settings;
-  auth_settings.provider =
+  auth_settings.token_provider =
       olp::authentication::TokenProviderDefault(std::move(settings));
 
   // Create and initialize cache

--- a/examples/ReadExample.cpp
+++ b/examples/ReadExample.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,7 +143,7 @@ int RunExampleRead(const AccessKey& access_key, const std::string& catalog,
   // Setup AuthenticationSettings with a default token provider that will
   // retrieve an OAuth 2.0 token from OLP.
   olp::client::AuthenticationSettings auth_settings;
-  auth_settings.provider =
+  auth_settings.token_provider =
       olp::authentication::TokenProviderDefault(std::move(settings));
 
   // Setup OlpClientSettings and provide it to the CatalogClient.

--- a/examples/WriteExample.cpp
+++ b/examples/WriteExample.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,8 @@
 #include <fstream>
 #include <iostream>
 
-using namespace olp::dataservice::write;
-using namespace olp::dataservice::write::model;
+namespace datawrite = olp::dataservice::write;
+namespace model = datawrite::model;
 
 namespace {
 const std::string kData("hello world");  // data to write
@@ -61,7 +61,7 @@ int RunExampleWrite(const AccessKey& access_key, const std::string& catalog,
   // Setup AuthenticationSettings with a default token provider that will
   // retrieve an OAuth 2.0 token from OLP.
   olp::client::AuthenticationSettings auth_settings;
-  auth_settings.provider =
+  auth_settings.token_provider =
       olp::authentication::TokenProviderDefault(std::move(settings));
 
   // Setup OlpClientSettings and provide it to the StreamLayerClient.
@@ -69,13 +69,14 @@ int RunExampleWrite(const AccessKey& access_key, const std::string& catalog,
   client_settings.authentication_settings = auth_settings;
   client_settings.network_request_handler = std::move(http_client);
 
-  auto stream_client_settings = StreamLayerClientSettings{};
-  auto client = std::make_shared<StreamLayerClient>(
+  auto stream_client_settings = datawrite::StreamLayerClientSettings{};
+  auto client = std::make_shared<datawrite::StreamLayerClient>(
       olp::client::HRN{catalog}, std::move(stream_client_settings),
       std::move(client_settings));
 
   // Create a publish data request
-  auto request = PublishDataRequest().WithData(buffer).WithLayerId(layer_id);
+  auto request =
+      model::PublishDataRequest().WithData(buffer).WithLayerId(layer_id);
 
   // Single publish to stream layer
   {
@@ -110,7 +111,7 @@ int RunExampleWrite(const AccessKey& access_key, const std::string& catalog,
     }
 
     // Flush and wait for uploading
-    auto flush_request = FlushRequest();
+    auto flush_request = model::FlushRequest();
     auto future_response = client->Flush(std::move(flush_request));
     auto responses = future_response.GetFuture().get();
     if (responses.empty()) {

--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenProvider.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenProvider.h
@@ -31,6 +31,7 @@
 #include <olp/authentication/TokenResult.h>
 #include <olp/authentication/Types.h>
 #include <olp/core/client/CancellationContext.h>
+#include <olp/core/client/OauthToken.h>
 #include <olp/core/http/HttpStatusCode.h>
 #include <olp/core/utils/WarningWorkarounds.h>
 
@@ -102,10 +103,11 @@ class TokenProvider {
    *
    * @param context Used to cancel the pending token request.
    *
-   * @returns An `TokenResult` if the response is successful; an
-   * `AuthenticationError` otherwise.
+   * @returns An `OauthTokenResponse` if the response is successful; an
+   * `ApiError` otherwise.
    */
-  TokenResponse operator()(client::CancellationContext& context) const {
+  client::OauthTokenResponse operator()(
+      client::CancellationContext& context) const {
     return impl_->operator()(context);
   }
 
@@ -142,9 +144,14 @@ class TokenProvider {
       return response ? response.GetResult().GetAccessToken() : "";
     }
 
-    /// @copydoc TokenProvider::operator()(client::CancellationContext)
-    TokenResponse operator()(client::CancellationContext& context) const {
-      return GetResponse(context);
+    /// @copydoc TokenProvider::operator()(client::CancellationContext&)
+    client::OauthTokenResponse operator()(
+        client::CancellationContext& context) const {
+      const auto response = GetResponse(context);
+      return response ? client::OauthTokenResponse(
+                            {response.GetResult().GetAccessToken(),
+                             response.GetResult().GetExpiryTime()})
+                      : client::OauthTokenResponse(response.GetError());
     }
 
     /// @copydoc TokenProvider::GetErrorResponse()

--- a/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.cpp
@@ -98,6 +98,7 @@ constexpr auto kOperator = "operator";
 // Values
 constexpr auto kErrorWrongTimestamp = 401204;
 constexpr auto kLogTag = "AuthenticationClient";
+const auto kMaxTime = std::numeric_limits<time_t>::max();
 
 bool HasWrongTimestamp(olp::authentication::SignInResult& result) {
   const auto& error_response = result.GetErrorResponse();
@@ -714,7 +715,10 @@ client::CancellationToken AuthenticationClientImpl::IntrospectApp(
     }
 
     client::AuthenticationSettings auth_settings;
-    auth_settings.provider = [&access_token]() { return access_token; };
+    auth_settings.token_provider =
+        [&access_token](client::CancellationContext&) {
+          return client::OauthToken(access_token, kMaxTime);
+        };
 
     client::OlpClient client = CreateOlpClient(settings_, auth_settings);
 
@@ -757,7 +761,10 @@ client::CancellationToken AuthenticationClientImpl::Authorize(
     }
 
     client::AuthenticationSettings auth_settings;
-    auth_settings.provider = [&access_token]() { return access_token; };
+    auth_settings.token_provider =
+        [&access_token](client::CancellationContext&) {
+          return client::OauthToken(access_token, kMaxTime);
+        };
 
     client::OlpClient client = CreateOlpClient(settings_, auth_settings);
 
@@ -813,7 +820,10 @@ client::CancellationToken AuthenticationClientImpl::GetMyAccount(
     }
 
     client::AuthenticationSettings auth_settings;
-    auth_settings.provider = [&access_token]() { return access_token; };
+    auth_settings.token_provider =
+        [&access_token](client::CancellationContext&) {
+          return client::OauthToken(access_token, kMaxTime);
+        };
 
     client::OlpClient client = CreateOlpClient(settings_, auth_settings);
 

--- a/olp-cpp-sdk-authentication/src/TokenResult.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenResult.cpp
@@ -19,10 +19,6 @@
 
 #include <olp/authentication/TokenResult.h>
 
-namespace {
-const std::string kOauth2TokenEndpoint = "/oauth2/token";
-}  // namespace
-
 namespace olp {
 namespace authentication {
 TokenResult::TokenResult(std::string access_token, time_t expiry_time,

--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -80,6 +80,7 @@ set(OLP_SDK_CLIENT_HEADERS
     ./include/olp/core/client/FetchOptions.h
     ./include/olp/core/client/HRN.h
     ./include/olp/core/client/HttpResponse.h
+    ./include/olp/core/client/OauthToken.h
     ./include/olp/core/client/OlpClient.h
     ./include/olp/core/client/OlpClientFactory.h
     ./include/olp/core/client/OlpClientSettings.h
@@ -256,6 +257,7 @@ set(OLP_SDK_CLIENT_SOURCES
     ./src/client/CancellationToken.cpp
     ./src/client/DefaultLookupEndpointProvider.cpp
     ./src/client/HRN.cpp
+    ./src/client/OauthToken.cpp
     ./src/client/OlpClient.cpp
     ./src/client/OlpClientFactory.cpp
     ./src/client/OlpClientSettingsFactory.cpp

--- a/olp-cpp-sdk-core/include/olp/core/client/OauthToken.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OauthToken.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <chrono>
+#include <ctime>
+#include <string>
+
+#include <olp/core/CoreApi.h>
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiResponse.h>
+
+namespace olp {
+namespace client {
+/**
+ * @brief A parsed response received from the OAuth2.0 token endpoint.
+ *
+ * You can get the following information: the access token issued by
+ * the authorization server ( \ref GetAccessToken ) and its expiry time
+ * ( \ref GetExpiryTime ).
+ */
+class CORE_API OauthToken {
+ public:
+  /**
+   * @brief Creates the `OauthToken` instance.
+   *
+   * @param access_token The access token issued by the authorization server.
+   * @param expiry_time The Epoch time when the token expires.
+   */
+  OauthToken(std::string access_token, time_t expiry_time);
+
+  /**
+   * @brief Creates the `OauthToken` instance.
+   *
+   * @param access_token The access token issued by the authorization server.
+   * @param expires_in The expiry time of the access token.
+   */
+  OauthToken(std::string access_token, std::chrono::seconds expires_in);
+
+  /**
+   * @brief Creates the default `OauthToken` instance.
+   */
+  OauthToken() = default;
+
+  /**
+   * @brief Gets the access token issued by the authorization server.
+   *
+   * @return The access token issued by the authorization server.
+   */
+  const std::string& GetAccessToken() const;
+
+  /**
+   * @brief Gets the Epoch time when the token expires.
+   *
+   * @return The Epoch time when the token expires.
+   */
+  time_t GetExpiryTime() const;
+
+  /**
+   * @brief Gets the number of seconds the token is still valid for.
+   *
+   * @return The number of seconds the token is still valid for.
+   */
+  std::chrono::seconds GetExpiresIn() const;
+
+ private:
+  std::string access_token_;
+  std::chrono::seconds expires_in_;
+  time_t expiry_time_;
+};
+
+using OauthTokenResponse = ApiResponse<OauthToken, ApiError>;
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/client/OauthToken.cpp
+++ b/olp-cpp-sdk-core/src/client/OauthToken.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/core/client/OauthToken.h>
+
+namespace olp {
+namespace client {
+OauthToken::OauthToken(std::string access_token, time_t expiry_time)
+    : access_token_(std::move(access_token)), expiry_time_(expiry_time) {
+  const auto now =
+      std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  expires_in_ =
+      std::chrono::seconds(expiry_time_ > now ? (expiry_time_ - now) : 0);
+}
+
+OauthToken::OauthToken(std::string access_token,
+                       std::chrono::seconds expires_in)
+    : access_token_(std::move(access_token)),
+      expires_in_(std::move(expires_in)),
+      expiry_time_(std::chrono::system_clock::to_time_t(
+                       std::chrono::system_clock::now()) +
+                   expires_in_.count()) {}
+
+const std::string& OauthToken::GetAccessToken() const { return access_token_; }
+
+time_t OauthToken::GetExpiryTime() const { return expiry_time_; }
+
+std::chrono::seconds OauthToken::GetExpiresIn() const { return expires_in_; }
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplPublishToBatchTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplPublishToBatchTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ class VersionedLayerClientImplPublishToBatchTest : public ::testing::Test {
     olp::authentication::TokenProviderDefault provider(auth_settings);
 
     olp::client::AuthenticationSettings auth_client_settings;
-    auth_client_settings.provider = provider;
+    auth_client_settings.token_provider = provider;
 
     settings_.network_request_handler = network_;
     settings_.cache = cache_;

--- a/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ class VersionedLayerClientImplTest : public ::testing::Test {
     olp::authentication::TokenProviderDefault provider(auth_settings);
 
     olp::client::AuthenticationSettings auth_client_settings;
-    auth_client_settings.provider = provider;
+    auth_client_settings.token_provider = provider;
 
     settings_.network_request_handler = network_;
     settings_.cache = cache_;

--- a/tests/functional/olp-cpp-sdk-authentication/HereAccountOauth2ProductionTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/HereAccountOauth2ProductionTest.cpp
@@ -292,15 +292,13 @@ TEST_F(HereAccountOuauth2ProductionTest, TokenProviderValidCredentialsValid) {
   olp::client::CancellationContext context;
   auto token_response = prov(context);
   ASSERT_TRUE(token_response);
-  EXPECT_EQ(olp::http::HttpStatusCode::OK,
-            token_response.GetResult().GetHttpStatus());
+  EXPECT_FALSE(token_response.GetResult().GetAccessToken().empty());
 
   ASSERT_TRUE(prov);
 
   token_response = prov(context);
   ASSERT_TRUE(token_response);
-  EXPECT_EQ(olp::http::HttpStatusCode::OK,
-            token_response.GetResult().GetHttpStatus());
+  EXPECT_FALSE(token_response.GetResult().GetAccessToken().empty());
 }
 
 TEST_F(HereAccountOuauth2ProductionTest, TokenProviderValidCredentialsInvalid) {

--- a/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
@@ -64,7 +64,7 @@ class ApiTest : public ::testing::Test {
 
     olp::authentication::TokenProviderDefault provider(authentication_settings);
     olp::client::AuthenticationSettings auth_client_settings;
-    auth_client_settings.provider = provider;
+    auth_client_settings.token_provider = provider;
 
     settings_ = std::make_shared<olp::client::OlpClientSettings>();
     settings_->authentication_settings = auth_client_settings;

--- a/tests/functional/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
@@ -136,7 +136,7 @@ class CatalogClientTest : public ::testing::TestWithParam<CacheType> {
             .WithType(olp::http::NetworkProxySettings::Type::HTTP);
     olp::authentication::TokenProviderDefault provider(auth_settings);
     olp::client::AuthenticationSettings auth_client_settings;
-    auth_client_settings.provider = provider;
+    auth_client_settings.token_provider = provider;
 
     settings_ = olp::client::OlpClientSettings();
     settings_.network_request_handler = network;

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -54,7 +54,7 @@ class DataserviceReadVersionedLayerClientTest : public ::testing::Test {
 
     olp::authentication::TokenProviderDefault provider(auth_settings);
     olp::client::AuthenticationSettings auth_client_settings;
-    auth_client_settings.provider = provider;
+    auth_client_settings.token_provider = provider;
 
     settings_ = std::make_shared<olp::client::OlpClientSettings>();
     settings_->network_request_handler = network;

--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVolatileLayerClientTest.cpp
@@ -80,7 +80,7 @@ class VolatileLayerClientTest : public ::testing::Test {
 
     olp::authentication::TokenProviderDefault provider(authentication_settings);
     olp::client::AuthenticationSettings auth_client_settings;
-    auth_client_settings.provider = provider;
+    auth_client_settings.token_provider = provider;
     settings_ = olp::client::OlpClientSettings();
     settings_.network_request_handler = network;
     settings_.authentication_settings = auth_client_settings;
@@ -103,7 +103,7 @@ class VolatileLayerClientTest : public ::testing::Test {
     prefetch_auth_settings.network_request_handler = network;
 
     olp::client::AuthenticationSettings prefetch_auth_client_settings;
-    prefetch_auth_client_settings.provider =
+    prefetch_auth_client_settings.token_provider =
         olp::authentication::TokenProviderDefault(prefetch_auth_settings);
 
     prefetch_settings_.authentication_settings = prefetch_auth_client_settings;

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteIndexLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteIndexLayerClientTest.cpp
@@ -78,7 +78,7 @@ class DataserviceWriteIndexLayerClientTest : public ::testing::Test {
     olp::authentication::TokenProviderDefault provider(authentication_settings);
 
     olp::client::AuthenticationSettings auth_client_settings;
-    auth_client_settings.provider = provider;
+    auth_client_settings.token_provider = provider;
 
     olp::client::OlpClientSettings settings;
     settings.authentication_settings = auth_client_settings;

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientCacheTest.cpp
@@ -149,7 +149,7 @@ class DataserviceWriteStreamLayerClientCacheTest : public ::testing::Test {
     olp::authentication::TokenProviderDefault provider(authentication_settings);
 
     olp::client::AuthenticationSettings auth_client_settings;
-    auth_client_settings.provider = provider;
+    auth_client_settings.token_provider = provider;
 
     olp::client::OlpClientSettings settings;
     settings.authentication_settings = auth_client_settings;

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteStreamLayerClientTest.cpp
@@ -194,7 +194,7 @@ class DataserviceWriteStreamLayerClientTest : public ::testing::Test {
     olp::authentication::TokenProviderDefault provider(authentication_settings);
 
     olp::client::AuthenticationSettings auth_client_settings;
-    auth_client_settings.provider = provider;
+    auth_client_settings.token_provider = provider;
 
     olp::client::OlpClientSettings settings;
     settings.authentication_settings = auth_client_settings;

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVersionedLayerClientTest.cpp
@@ -81,7 +81,7 @@ class DataserviceWriteVersionedLayerClientTest : public ::testing::Test {
     olp::authentication::TokenProviderDefault provider(authentication_settings);
 
     olp::client::AuthenticationSettings auth_client_settings;
-    auth_client_settings.provider = provider;
+    auth_client_settings.token_provider = provider;
 
     olp::client::OlpClientSettings settings;
     settings.authentication_settings = auth_client_settings;

--- a/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVolatileLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-write/DataserviceWriteVolatileLayerClientTest.cpp
@@ -93,7 +93,7 @@ class DataserviceWriteVolatileLayerClientTest : public ::testing::Test {
     olp::authentication::TokenProviderDefault provider(authentication_settings);
 
     olp::client::AuthenticationSettings auth_client_settings;
-    auth_client_settings.provider = provider;
+    auth_client_settings.token_provider = provider;
 
     olp::client::OlpClientSettings settings;
     settings.authentication_settings = auth_client_settings;

--- a/tests/functional/utils/SetupMockServer.h
+++ b/tests/functional/utils/SetupMockServer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ class SetupMockServer {
         mockserver::SetupMockServer::CreateProxySettings();
     olp::authentication::TokenProviderDefault provider(auth_settings);
     olp::client::AuthenticationSettings auth_client_settings;
-    auth_client_settings.provider = provider;
+    auth_client_settings.token_provider = provider;
 
     auto settings = std::make_shared<olp::client::OlpClientSettings>();
     settings->network_request_handler = network;

--- a/tests/integration/olp-cpp-sdk-dataservice-write/VersionedLayerClientPublishToBatchTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/VersionedLayerClientPublishToBatchTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ class VersionedLayerClientPublishToBatchTest : public ::testing::Test {
     olp::authentication::TokenProviderDefault provider(auth_settings);
 
     olp::client::AuthenticationSettings auth_client_settings;
-    auth_client_settings.provider = provider;
+    auth_client_settings.token_provider = provider;
 
     settings_.network_request_handler = network_;
     settings_.task_scheduler =

--- a/tests/integration/olp-cpp-sdk-dataservice-write/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/VersionedLayerClientTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ class VersionedLayerClientTest : public ::testing::Test {
     olp::authentication::TokenProviderDefault provider(auth_settings);
 
     olp::client::AuthenticationSettings auth_client_settings;
-    auth_client_settings.provider = provider;
+    auth_client_settings.token_provider = provider;
 
     settings_.network_request_handler = network_;
     settings_.cache =

--- a/tests/performance/MemoryTestBase.h
+++ b/tests/performance/MemoryTestBase.h
@@ -68,7 +68,9 @@ class MemoryTestBase : public ::testing::TestWithParam<Param> {
     network->WithTimeouts(parameter.with_network_timeouts);
 
     olp::client::AuthenticationSettings auth_settings;
-    auth_settings.provider = []() { return "invalid"; };
+    auth_settings.token_provider = [](olp::client::CancellationContext&) {
+      return olp::client::OauthToken("invalid", -1);
+    };
 
     olp::client::OlpClientSettings client_settings;
     client_settings.authentication_settings = auth_settings;


### PR DESCRIPTION
Its signature is the same as the signature of the new operator() of
TokenProvider.
    
AuthenticationSettings::provider and its type alias are deprecated.
    
New class OauthToken is added to core API.
    
New operator() of TokenProvider return type is switched to use
olp::client::OauthToken.

Relates-To: OLPEDGE-2598

Signed-off-by: Mykola Malik <ext-mykola.malik@here.com>