### PR TITLE
Change the Android HTTP request error handling

### DIFF
--- a/olp-cpp-sdk-core/src/client/OlpClient.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClient.cpp
@@ -311,9 +311,15 @@ HttpResponse SendRequest(const http::NetworkRequest& request,
     return ToHttpResponse(kCancelledErrorResponse);
   }
 
-  HttpResponse response{response_data->response.GetStatus(),
-                        std::move(*response_body),
-                        std::move(response_data->headers)};
+  HttpResponse response = [&]() {
+    const auto status = response_data->response.GetStatus();
+    if (status < 0) {
+      return HttpResponse{status, response_data->response.GetError()};
+    } else {
+      return HttpResponse{status, std::move(*response_body),
+                          std::move(response_data->headers)};
+    }
+  }();
 
   response.SetNetworkStatistics(GetStatistics(response_data->response));
 

--- a/olp-cpp-sdk-core/src/http/android/HttpClient.java
+++ b/olp-cpp-sdk-core/src/http/android/HttpClient.java
@@ -470,15 +470,15 @@ public class HttpClient {
             httpClient.completeRequest(request.requestId(), status, uploadedContentSize, downloadContentSize, error, contentType);
           } while (!isDone);
         } catch (SSLException e) {
-          completeErrorRequest(request.requestId(), AUTHORIZATION_ERROR, uploadedContentSize, downloadContentSize, "SSL connection failed.");
+          completeErrorRequest(request.requestId(), IO_ERROR, uploadedContentSize, downloadContentSize, "SSL connection failed: " + e);
         } catch (MalformedURLException e) {
-          completeErrorRequest(request.requestId(), INVALID_URL_ERROR, uploadedContentSize, downloadContentSize, "The provided URL is not valid.");
+          completeErrorRequest(request.requestId(), INVALID_URL_ERROR, uploadedContentSize, downloadContentSize, "The provided URL is not valid: " + e);
         } catch (OperationCanceledException e) {
-          completeErrorRequest(request.requestId(), CANCELLED_ERROR, uploadedContentSize, downloadContentSize, "Cancelled");
+          completeErrorRequest(request.requestId(), CANCELLED_ERROR, uploadedContentSize, downloadContentSize, "Cancelled: " + e);
         } catch (SocketTimeoutException e) {
-          completeErrorRequest(request.requestId(), TIMEOUT_ERROR, uploadedContentSize, downloadContentSize, "Timed out");
+          completeErrorRequest(request.requestId(), TIMEOUT_ERROR, uploadedContentSize, downloadContentSize, "Timed out: " + e);
         } catch (UnknownHostException e) {
-          completeErrorRequest(request.requestId(), OFFLINE_ERROR, uploadedContentSize, downloadContentSize, "The device has no internet connectivity");
+          completeErrorRequest(request.requestId(), OFFLINE_ERROR, uploadedContentSize, downloadContentSize, "The device has no internet connectivity: " + e);
         } catch (Exception e) {
           Log.e(LOGTAG, "HttpClient::HttpTask::run exception: " + e);
           e.printStackTrace();


### PR DESCRIPTION
Now the HttpClient treats the SSLException as IO_ERROR.
See the https://issues.apache.org/jira/browse/WAGON-565 for details.
Change the OlpClient to correctly pass the error.

Resolves: OLPEDGE-2652

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>