### PR TITLE
Expose cache keys creation.

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -62,6 +62,7 @@ include(cmake/ios.cmake)
 set(OLP_SDK_CACHE_HEADERS
     ./include/olp/core/cache/CacheSettings.h
     ./include/olp/core/cache/DefaultCache.h
+    ./include/olp/core/cache/KeyGenerator.h
     ./include/olp/core/cache/KeyValueCache.h
 )
 
@@ -234,6 +235,7 @@ set(OLP_SDK_CACHE_SOURCES
     ./src/cache/DiskCacheSizeLimitEnv.h
     ./src/cache/DiskCacheSizeLimitWritableFile.cpp
     ./src/cache/DiskCacheSizeLimitWritableFile.h
+    ./src/cache/KeyGenerator.cpp
     ./src/cache/ProtectedKeyList.cpp
     ./src/cache/ProtectedKeyList.h
     ./src/cache/InMemoryCache.cpp

--- a/olp-cpp-sdk-core/include/olp/core/cache/KeyGenerator.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/KeyGenerator.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+
+#include <olp/core/CoreApi.h>
+#include <olp/core/client/HRN.h>
+#include <olp/core/geo/tiling/TileKey.h>
+#include <boost/optional.hpp>
+
+namespace olp {
+namespace cache {
+
+/**
+ * @brief Helper class to generate cache keys for different entities.
+ */
+class CORE_API KeyGenerator {
+ public:
+  /**
+   * @brief Generates cache key for service API.
+   *
+   * @param hrn The HRN of the catalog.
+   * @param service The service.
+   * @param version The version of the service.
+   *
+   * @return A key used to store the API in cache.
+   */
+  static std::string CreateApiKey(const std::string& hrn,
+                                  const std::string& service,
+                                  const std::string& version);
+
+  /**
+   * @brief Generates cache key for catalog data.
+   *
+   * @param hrn The HRN of the catalog.
+   *
+   * @return A key used to store the catalog data in cache.
+   */
+  static std::string CreateCatalogKey(const std::string& hrn);
+
+  /**
+   * @brief Generates cache key to store latest catalog version.
+   *
+   * @param hrn The HRN of the catalog.
+   *
+   * @return A key used to store the version in cache.
+   */
+  static std::string CreateLatestVersionKey(const std::string& hrn);
+
+  /**
+   * @brief Generates cache key for storing partition data.
+   *
+   * @param hrn The HRN of the catalog.
+   * @param layer_id The layer of the partition.
+   * @param partition_id The partition name.
+   * @param version The version of the catalog.
+   *
+   * @return A key used to store the patition data in cache.
+   */
+  static std::string CreatePartitionKey(
+      const std::string& hrn, const std::string& layer_id,
+      const std::string& partition_id, const boost::optional<int64_t>& version);
+
+  /**
+   * @brief Generates cache key for storing list of partitions.
+   *
+   * @param hrn The HRN of the catalog.
+   * @param layer_id The layer of the partition.
+   * @param version The version of the catalog.
+   *
+   * @return A key used to store the list of patitions in cache.
+   */
+  static std::string CreatePartitionsKey(
+      const std::string& hrn, const std::string& layer_id,
+      const boost::optional<int64_t>& version);
+
+  /**
+   * @brief Generates cache key for storing list of available layer versions.
+   *
+   * @param hrn The HRN of the catalog.
+   * @param version The version of the catalog.
+   *
+   * @return A key used to store the list layer versions in cache.
+   */
+  static std::string CreateLayerVersionsKey(const std::string& hrn,
+                                            const int64_t version);
+
+  /**
+   * @brief Generates cache key for storing quadtree metadata.
+   *
+   * @param hrn The HRN of the catalog.
+   * @param layer_id The layer of the quadtree.
+   * @param root The root tile of the quadtree.
+   * @param version The version of the catalog.
+   * @param depth The quadtree depth.
+   *
+   * @return A key used to store the quadtree in cache.
+   */
+  static std::string CreateQuadTreeKey(const std::string& hrn,
+                                       const std::string& layer_id,
+                                       olp::geo::TileKey root,
+                                       const boost::optional<int64_t>& version,
+                                       int32_t depth);
+
+  /**
+   * @brief Generates cache key for data handle entities.
+   *
+   * @param hrn The HRN of the catalog.
+   * @param layer_id The layer of the data handle.
+   * @param data_handle The data handle.
+   *
+   * @return A key used to store the data handle in cache.
+   */
+  static std::string CreateDataHandleKey(const std::string& hrn,
+                                         const std::string& layer_id,
+                                         const std::string& data_handle);
+};
+
+}  // namespace cache
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/cache/KeyGenerator.cpp
+++ b/olp-cpp-sdk-core/src/cache/KeyGenerator.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "olp/core/cache/KeyGenerator.h"
+
+namespace olp {
+namespace cache {
+std::string KeyGenerator::CreateApiKey(const std::string& hrn,
+                                       const std::string& service,
+                                       const std::string& version) {
+  return hrn + "::" + service + "::" + version + "::api";
+}
+
+std::string KeyGenerator::CreateCatalogKey(const std::string& hrn) {
+  return hrn + "::catalog";
+}
+
+std::string KeyGenerator::CreateLatestVersionKey(const std::string& hrn) {
+  return hrn + "::latestVersion";
+}
+
+std::string KeyGenerator::CreatePartitionKey(
+    const std::string& hrn, const std::string& layer_id,
+    const std::string& partition_id, const boost::optional<int64_t>& version) {
+  return hrn + "::" + layer_id + "::" + partition_id +
+         "::" + (version ? std::to_string(*version) + "::" : "") + "partition";
+}
+
+std::string KeyGenerator::CreatePartitionsKey(
+    const std::string& hrn, const std::string& layer_id,
+    const boost::optional<int64_t>& version) {
+  return hrn + "::" + layer_id +
+         "::" + (version ? std::to_string(*version) + "::" : "") + "partitions";
+}
+
+std::string KeyGenerator::CreateLayerVersionsKey(const std::string& hrn,
+                                                 const int64_t version) {
+  return hrn + "::" + std::to_string(version) + "::layerVersions";
+}
+
+std::string KeyGenerator::CreateQuadTreeKey(
+    const std::string& hrn, const std::string& layer_id, olp::geo::TileKey root,
+    const boost::optional<int64_t>& version, int32_t depth) {
+  return hrn + "::" + layer_id + "::" + root.ToHereTile() +
+         "::" + (version ? std::to_string(*version) + "::" : "") +
+         std::to_string(depth) + "::quadtree";
+}
+
+std::string KeyGenerator::CreateDataHandleKey(const std::string& hrn,
+                                              const std::string& layer_id,
+                                              const std::string& data_handle) {
+  return hrn + "::" + layer_id + "::" + data_handle + "::Data";
+}
+
+}  // namespace cache
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/client/repository/ApiCacheRepository.cpp
+++ b/olp-cpp-sdk-core/src/client/repository/ApiCacheRepository.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,17 +19,13 @@
 
 #include "ApiCacheRepository.h"
 
+#include <olp/core/cache/KeyGenerator.h>
 #include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/logging/Log.h>
 
 namespace {
 constexpr auto kLogTag = "ApiCacheRepository";
 constexpr time_t kLookupApiExpiryTime = 3600;
-
-std::string CreateKey(const std::string& hrn, const std::string& service,
-                      const std::string& serviceVersion) {
-  return hrn + "::" + service + "::" + serviceVersion + "::api";
-}
 }  // namespace
 
 namespace olp {
@@ -42,7 +38,7 @@ ApiCacheRepository::ApiCacheRepository(
 void ApiCacheRepository::Put(const std::string& service,
                              const std::string& version, const std::string& url,
                              boost::optional<time_t> expiry) {
-  auto key = CreateKey(hrn_, service, version);
+  const auto key = cache::KeyGenerator::CreateApiKey(hrn_, service, version);
   OLP_SDK_LOG_DEBUG_F(kLogTag, "Put -> '%s'", key.c_str());
 
   cache_->Put(key, url, [&]() { return url; },
@@ -51,7 +47,7 @@ void ApiCacheRepository::Put(const std::string& service,
 
 boost::optional<std::string> ApiCacheRepository::Get(
     const std::string& service, const std::string& version) {
-  auto key = CreateKey(hrn_, service, version);
+  const auto key = cache::KeyGenerator::CreateApiKey(hrn_, service, version);
   OLP_SDK_LOG_DEBUG_F(kLogTag, "Get -> '%s'", key.c_str());
 
   auto url = cache_->Get(key, [](const std::string& value) { return value; });

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(OLP_CPP_SDK_CORE_TESTS_SOURCES
     ./cache/Helpers.cpp
     ./cache/Helpers.h
     ./cache/InMemoryCacheTest.cpp
+    ./cache/KeyGeneratorTest.cpp
     ./cache/ProtectedKeyListTest.cpp
 
     ./client/ApiLookupClientImplTest.cpp

--- a/olp-cpp-sdk-core/tests/cache/KeyGeneratorTest.cpp
+++ b/olp-cpp-sdk-core/tests/cache/KeyGeneratorTest.cpp
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gtest/gtest.h>
+
+#include <olp/core/cache/KeyGenerator.h>
+
+namespace {
+using KeyGenerator = olp::cache::KeyGenerator;
+
+constexpr auto kCatalogVersion = 13;
+const std::string kCatalogHrn =
+    "hrn:here:data::olp-here-test:hereos-internal-test-v2";
+const std::string kLayerName = "some_layer";
+const std::string kPartitionName = "partition";
+
+TEST(KeyGeneratorTest, CreateApiKey) {
+  {
+    SCOPED_TRACE("Success");
+
+    const std::string service_name = "random_service";
+    const std::string service_version = "v8";
+    const auto key =
+        KeyGenerator::CreateApiKey(kCatalogHrn, service_name, service_version);
+
+    EXPECT_EQ(key, kCatalogHrn + "::" + service_name + "::" + service_version +
+                       "::api");
+  }
+
+  {
+    SCOPED_TRACE("Empty values");
+
+    // Not a special case, just make sure it will not crash.
+    const auto key = KeyGenerator::CreateApiKey("", "", "");
+
+    EXPECT_EQ(key, "::::::api");
+  }
+}
+
+TEST(KeyGeneratorTest, CreateCatalogKey) {
+  {
+    SCOPED_TRACE("Success");
+
+    const auto key = KeyGenerator::CreateCatalogKey(kCatalogHrn);
+
+    EXPECT_EQ(key, kCatalogHrn + "::catalog");
+  }
+
+  {
+    SCOPED_TRACE("Empty values");
+
+    // Not a special case, just make sure it will not crash.
+    const auto key = KeyGenerator::CreateCatalogKey("");
+
+    EXPECT_EQ(key, "::catalog");
+  }
+}
+
+TEST(KeyGeneratorTest, CreateLatestVersionKey) {
+  {
+    SCOPED_TRACE("Success");
+
+    const auto key = KeyGenerator::CreateLatestVersionKey(kCatalogHrn);
+
+    EXPECT_EQ(key, kCatalogHrn + "::latestVersion");
+  }
+
+  {
+    SCOPED_TRACE("Empty values");
+
+    // Not a special case, just make sure it will not crash.
+    const auto key = KeyGenerator::CreateLatestVersionKey("");
+
+    EXPECT_EQ(key, "::latestVersion");
+  }
+}
+
+TEST(KeyGeneratorTest, CreatePartitionKey) {
+  {
+    SCOPED_TRACE("Success");
+
+    const auto key = KeyGenerator::CreatePartitionKey(
+        kCatalogHrn, kLayerName, kPartitionName, kCatalogVersion);
+
+    EXPECT_EQ(key, kCatalogHrn + "::" + kLayerName + "::" + kPartitionName +
+                       "::" + std::to_string(kCatalogVersion) + "::partition");
+  }
+
+  {
+    SCOPED_TRACE("No version");
+
+    const auto key = KeyGenerator::CreatePartitionKey(
+        kCatalogHrn, kLayerName, kPartitionName, boost::none);
+
+    EXPECT_EQ(key, kCatalogHrn + "::" + kLayerName + "::" + kPartitionName +
+                       "::partition");
+  }
+
+  {
+    SCOPED_TRACE("Empty values");
+
+    // Not a special case, just make sure it will not crash.
+    const auto key = KeyGenerator::CreatePartitionKey("", "", "", boost::none);
+
+    EXPECT_EQ(key, "::::::partition");
+  }
+}
+
+TEST(KeyGeneratorTest, CreatePatitionsKey) {
+  {
+    SCOPED_TRACE("Success");
+
+    const auto key = KeyGenerator::CreatePartitionsKey(kCatalogHrn, kLayerName,
+                                                       kCatalogVersion);
+
+    EXPECT_EQ(key, kCatalogHrn + "::" + kLayerName +
+                       "::" + std::to_string(kCatalogVersion) + "::partitions");
+  }
+
+  {
+    SCOPED_TRACE("No version");
+
+    const auto key =
+        KeyGenerator::CreatePartitionsKey(kCatalogHrn, kLayerName, boost::none);
+
+    EXPECT_EQ(key, kCatalogHrn + "::" + kLayerName + "::partitions");
+  }
+
+  {
+    SCOPED_TRACE("Empty values");
+
+    // Not a special case, just make sure it will not crash.
+    const auto key = KeyGenerator::CreatePartitionsKey("", "", boost::none);
+
+    EXPECT_EQ(key, "::::partitions");
+  }
+}
+
+TEST(KeyGeneratorTest, CreateLayerVersionsKey) {
+  {
+    SCOPED_TRACE("Success");
+
+    const auto key =
+        KeyGenerator::CreateLayerVersionsKey(kCatalogHrn, kCatalogVersion);
+
+    EXPECT_EQ(key, kCatalogHrn + "::" + std::to_string(kCatalogVersion) +
+                       "::layerVersions");
+  }
+
+  {
+    SCOPED_TRACE("Empty values");
+
+    // Not a special case, just make sure it will not crash.
+    const auto key = KeyGenerator::CreateLayerVersionsKey("", kCatalogVersion);
+
+    EXPECT_EQ(key, "::" + std::to_string(kCatalogVersion) + "::layerVersions");
+  }
+}
+
+TEST(KeyGeneratorTest, CreateQuadTreeKey) {
+  const auto root_tile = olp::geo::TileKey::FromRowColumnLevel(0, 0, 0);
+  const auto depth = 4;
+
+  {
+    SCOPED_TRACE("Success");
+
+    const auto key = KeyGenerator::CreateQuadTreeKey(
+        kCatalogHrn, kLayerName, root_tile, kCatalogVersion, depth);
+
+    EXPECT_EQ(key, kCatalogHrn + "::" + kLayerName +
+                       "::" + root_tile.ToHereTile() +
+                       "::" + std::to_string(kCatalogVersion) +
+                       "::" + std::to_string(depth) + "::quadtree");
+  }
+
+  {
+    SCOPED_TRACE("No version");
+
+    const auto key = KeyGenerator::CreateQuadTreeKey(
+        kCatalogHrn, kLayerName, root_tile, boost::none, depth);
+
+    EXPECT_EQ(key, kCatalogHrn + "::" + kLayerName +
+                       "::" + root_tile.ToHereTile() +
+                       "::" + std::to_string(depth) + "::quadtree");
+  }
+
+  {
+    SCOPED_TRACE("Empty values");
+
+    // Not a special case, just make sure it will not crash.
+    const auto key =
+        KeyGenerator::CreateQuadTreeKey("", "", root_tile, boost::none, depth);
+
+    EXPECT_EQ(key, "::::" + root_tile.ToHereTile() +
+                       "::" + std::to_string(depth) + "::quadtree");
+  }
+}
+
+TEST(KeyGeneratorTest, CreateDataHandleKey) {
+  {
+    SCOPED_TRACE("Success");
+
+    const auto data_handle = "data_handle";
+    const auto key =
+        KeyGenerator::CreateDataHandleKey(kCatalogHrn, kLayerName, data_handle);
+
+    EXPECT_EQ(key,
+              kCatalogHrn + "::" + kLayerName + "::" + data_handle + "::Data");
+  }
+
+  {
+    SCOPED_TRACE("Empty values");
+
+    // Not a special case, just make sure it will not crash.
+    const auto key = KeyGenerator::CreateDataHandleKey("", "", "");
+
+    EXPECT_EQ(key, "::::::Data");
+  }
+}
+
+}  // namespace

--- a/olp-cpp-sdk-dataservice-read/src/ProtectDependencyResolver.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ProtectDependencyResolver.cpp
@@ -24,6 +24,8 @@
 #include <string>
 #include <utility>
 
+#include <olp/core/cache/KeyGenerator.h>
+
 namespace {
 constexpr auto kQuadTreeDepth = 4u;
 }  // namespace
@@ -35,9 +37,9 @@ namespace read {
 ProtectDependencyResolver::ProtectDependencyResolver(
     const client::HRN& catalog, const std::string& layer_id, int64_t version,
     const client::OlpClientSettings& settings)
-    : layer_id_(layer_id),
+    : catalog_(catalog.ToCatalogHRNString()),
+      layer_id_(layer_id),
       version_(version),
-      data_cache_repository_(catalog, settings.cache),
       partitions_cache_repository_(catalog, layer_id_, settings.cache),
       quad_trees_(),
       keys_to_protect_() {}
@@ -76,8 +78,8 @@ bool ProtectDependencyResolver::AddDataHandle(
     const geo::TileKey& tile, const read::QuadTreeIndex& quad_tree) {
   auto data = quad_tree.Find(tile, false);
   if (data) {
-    keys_to_protect_.emplace_back(
-        data_cache_repository_.CreateKey(layer_id_, data->data_handle));
+    keys_to_protect_.emplace_back(cache::KeyGenerator::CreateDataHandleKey(
+        catalog_, layer_id_, data->data_handle));
     return true;
   }
   return false;
@@ -90,8 +92,8 @@ bool ProtectDependencyResolver::ProcessTileKeyInCache(
       AddDataHandle(tile, cached_tree)) {
     auto root_tile = cached_tree.GetRootTile();
     // add quad tree to list for protection
-    keys_to_protect_.emplace_back(partitions_cache_repository_.CreateQuadKey(
-        root_tile, kQuadTreeDepth, version_));
+    keys_to_protect_.emplace_back(cache::KeyGenerator::CreateQuadTreeKey(
+        catalog_, layer_id_, root_tile, version_, kQuadTreeDepth));
     // save quad tree, because  there is could be more tiles to protect from
     // this quad
     quad_trees_[root_tile] = std::move(cached_tree);

--- a/olp-cpp-sdk-dataservice-read/src/ProtectDependencyResolver.h
+++ b/olp-cpp-sdk-dataservice-read/src/ProtectDependencyResolver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,9 +58,9 @@ class ProtectDependencyResolver {
   bool ProcessTileKeyInCache(const geo::TileKey& tile);
 
  private:
+  const std::string catalog_;
   const std::string& layer_id_;
   const int64_t version_;
-  repository::DataCacheRepository data_cache_repository_;
   repository::PartitionsCacheRepository partitions_cache_repository_;
   std::map<geo::TileKey, read::QuadTreeIndex> quad_trees_;
   cache::KeyValueCache::KeyListType keys_to_protect_;

--- a/olp-cpp-sdk-dataservice-read/src/ReleaseDependencyResolver.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ReleaseDependencyResolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@
 #include <string>
 #include <utility>
 
+#include <olp/core/cache/KeyGenerator.h>
+
 namespace {
 constexpr auto kQuadTreeDepth = 4u;
 }  // namespace
@@ -35,7 +37,8 @@ namespace read {
 ReleaseDependencyResolver::ReleaseDependencyResolver(
     const client::HRN& catalog, const std::string& layer_id, int64_t version,
     const client::OlpClientSettings& settings)
-    : layer_id_(layer_id),
+    : catalog_(catalog.ToCatalogHRNString()),
+      layer_id_(layer_id),
       version_(version),
       cache_(settings.cache),
       data_cache_repository_(catalog, settings.cache),
@@ -75,9 +78,8 @@ void ReleaseDependencyResolver::ProcessTileKey(const geo::TileKey& tile_key) {
       if (it->second.empty()) {
         // no more protected tiles associated with this quad tree
         // can add key for quad tree to be released and remove from map
-        keys_to_release_.emplace_back(
-            partitions_cache_repository_.CreateQuadKey(
-                it->first, kQuadTreeDepth, version_));
+        keys_to_release_.emplace_back(cache::KeyGenerator::CreateQuadTreeKey(
+            catalog_, layer_id_, it->first, version_, kQuadTreeDepth));
       }
       return true;
     }
@@ -105,8 +107,8 @@ ReleaseDependencyResolver::CheckProtectedTilesInQuad(
   auto index_data = cached_tree.GetIndexData();
   TilesDataKeysType protected_keys;
   for (const auto& ind : index_data) {
-    auto tile_data_key =
-        data_cache_repository_.CreateKey(layer_id_, ind.data_handle);
+    const auto tile_data_key = cache::KeyGenerator::CreateDataHandleKey(
+        catalog_, layer_id_, ind.data_handle);
     if (cache_->IsProtected(tile_data_key)) {
       if (ind.tile_key == tile) {
         // add key to release list
@@ -134,8 +136,8 @@ void ReleaseDependencyResolver::ProcessQuadTreeCache(
         CheckProtectedTilesInQuad(cached_tree, tile, add_data_handle_key);
     if (protected_keys.empty()) {
       // no other tiles are protected, can add quad tree to release list
-      keys_to_release_.emplace_back(partitions_cache_repository_.CreateQuadKey(
-          root_quad_key, kQuadTreeDepth, version_));
+      keys_to_release_.emplace_back(cache::KeyGenerator::CreateQuadTreeKey(
+          catalog_, layer_id_, root_quad_key, version_, kQuadTreeDepth));
     }
     // add quad key with other protected keys dependent on this quad to
     // reduce future calls to cache

--- a/olp-cpp-sdk-dataservice-read/src/ReleaseDependencyResolver.h
+++ b/olp-cpp-sdk-dataservice-read/src/ReleaseDependencyResolver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ class ReleaseDependencyResolver {
                             bool& add_data_handle_key);
 
  private:
+  const std::string catalog_;
   const std::string& layer_id_;
   const int64_t version_;
   std::shared_ptr<cache::KeyValueCache> cache_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/ApiCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/ApiCacheRepository.cpp
@@ -19,17 +19,13 @@
 
 #include "ApiCacheRepository.h"
 
+#include <olp/core/cache/KeyGenerator.h>
 #include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/logging/Log.h>
 
 namespace {
 constexpr auto kLogTag = "ApiCacheRepository";
 constexpr time_t kLookupApiExpiryTime = 3600;
-
-std::string CreateKey(const std::string& hrn, const std::string& service,
-                      const std::string& serviceVersion) {
-  return hrn + "::" + service + "::" + serviceVersion + "::api";
-}
 }  // namespace
 
 namespace olp {
@@ -43,8 +39,8 @@ ApiCacheRepository::ApiCacheRepository(
 void ApiCacheRepository::Put(const std::string& service,
                              const std::string& version,
                              const std::string& url) {
-  std::string hrn(hrn_.ToCatalogHRNString());
-  auto key = CreateKey(hrn, service, version);
+  const std::string hrn(hrn_.ToCatalogHRNString());
+  const auto key = cache::KeyGenerator::CreateApiKey(hrn, service, version);
   OLP_SDK_LOG_DEBUG_F(kLogTag, "Put -> '%s'", key.c_str());
 
   cache_->Put(key, url, [&]() { return url; }, kLookupApiExpiryTime);
@@ -52,8 +48,8 @@ void ApiCacheRepository::Put(const std::string& service,
 
 boost::optional<std::string> ApiCacheRepository::Get(
     const std::string& service, const std::string& version) {
-  std::string hrn(hrn_.ToCatalogHRNString());
-  auto key = CreateKey(hrn, service, version);
+  const std::string hrn(hrn_.ToCatalogHRNString());
+  const auto key = cache::KeyGenerator::CreateApiKey(hrn, service, version);
   OLP_SDK_LOG_DEBUG_F(kLogTag, "Get -> '%s'", key.c_str());
 
   auto url = cache_->Get(key, [](const std::string& value) { return value; });

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.h
@@ -54,9 +54,6 @@ class DataCacheRepository final {
 
   bool Clear(const std::string& layer_id, const std::string& data_handle);
 
-  std::string CreateKey(const std::string& layer_id,
-                        const std::string& datahandle) const;
-
  private:
   client::HRN hrn_;
   std::shared_ptr<cache::KeyValueCache> cache_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.h
@@ -86,9 +86,6 @@ class PartitionsCacheRepository final {
                           const boost::optional<int64_t>& catalog_version,
                           std::string& data_handle);
 
-  std::string CreateQuadKey(geo::TileKey key, int32_t depth,
-                            const boost::optional<int64_t>& version) const;
-
   bool FindQuadTree(geo::TileKey key, boost::optional<int64_t> version,
                     read::QuadTreeIndex& tree);
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -22,10 +22,10 @@
 #include <algorithm>
 #include <utility>
 
-#include <boost/functional/hash.hpp>
-
+#include <olp/core/cache/KeyGenerator.h>
 #include <olp/core/client/Condition.h>
 #include <olp/core/logging/Log.h>
+#include <boost/functional/hash.hpp>
 #include "CatalogRepository.h"
 #include "generated/api/MetadataApi.h"
 #include "generated/api/QueryApi.h"
@@ -361,8 +361,9 @@ QuadTreeIndexResponse PartitionsRepository::GetQuadTreeIndexForTile(
   const auto& root_tile_key = tile_key.ChangedLevelBy(-kAggregateQuadTreeDepth);
   const auto root_tile_here = root_tile_key.ToHereTile();
 
-  const auto quad_cache_key =
-      cache_.CreateQuadKey(root_tile_key, kAggregateQuadTreeDepth, version);
+  const auto quad_cache_key = cache::KeyGenerator::CreateQuadTreeKey(
+      catalog_.ToCatalogHRNString(), layer_id_, root_tile_key, version,
+      kAggregateQuadTreeDepth);
 
   NamedMutex mutex(storage_, quad_cache_key);
   std::unique_lock<NamedMutex> lock(mutex, std::defer_lock);

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -26,6 +26,7 @@
 #include <utility>
 #include <vector>
 
+#include <olp/core/cache/KeyGenerator.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/core/geo/tiling/TileKey.h>
 #include <olp/core/logging/Log.h>
@@ -197,8 +198,8 @@ client::NetworkStatistics PrefetchTilesRepository::LoadAggregatedSubQuads(
     while (root.Level() > aggregated_tile_key.Level()) {
       root = root.ChangedLevelBy(-kMaxQuadTreeIndexDepth - 1);
 
-      const auto quad_cache_key = cache_repository_.CreateQuadKey(
-          root, kMaxQuadTreeIndexDepth, version);
+      const auto quad_cache_key = cache::KeyGenerator::CreateQuadTreeKey(
+          catalog_str_, layer_id_, root, version, kMaxQuadTreeIndexDepth);
 
       NamedMutex mutex(storage_, quad_cache_key);
       std::unique_lock<NamedMutex> lock(mutex);
@@ -225,8 +226,8 @@ SubQuadsResponse PrefetchTilesRepository::GetVersionedSubQuads(
   QuadTreeIndex quad_tree;
   client::NetworkStatistics network_stats;
 
-  const auto quad_cache_key =
-      cache_repository_.CreateQuadKey(tile, kMaxQuadTreeIndexDepth, version);
+  const auto quad_cache_key = cache::KeyGenerator::CreateQuadTreeKey(
+      catalog_str_, layer_id_, tile, version, kMaxQuadTreeIndexDepth);
 
   NamedMutex mutex(storage_, quad_cache_key);
   std::lock_guard<NamedMutex> lock(mutex);

--- a/tests/integration/olp-cpp-sdk-core/ApiLookupClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-core/ApiLookupClientTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@
 #include <mocks/CacheMock.h>
 #include <mocks/NetworkMock.h>
 #include <olp/core/cache/CacheSettings.h>
+#include <olp/core/cache/KeyGenerator.h>
 #include <olp/core/client/ApiLookupClient.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
 
@@ -103,6 +104,11 @@ TEST_F(ApiLookupClientTest, LookupApi) {
 
     EXPECT_TRUE(response.IsSuccessful());
     EXPECT_EQ(response.GetResult().GetBaseUrl(), kConfigBaseUrl);
+
+    const auto api_cache_key = olp::cache::KeyGenerator::CreateApiKey(
+        catalog, service_name, service_version);
+    EXPECT_TRUE(settings_.cache->Contains(api_cache_key));
+
     testing::Mock::VerifyAndClearExpectations(network_.get());
   }
 

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
@@ -20,6 +20,8 @@
 #include <gmock/gmock.h>
 #include <matchers/NetworkUrlMatchers.h>
 #include <mocks/NetworkMock.h>
+#include <olp/core/cache/KeyGenerator.h>
+#include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/client/HRN.h>
 #include <olp/core/http/HttpStatusCode.h>
 #include <olp/core/http/Network.h>
@@ -60,6 +62,10 @@ TEST_P(CatalogClientTest, GetCatalog) {
 
   ASSERT_TRUE(catalog_response.IsSuccessful())
       << ApiErrorToString(catalog_response.GetError());
+
+  const auto cache_key =
+      olp::cache::KeyGenerator::CreateCatalogKey(GetTestCatalog());
+  EXPECT_TRUE(settings_.cache->Contains(cache_key));
 }
 
 TEST_P(CatalogClientTest, GetCatalogCallback) {
@@ -248,6 +254,10 @@ TEST_P(CatalogClientTest, GetCatalogVersion) {
 
   ASSERT_TRUE(catalog_version_response.IsSuccessful())
       << ApiErrorToString(catalog_version_response.GetError());
+
+  const auto cache_key =
+      olp::cache::KeyGenerator::CreateLatestVersionKey(GetTestCatalog());
+  EXPECT_TRUE(settings_.cache->Contains(cache_key));
 }
 
 TEST_P(CatalogClientTest, GetCatalogVersionCancel) {

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientPrefetchPartitionsTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientPrefetchPartitionsTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@
 #include <mocks/NetworkMock.h>
 #include <olp/authentication/Settings.h>
 #include <olp/core/cache/CacheSettings.h>
+#include <olp/core/cache/KeyGenerator.h>
+#include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
 #include <olp/dataservice/read/VersionedLayerClient.h>
@@ -90,6 +92,16 @@ TEST_F(VersionedLayerClientPrefetchPartitionsTest, PrefetchPartitions) {
 
     for (const auto& partition : result.GetPartitions()) {
       ASSERT_TRUE(client.IsCached(partition));
+
+      const auto cache_key = olp::cache::KeyGenerator::CreatePartitionKey(
+          kCatalog, kLayer, partition, version_);
+      EXPECT_TRUE(settings_.cache->Contains(cache_key));
+    }
+
+    for (const auto& data_handle : partition_data_handles) {
+      const auto cache_key = olp::cache::KeyGenerator::CreateDataHandleKey(
+          kCatalog, kLayer, data_handle);
+      EXPECT_TRUE(settings_.cache->Contains(cache_key));
     }
   }
   {


### PR DESCRIPTION
Added new class to create keys used to store partitions, bundles,
quadtrees etc. Now user can modify and rewrite data in the cache.
All `*CacheRepository` classes now use the API instead of internal
hidden scattered methods.

Integration testing done via adding new checks in existing tests. The
change doesn't add new functionality, but we must be sure clients
write data with same cache keys.

Resolves: OLPEDGE-2649
Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>