### PR TITLE
Make Dir::Size() ignore deleted files.

### DIFF
--- a/olp-cpp-sdk-core/src/utils/Dir.cpp
+++ b/olp-cpp-sdk-core/src/utils/Dir.cpp
@@ -467,7 +467,8 @@ uint64_t Dir::Size(const std::string& path, FilterFunction filter_fn) {
           default:
             break;
         }
-      } else {
+      } else if (errno != ENOENT) {
+        // Ignore ENOENT errors as its a common case, e.g. cache compaction.
         result = 0;
         break;
       }


### PR DESCRIPTION
Cache is the only thing we currently need to check size. During
compaction leveldb moves files around. lstat() will return an error
if current file is removed. In such cases Dir::Size() returns 0 making
it impossible to use the method for `live` cache.

The issue is related only to unix systems, windows workflow should be
fine.

Resolves: OAM-1303
Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>