### PR TITLE
Fix the backwards compatibility for the old token provider

### DIFF
--- a/olp-cpp-sdk-core/src/client/OlpClient.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClient.cpp
@@ -425,7 +425,7 @@ boost::optional<client::ApiError> OlpClient::OlpClientImpl::AddBearer(
 
     token = response.GetResult().GetAccessToken();
   } else if (settings->provider) {
-    auto token = settings->provider();
+    token = settings->provider();
   } else {
     // There is no token provider defined.
     return boost::none;


### PR DESCRIPTION
Fix the backwards compatibility when using the old authentication
provider.

Relates-To: OAM-2598

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>