### PR TITLE
Add proper cancellation for the new token provider

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AutoRefreshingToken.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AutoRefreshingToken.h
@@ -28,6 +28,7 @@
 #include "TokenRequest.h"
 #include "TokenResult.h"
 
+#include "olp/core/client/CancellationContext.h"
 #include "olp/core/client/CancellationToken.h"
 #include "olp/core/porting/warning_disable.h"
 
@@ -67,8 +68,6 @@ class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed by 10.2020.")
    * @note This method is blocked when a new token needs to be retrieved.
    * Therefore, the token should not be called from a time-sensitive thread (for
    * example, the UI thread).
-   * @throw std::future_error Thrown when a failure occurs.
-   * Contains the error code and message.
    *
    * @param cancellation_token The token used to cancel the operation.
    * @param minimum_validity (Optional) Sets the minimum validity period of
@@ -78,8 +77,29 @@ class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed by 10.2020.")
    * @return The `TokenResponse` instance if the old one is expired.
    * Otherwise, returns the cached `TokenResponse` instance.
    */
-
   TokenResponse GetToken(client::CancellationToken& cancellation_token,
+                         const std::chrono::seconds& minimum_validity =
+                             kDefaultMinimumValiditySeconds) const;
+
+  /**
+   * @brief Synchronously gets a token that is always fresh.
+   *
+   * If no token has been retrieved yet or the current token is expired or
+   * expires within five minutes, a new token is requested. Otherwise,
+   * the cached token is returned. This method is thread-safe.
+   * @note This method is blocked when a new token needs to be retrieved.
+   * Therefore, the token should not be called from a time-sensitive thread (for
+   * example, the UI thread).
+   *
+   * @param context Used to cancel the pending token request.
+   * @param minimum_validity (Optional) Sets the minimum validity period of
+   * the token in seconds. The default validity period is 5 minutes. If
+   * the period is set to 0, the token is refreshed immediately.
+   *
+   * @return The `TokenResponse` instance if the old one is expired.
+   * Otherwise, returns the cached `TokenResponse` instance.
+   */
+  TokenResponse GetToken(client::CancellationContext& context,
                          const std::chrono::seconds& minimum_validity =
                              kDefaultMinimumValiditySeconds) const;
 
@@ -92,8 +112,6 @@ class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed by 10.2020.")
    * @note This method is blocked when a new token needs to be retrieved.
    * Therefore, it should not be called from a time-sensitive thread (for
    * example, the UI thread).
-   * @throw std::future_error Thrown when a failure occurs.
-   * Contains the error code and message.
    *
    * @param minimum_validity (Optional) Sets the minimum validity period of
    * the token in seconds. The default validity period is 5 minutes. If

--- a/olp-cpp-sdk-authentication/include/olp/authentication/SignInResult.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/SignInResult.h
@@ -134,6 +134,7 @@ class AUTHENTICATION_API SignInResult {
  private:
   friend class SignInUserResult;
   friend class AuthenticationClientImpl;
+  friend class TokenEndpointImpl;
 
   SignInResult(std::shared_ptr<SignInResultImpl> impl);
 

--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenEndpoint.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenEndpoint.h
@@ -30,12 +30,14 @@
 #include <olp/authentication/TokenResult.h>
 #include <olp/authentication/Types.h>
 #include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/porting/warning_disable.h>
 
 namespace olp {
 namespace authentication {
 class AutoRefreshingToken;
+class TokenEndpointImpl;
 
 /**
  * @brief Corresponds to the token endpoint as specified in the OAuth2.0
@@ -90,6 +92,22 @@ class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed in 10.2020")
       const TokenRequest& token_request = TokenRequest()) const;
 
   /**
+   * @brief Executes the POST request method to the token endpoint.
+   *
+   * The request gets the HERE Access token that is used to access the HERE
+   * platform Services. Returns the token that is used as the `Authorization:
+   * Bearer` token value.
+   *
+   * @param context Used to cancel the pending token request.
+   * @param token_request The `TokenRequest` instance.
+   *
+   * @return The `TokenResponse` instance.
+   */
+  TokenResponse RequestToken(
+      client::CancellationContext& context,
+      const TokenRequest& token_request = TokenRequest()) const;
+
+  /**
    * Executes the POST request method to the token endpoint.
    *
    * The request gets the HERE Access token that is used to access the HERE platform
@@ -127,8 +145,7 @@ class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed in 10.2020")
   explicit TokenEndpoint(Settings settings);
 
  private:
-  class Impl;
-  std::shared_ptr<Impl> impl_;
+  std::shared_ptr<TokenEndpointImpl> impl_;
 };
 
 }  // namespace authentication

--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenProvider.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenProvider.h
@@ -173,13 +173,11 @@ class TokenProvider {
     /// Gets the token response from `AutoRefreshingToken` or requests a new
     /// token if the token response expired or is not present.
     TokenResponse GetResponse(client::CancellationContext& context) const {
-      OLP_SDK_CORE_UNUSED(context);
-
       // Mutex is needed to prevent multiple authorization requests that can
       // happen when the token is not available, and multiple consumers
       // requested it.
       std::lock_guard<std::mutex> lock(request_mutex_);
-      return token_.GetToken(minimum_validity_);
+      return token_.GetToken(context, minimum_validity_);
     }
 
     /// Checks whether the available token response is valid.

--- a/olp-cpp-sdk-authentication/src/TokenEndpointImpl.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenEndpointImpl.cpp
@@ -1,0 +1,370 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "TokenEndpointImpl.h"
+
+#include <olp/authentication/SignInResult.h>
+#include <olp/core/http/HttpStatusCode.h>
+#include <olp/core/http/NetworkConstants.h>
+#include <olp/core/http/NetworkUtils.h>
+#include <olp/core/logging/Log.h>
+#include <olp/core/thread/Atomic.h>
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "AuthenticationClientUtils.h"
+#include "Constants.h"
+#include "SignInResultImpl.h"
+
+namespace olp {
+namespace authentication {
+
+namespace {
+using TimeResponse = Response<time_t>;
+using SignInResponse = Response<SignInResult>;
+using RequestBodyData = client::OlpClient::RequestBodyType::element_type;
+
+constexpr auto kApplicationJson = "application/json";
+constexpr auto kOauthEndpoint = "/oauth2/token";
+constexpr auto kTimestampEndpoint = "/timestamp";
+constexpr auto kGrantType = "grantType";
+constexpr auto kClientGrantType = "client_credentials";
+constexpr auto kLogTag = "TokenEndpointImpl";
+constexpr auto kErrorWrongTimestamp = 401204;
+
+AuthenticationSettings ConvertSettings(Settings settings) {
+  AuthenticationSettings auth_settings;
+  auth_settings.network_proxy_settings =
+      std::move(settings.network_proxy_settings);
+  auth_settings.network_request_handler =
+      std::move(settings.network_request_handler);
+  auth_settings.token_endpoint_url = std::move(settings.token_endpoint_url);
+  auth_settings.use_system_time = settings.use_system_time;
+  auth_settings.retry_settings = std::move(settings.retry_settings);
+
+  // Ignore `settings.task_scheduler`. It can cause a deadlock on the sign in
+  // when used from another task within `TaskScheduler` with 1 thread.
+
+  return auth_settings;
+}
+
+bool HasWrongTimestamp(const SignInResult& result) {
+  const auto& error_response = result.GetErrorResponse();
+  const auto status = result.GetStatus();
+  return status == http::HttpStatusCode::UNAUTHORIZED &&
+         error_response.code == kErrorWrongTimestamp;
+}
+
+void RetryDelay(const client::RetrySettings& retry_settings, size_t retry) {
+  std::this_thread::sleep_for(retry_settings.backdown_strategy(
+      std::chrono::milliseconds(retry_settings.initial_backdown_period),
+      retry));
+}
+
+TimeResponse ParseTimeResponse(std::stringstream& payload) {
+  rapidjson::Document document;
+  rapidjson::IStreamWrapper stream(payload);
+  document.ParseStream(stream);
+
+  if (!document.IsObject()) {
+    return AuthenticationError(client::ErrorCode::InternalFailure,
+                               "JSON document root is not an Object type");
+  }
+
+  const auto timestamp_it = document.FindMember("timestamp");
+  if (timestamp_it == document.MemberEnd() || !timestamp_it->value.IsUint()) {
+    return AuthenticationError(
+        client::ErrorCode::InternalFailure,
+        "JSON document must contain timestamp integer field");
+  }
+
+  return timestamp_it->value.GetUint();
+}
+
+std::string GenerateUid() {
+  static thread::Atomic<boost::uuids::random_generator> generator;
+  return generator.locked([](boost::uuids::random_generator& gen) {
+    return boost::uuids::to_string(gen());
+  });
+}
+
+// Needed to avoid endless warnings from TokenRequest
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+
+client::OlpClient::RequestBodyType GenerateClientBody(
+    const TokenRequest& token_request) {
+  rapidjson::StringBuffer data;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(data);
+  writer.StartObject();
+
+  writer.Key(kGrantType);
+  writer.String(kClientGrantType);
+
+  auto expires_in =
+      static_cast<unsigned int>(token_request.GetExpiresIn().count());
+  if (expires_in > 0) {
+    writer.Key(Constants::EXPIRES_IN);
+    writer.Uint(expires_in);
+  }
+
+  writer.EndObject();
+  auto content = data.GetString();
+  return std::make_shared<RequestBodyData>(content, content + data.GetSize());
+}
+
+PORTING_POP_WARNINGS()
+}  // namespace
+
+TokenEndpointImpl::TokenEndpointImpl(Settings settings)
+    : credentials_(std::move(settings.credentials)),
+      settings_(ConvertSettings(std::move(settings))),
+      auth_client_(settings_) {}
+
+// Needed to avoid endless warnings from TokenRequest
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+
+client::CancellationToken TokenEndpointImpl::RequestToken(
+    const TokenRequest& token_request, const RequestTokenCallback& callback) {
+  AuthenticationClient::SignInProperties properties;
+  properties.expires_in = token_request.GetExpiresIn();
+  return auth_client_.SignInClient(
+      credentials_, properties,
+      [callback](
+          const AuthenticationClient::SignInClientResponse& sign_in_response) {
+        if (!sign_in_response) {
+          callback(sign_in_response.GetError());
+          return;
+        }
+
+        const auto& sign_in_result = sign_in_response.GetResult();
+        if (sign_in_result.GetAccessToken().empty()) {
+          callback(client::ApiError{sign_in_result.GetStatus(),
+                                    sign_in_result.GetFullMessage()});
+          return;
+        }
+
+        callback(TokenResult{sign_in_result.GetAccessToken(),
+                             sign_in_result.GetExpiresIn(),
+                             http::HttpStatusCode::OK, ErrorResponse{}});
+      });
+}
+
+std::future<TokenResponse> TokenEndpointImpl::RequestToken(
+    client::CancellationToken& cancel_token,
+    const TokenRequest& token_request) {
+  auto promise = std::make_shared<std::promise<TokenResponse>>();
+  cancel_token = RequestToken(token_request, [promise](TokenResponse response) {
+    promise->set_value(std::move(response));
+  });
+  return promise->get_future();
+}
+
+TokenResponse TokenEndpointImpl::RequestToken(
+    client::CancellationContext& context,
+    const TokenRequest& token_request) const {
+  auto sign_in_response = SignInClient(context, token_request);
+  if (!sign_in_response) {
+    return sign_in_response.GetError();
+  }
+
+  const auto& sign_in_result = sign_in_response.GetResult();
+  if (sign_in_result.GetAccessToken().empty()) {
+    auto message = sign_in_result.GetFullMessage();
+
+    // Full message can be empty if an error occurred during response parsing.
+    // Use message from an error response in this case.
+    if (message.empty()) {
+      message = sign_in_result.GetErrorResponse().message;
+    }
+
+    return client::ApiError{sign_in_result.GetStatus(), std::move(message)};
+  }
+
+  return TokenResult{sign_in_result.GetAccessToken(),
+                     sign_in_result.GetExpiresIn(), http::HttpStatusCode::OK,
+                     ErrorResponse{}};
+}
+
+SignInResponse TokenEndpointImpl::SignInClient(
+    client::CancellationContext& context,
+    const TokenRequest& token_request) const {
+  if (!settings_.network_request_handler) {
+    return client::ApiError::NetworkConnection("Cannot sign in while offline");
+  }
+
+  if (context.IsCancelled()) {
+    return client::ApiError::Cancelled();
+  }
+
+  auto client = CreateOlpClient(settings_, boost::none, false);
+
+  RequestTimer timer = CreateRequestTimer(client, context);
+
+  const auto request_body = GenerateClientBody(token_request);
+
+  SignInResult response;
+
+  const auto& retry_settings = settings_.retry_settings;
+
+  for (auto retry = 0; retry < retry_settings.max_attempts; ++retry) {
+    if (context.IsCancelled()) {
+      return client::ApiError::Cancelled();
+    }
+
+    auto auth_response = CallAuth(client, kOauthEndpoint, context, request_body,
+                                  timer.GetRequestTime());
+    const auto status = auth_response.status;
+    if (status < 0) {
+      // If a timeout occurred, the cancellation id done through the context.
+      // So this case needs to be handled independently of context state.
+      if (status != static_cast<int>(http::ErrorCode::TIMEOUT_ERROR) &&
+          context.IsCancelled()) {
+        return client::ApiError::Cancelled();
+      }
+
+      // Auth response message may be empty in case of unknown errors.
+      // Fill in the message as a status string representation in this case.
+      auto message = auth_response.response.str();
+      if (message.empty()) {
+        message = http::HttpErrorToString(status);
+      }
+
+      return client::ApiError(status, message);
+    }
+
+    response = ParseAuthResponse(status, auth_response.response);
+
+    // The request ended up with `OK` status should not be retriggered even if
+    // `retry_condition` is `true` for this `HttpResponse`.
+    if (status == http::HttpStatusCode::OK) {
+      break;
+    }
+
+    if (retry_settings.retry_condition(auth_response)) {
+      RetryDelay(retry_settings, retry);
+      continue;
+    }
+
+    // In case we can't authorize with system time, retry with the server
+    // time from response headers (if available).
+    if (HasWrongTimestamp(response)) {
+      auto server_time = GetTimestampFromHeaders(auth_response.headers);
+      if (server_time) {
+        timer = RequestTimer(*server_time);
+        continue;
+      }
+    }
+
+    break;
+  }
+
+  return response;
+}
+
+PORTING_POP_WARNINGS()
+
+SignInResult TokenEndpointImpl::ParseAuthResponse(
+    int status, std::stringstream& auth_response) {
+  auto document = std::make_shared<rapidjson::Document>();
+  rapidjson::IStreamWrapper stream(auth_response);
+  document->ParseStream(stream);
+  return std::make_shared<SignInResultImpl>(
+      status, http::HttpErrorToString(status), document);
+}
+
+client::HttpResponse TokenEndpointImpl::CallAuth(
+    const client::OlpClient& client, const std::string& endpoint,
+    client::CancellationContext& context,
+    client::OlpClient::RequestBodyType body, std::time_t timestamp) const {
+  const auto url = settings_.token_endpoint_url + endpoint;
+
+  auto auth_header =
+      GenerateAuthorizationHeader(credentials_, url, timestamp, GenerateUid());
+
+  client::OlpClient::ParametersType headers = {
+      {http::kAuthorizationHeader, std::move(auth_header)}};
+
+  return client.CallApi(endpoint, "POST", {}, std::move(headers), {},
+                        std::move(body), kApplicationJson, context);
+}
+
+TokenEndpointImpl::RequestTimer TokenEndpointImpl::CreateRequestTimer(
+    const client::OlpClient& client,
+    client::CancellationContext& context) const {
+  if (settings_.use_system_time) {
+    return RequestTimer();
+  }
+
+  auto server_time = GetTimeFromServer(context, client);
+  if (!server_time) {
+    return RequestTimer();
+  }
+
+  return RequestTimer(server_time.GetResult());
+}
+
+TimeResponse TokenEndpointImpl::GetTimeFromServer(
+    client::CancellationContext& context,
+    const client::OlpClient& client) const {
+  auto http_result = client.CallApi(kTimestampEndpoint, "GET", {}, {}, {},
+                                    nullptr, {}, context);
+
+  if (http_result.status != http::HttpStatusCode::OK) {
+    auto response = http_result.response.str();
+    OLP_SDK_LOG_WARNING_F(
+        kLogTag, "Failed to get time from server, status=%d, response='%s'",
+        http_result.status, response.c_str());
+    return AuthenticationError(http_result.status, http_result.response.str());
+  }
+
+  auto server_time = ParseTimeResponse(http_result.response);
+
+  if (!server_time) {
+    const auto& error = server_time.GetError();
+    const auto& message = error.GetMessage();
+    OLP_SDK_LOG_WARNING_F(kLogTag,
+                          "Failed to decode time from server, message='%s'",
+                          message.c_str());
+  }
+
+  return server_time;
+}
+
+TokenEndpointImpl::RequestTimer::RequestTimer()
+    : timer_start_{std::chrono::steady_clock::now()},
+      time_{std::chrono::system_clock::to_time_t(
+          std::chrono::system_clock::now())} {}
+
+TokenEndpointImpl::RequestTimer::RequestTimer(std::time_t server_time)
+    : timer_start_{std::chrono::steady_clock::now()}, time_{server_time} {}
+
+std::time_t TokenEndpointImpl::RequestTimer::GetRequestTime() const {
+  const auto now = std::chrono::steady_clock::now();
+  const auto time_since_start =
+      std::chrono::duration_cast<std::chrono::seconds>(now - timer_start_);
+  return time_ + time_since_start.count();
+}
+
+}  // namespace authentication
+}  // namespace olp

--- a/olp-cpp-sdk-authentication/src/TokenEndpointImpl.h
+++ b/olp-cpp-sdk-authentication/src/TokenEndpointImpl.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <olp/authentication/AuthenticationClient.h>
+#include <olp/authentication/AuthenticationCredentials.h>
+#include <olp/authentication/AuthenticationSettings.h>
+#include <olp/authentication/Settings.h>
+#include <olp/authentication/SignInResult.h>
+#include <olp/authentication/TokenRequest.h>
+#include <olp/authentication/Types.h>
+#include <olp/core/client/CancellationContext.h>
+#include <olp/core/client/OlpClient.h>
+#include <olp/core/porting/warning_disable.h>
+
+namespace olp {
+namespace authentication {
+
+/// @copydoc TokenEndpoint
+class TokenEndpointImpl {
+ public:
+  /// Defines the callback that is invoked when the response on
+  /// `TokenRequest` is returned.
+  using RequestTokenCallback = Callback<TokenResult>;
+
+  /// @copydoc TokenEndpoint::TokenEndpoint()
+  explicit TokenEndpointImpl(Settings settings);
+
+  // Needed to avoid endless warnings from TokenRequest
+  PORTING_PUSH_WARNINGS()
+  PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+
+  /// @copydoc TokenEndpoint::RequestToken(const TokenRequest&, const
+  /// RequestTokenCallback&)
+  client::CancellationToken RequestToken(const TokenRequest& token_request,
+                                         const RequestTokenCallback& callback);
+
+  /// @copydoc TokenEndpoint::RequestToken(client::CancellationToken&, const
+  /// TokenRequest&)
+  std::future<TokenResponse> RequestToken(
+      client::CancellationToken& cancel_token,
+      const TokenRequest& token_request);
+
+  /// @copydoc TokenEndpoint::RequestToken(client::CancellationContext&, const
+  /// TokenRequest&)
+  TokenResponse RequestToken(
+      client::CancellationContext& context,
+      const TokenRequest& token_request = TokenRequest()) const;
+
+  PORTING_POP_WARNINGS()
+
+ private:
+  class RequestTimer {
+   public:
+    RequestTimer();
+    explicit RequestTimer(std::time_t server_time);
+    std::time_t GetRequestTime() const;
+
+   private:
+    std::chrono::steady_clock::time_point timer_start_;
+    std::time_t time_;
+  };
+
+  static SignInResult ParseAuthResponse(int status,
+                                        std::stringstream& auth_response);
+
+  // Needed to avoid endless warnings from TokenRequest
+  PORTING_PUSH_WARNINGS()
+  PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+
+  Response<SignInResult> SignInClient(client::CancellationContext& context,
+                                      const TokenRequest& token_request) const;
+
+  PORTING_POP_WARNINGS()
+
+  client::HttpResponse CallAuth(const client::OlpClient& client,
+                                const std::string& endpoint,
+                                client::CancellationContext& context,
+                                client::OlpClient::RequestBodyType body,
+                                std::time_t timestamp) const;
+
+  RequestTimer CreateRequestTimer(const client::OlpClient& client,
+                                  client::CancellationContext& context) const;
+
+  Response<time_t> GetTimeFromServer(client::CancellationContext& context,
+                                     const client::OlpClient& client) const;
+
+  const AuthenticationCredentials credentials_;
+  const AuthenticationSettings settings_;
+  AuthenticationClient auth_client_;
+};
+
+}  // namespace authentication
+}  // namespace olp

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 HERE Europe B.V.
+# Copyright (C) 2019-2021 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 set(OLP_SDK_INTEGRATIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
     ./olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
+    ./olp-cpp-sdk-authentication/TokenEndpointTest.cpp
     ./olp-cpp-sdk-authentication/TokenProviderTest.cpp
     ./olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
     ./olp-cpp-sdk-dataservice-read/VolatileLayerClientCacheTest.cpp

--- a/tests/integration/olp-cpp-sdk-authentication/TokenEndpointTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/TokenEndpointTest.cpp
@@ -1,0 +1,801 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/authentication/TokenEndpoint.h>
+
+#include <future>
+#include <memory>
+
+#include <gmock/gmock.h>
+#include <matchers/NetworkUrlMatchers.h>
+#include <mocks/NetworkMock.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/http/HttpStatusCode.h>
+#include <olp/core/http/NetworkConstants.h>
+#include <olp/core/http/NetworkUtils.h>
+#include <olp/core/porting/make_unique.h>
+#include "AuthenticationMockedResponses.h"
+
+namespace auth = olp::authentication;
+namespace client = olp::client;
+namespace http = olp::http;
+using testing::_;
+
+namespace {
+constexpr auto kKey = "key";
+constexpr auto kSecret = "secret";
+
+constexpr auto kTimestampUrl = "https://authentication.server.url/timestamp";
+constexpr auto kTokenEndpointUrl = "https://authentication.server.url";
+
+constexpr unsigned int kExpiryTime = 3600;
+constexpr unsigned int kMaxExpiryTime = kExpiryTime + 30;
+constexpr unsigned int kMinExpiryTime = kExpiryTime - 10;
+constexpr unsigned int kExpectedRetryCount = 3;
+
+constexpr auto kWaitTimeout = std::chrono::seconds(3);
+constexpr auto kMaxRetryAttempts = 5;
+constexpr auto kRetryTimeout = 10;
+constexpr auto kMinTimeout = 1;
+
+constexpr http::RequestId kRequestId = 5;
+
+constexpr auto kErrorServiceUnavailable = "Service Unavailable";
+constexpr auto kErrorTimeOut = "Network request timed out.";
+constexpr auto kErrorCancelled = "Cancelled";
+constexpr auto kErrorBadRequestFullMessage =
+    R"JSON({"errorCode":400002,"message":"Invalid JSON."})JSON";
+constexpr auto kErrorUnauthorizedFullMessage =
+    R"JSON({"errorCode":401300,"message":"Signature mismatch. Authorization signature or client credential is wrong."})JSON";
+constexpr auto kErrorUserNotFoundFullMessage =
+    R"JSON({"errorCode":404000,"message":"User for the given access token cannot be found."})JSON";
+constexpr auto kErrorConflictFullMessage =
+    R"JSON({"errorCode":409100,"message":"A password account with the specified email address already exists."})JSON";
+constexpr auto kErrorTooManyRequestsFullMessage =
+    R"JSON({"errorCode":429002,"message":"Request blocked because too many requests were made. Please wait for a while before making a new request."})JSON";
+constexpr auto kErrorInternalServerFullMessage =
+    R"JSON({"errorCode":500203,"message":"Missing Thing Encrypted Secret."})JSON";
+constexpr auto kDateHeader = "Fri, 29 May 2020 11:07:45 GMT";
+constexpr auto kRequestAuth = "https://authentication.server.url/oauth2/token";
+constexpr auto kDate = "date";
+
+NetworkCallback MockWrongTimestamp() {
+  return [](http::NetworkRequest /*request*/, http::Network::Payload payload,
+            http::Network::Callback callback,
+            http::Network::HeaderCallback header_callback,
+            http::Network::DataCallback data_callback) {
+    if (payload) {
+      *payload << kResponseWrongTimestamp;
+    }
+    callback(http::NetworkResponse()
+                 .WithRequestId(kRequestId)
+                 .WithStatus(http::HttpStatusCode::UNAUTHORIZED));
+    if (data_callback) {
+      auto raw = const_cast<char*>(kResponseWrongTimestamp.c_str());
+      data_callback(reinterpret_cast<uint8_t*>(raw), 0,
+                    kResponseWrongTimestamp.size());
+    }
+    if (header_callback) {
+      header_callback(kDate, kDateHeader);
+    }
+
+    return http::SendOutcome(kRequestId);
+  };
+}
+
+void ExpectNoTimestampRequest(NetworkMock& network) {
+  EXPECT_CALL(network, Send(IsGetRequest(kTimestampUrl), _, _, _, _)).Times(0);
+}
+
+void ExpectTimestampRequest(NetworkMock& network) {
+  EXPECT_CALL(network, Send(IsGetRequest(kTimestampUrl), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
+                                   kResponseTime));
+}
+}  // namespace
+
+PORTING_PUSH_WARNINGS()
+PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+
+class TokenEndpointTest : public testing::Test {
+ public:
+  void SetUp() override {
+    network_ = std::make_shared<NetworkMock>();
+    task_scheduler_ =
+        client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(2u);
+
+    settings_.network_request_handler = network_;
+    settings_.task_scheduler = task_scheduler_;
+    settings_.token_endpoint_url = kTokenEndpointUrl;
+
+    PrepareEndpoint();
+  }
+
+  void TearDown() override {
+    endpoint_.reset();
+    task_scheduler_.reset();
+    network_.reset();
+  }
+
+  void PrepareEndpoint(bool use_system_time = true) {
+    settings_.use_system_time = use_system_time;
+    endpoint_ = std::make_unique<auth::TokenEndpoint>(settings_);
+  }
+
+  void ExecuteRequestTokenWithError(int http_response,
+                                    const std::string& error_message,
+                                    const std::string& response_data = "") {
+    const bool is_retryable = client::DefaultRetryCondition({http_response});
+
+    const auto expected_calls_count =
+        is_retryable ? settings_.retry_settings.max_attempts : 1;
+
+    EXPECT_CALL(*network_, Send(_, _, _, _, _))
+        .Times(expected_calls_count)
+        .WillRepeatedly(testing::WithArgs<1, 2, 4>(
+            [&](http::Network::Payload payload,
+                http::Network::Callback callback,
+                http::Network::DataCallback data_callback) {
+              if (payload) {
+                *payload << response_data;
+              }
+
+              callback(http::NetworkResponse()
+                           .WithRequestId(kRequestId)
+                           .WithStatus(http_response));
+              if (data_callback) {
+                auto raw = const_cast<char*>(response_data.c_str());
+                data_callback(reinterpret_cast<uint8_t*>(raw), 0,
+                              response_data.size());
+              }
+
+              return http::SendOutcome(kRequestId);
+            }));
+
+    client::CancellationContext context;
+    const auto token_response = endpoint_->RequestToken(context);
+
+    ASSERT_FALSE(token_response);
+    EXPECT_EQ(token_response.GetError().GetHttpStatusCode(), http_response);
+    EXPECT_EQ(token_response.GetError().GetMessage(), error_message);
+
+    testing::Mock::VerifyAndClearExpectations(network_.get());
+  }
+
+ protected:
+  const auth::AuthenticationCredentials credentials_{kKey, kSecret};
+  auth::Settings settings_{credentials_};
+  std::shared_ptr<NetworkMock> network_;
+  std::shared_ptr<olp::thread::TaskScheduler> task_scheduler_;
+  std::unique_ptr<auth::TokenEndpoint> endpoint_;
+};
+
+TEST_F(TokenEndpointTest, RequestTokenUsingSystemTime) {
+  // Default time source should be system time
+  ASSERT_TRUE(settings_.use_system_time);
+
+  ExpectNoTimestampRequest(*network_);
+
+  EXPECT_CALL(*network_, Send(IsPostRequest(kRequestAuth), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
+                                   kResponseValidJson));
+
+  client::CancellationContext context;
+  const auto token_response = endpoint_->RequestToken(context);
+
+  ASSERT_TRUE(token_response);
+  const auto& token_result = token_response.GetResult();
+
+  const auto now =
+      std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  EXPECT_LT(token_result.GetExpiryTime(), now + kMaxExpiryTime);
+  EXPECT_GE(token_result.GetExpiryTime(), now + kMinExpiryTime);
+  EXPECT_EQ(token_result.GetAccessToken(), kResponseToken);
+}
+
+TEST_F(TokenEndpointTest, RequestTokenUsingWrongSystemTime) {
+  // Default time source should be system time
+  ASSERT_TRUE(settings_.use_system_time);
+
+  ExpectNoTimestampRequest(*network_);
+
+  EXPECT_CALL(*network_, Send(IsPostRequest(kRequestAuth), _, _, _, _))
+      .WillOnce(MockWrongTimestamp())
+      .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
+                                   kResponseValidJson));
+
+  client::CancellationContext context;
+  const auto token_response = endpoint_->RequestToken(context);
+
+  ASSERT_TRUE(token_response);
+  const auto& token_result = token_response.GetResult();
+
+  const auto now =
+      std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  EXPECT_LT(token_result.GetExpiryTime(), now + kMaxExpiryTime);
+  EXPECT_GE(token_result.GetExpiryTime(), now + kMinExpiryTime);
+  EXPECT_EQ(token_result.GetAccessToken(), kResponseToken);
+}
+
+TEST_F(TokenEndpointTest, RequestTokenUsingServerTime) {
+  PrepareEndpoint(false);
+
+  ExpectTimestampRequest(*network_);
+
+  EXPECT_CALL(*network_, Send(IsPostRequest(kRequestAuth), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
+                                   kResponseValidJson));
+
+  client::CancellationContext context;
+  const auto token_response = endpoint_->RequestToken(context);
+
+  ASSERT_TRUE(token_response);
+  const auto& token_result = token_response.GetResult();
+
+  const auto now =
+      std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  EXPECT_LT(token_result.GetExpiryTime(), now + kMaxExpiryTime);
+  EXPECT_GE(token_result.GetExpiryTime(), now + kMinExpiryTime);
+  EXPECT_EQ(token_result.GetAccessToken(), kResponseToken);
+}
+
+TEST_F(TokenEndpointTest, TestInvalidResponses) {
+  {
+    SCOPED_TRACE("Invalid JSON");
+
+    EXPECT_NO_FATAL_FAILURE(ExecuteRequestTokenWithError(
+        http::HttpStatusCode::SERVICE_UNAVAILABLE, kErrorServiceUnavailable,
+        kResponseInvalidJson));
+  }
+
+  {
+    SCOPED_TRACE("No token");
+
+    EXPECT_NO_FATAL_FAILURE(ExecuteRequestTokenWithError(
+        http::HttpStatusCode::SERVICE_UNAVAILABLE, kErrorServiceUnavailable,
+        kResponseNoToken));
+  }
+
+  {
+    SCOPED_TRACE("Token type missing");
+
+    EXPECT_NO_FATAL_FAILURE(ExecuteRequestTokenWithError(
+        http::HttpStatusCode::SERVICE_UNAVAILABLE, kErrorServiceUnavailable,
+        kResponseNoTokenType));
+  }
+
+  {
+    SCOPED_TRACE("Missing expiry");
+
+    EXPECT_NO_FATAL_FAILURE(ExecuteRequestTokenWithError(
+        http::HttpStatusCode::SERVICE_UNAVAILABLE, kErrorServiceUnavailable,
+        kResponseNoExpiry));
+  }
+}
+
+TEST_F(TokenEndpointTest, TestHttpRequestErrorCodes) {
+  int status;
+
+  {
+    SCOPED_TRACE("ACCEPTED");
+
+    status = http::HttpStatusCode::ACCEPTED;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("CREATED");
+
+    status = http::HttpStatusCode::CREATED;
+    EXPECT_NO_FATAL_FAILURE(ExecuteRequestTokenWithError(
+        status, http::HttpErrorToString(status), kResponseCreated));
+  }
+
+  {
+    SCOPED_TRACE("NON_AUTHORITATIVE_INFORMATION");
+
+    status = http::HttpStatusCode::NON_AUTHORITATIVE_INFORMATION;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("NO_CONTENT");
+
+    status = http::HttpStatusCode::NO_CONTENT;
+    EXPECT_NO_FATAL_FAILURE(ExecuteRequestTokenWithError(
+        status, http::HttpErrorToString(status), kResponseNoContent));
+  }
+
+  {
+    SCOPED_TRACE("RESET_CONTENT");
+
+    status = http::HttpStatusCode::RESET_CONTENT;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("MULTIPLE_CHOICES");
+
+    status = http::HttpStatusCode::PARTIAL_CONTENT;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("MULTIPLE_CHOICES");
+
+    status = http::HttpStatusCode::MULTIPLE_CHOICES;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("MOVED_PERMANENTLY");
+
+    status = http::HttpStatusCode::MOVED_PERMANENTLY;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("FOUND");
+
+    status = http::HttpStatusCode::FOUND;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("SEE_OTHER");
+
+    status = http::HttpStatusCode::SEE_OTHER;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("NOT_MODIFIED");
+
+    status = http::HttpStatusCode::NOT_MODIFIED;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("USE_PROXY");
+
+    status = http::HttpStatusCode::USE_PROXY;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("BAD_REQUEST");
+
+    status = http::HttpStatusCode::BAD_REQUEST;
+    EXPECT_NO_FATAL_FAILURE(ExecuteRequestTokenWithError(
+        status, kErrorBadRequestFullMessage, kResponseBadRequest));
+  }
+
+  {
+    SCOPED_TRACE("UNAUTHORIZED");
+
+    status = http::HttpStatusCode::UNAUTHORIZED;
+    EXPECT_NO_FATAL_FAILURE(ExecuteRequestTokenWithError(
+        status, kErrorUnauthorizedFullMessage, kResponseUnauthorized));
+  }
+
+  {
+    SCOPED_TRACE("PAYMENT_REQUIRED");
+
+    status = http::HttpStatusCode::PAYMENT_REQUIRED;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("NOT_FOUND");
+
+    status = http::HttpStatusCode::NOT_FOUND;
+    EXPECT_NO_FATAL_FAILURE(ExecuteRequestTokenWithError(
+        status, kErrorUserNotFoundFullMessage, kResponseNotFound));
+  }
+
+  {
+    SCOPED_TRACE("METHOD_NOT_ALLOWED");
+
+    status = http::HttpStatusCode::METHOD_NOT_ALLOWED;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("FORBIDDEN");
+
+    status = http::HttpStatusCode::FORBIDDEN;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("NOT_ACCEPTABLE");
+
+    status = http::HttpStatusCode::NOT_ACCEPTABLE;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("PROXY_AUTHENTICATION_REQUIRED");
+
+    status = http::HttpStatusCode::PROXY_AUTHENTICATION_REQUIRED;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("REQUEST_TIMEOUT");
+
+    status = http::HttpStatusCode::REQUEST_TIMEOUT;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("CONFLICT");
+
+    status = http::HttpStatusCode::CONFLICT;
+    EXPECT_NO_FATAL_FAILURE(ExecuteRequestTokenWithError(
+        status, kErrorConflictFullMessage, kResponseConflict));
+  }
+
+  {
+    SCOPED_TRACE("GONE");
+
+    status = http::HttpStatusCode::GONE;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("LENGTH_REQUIRED");
+
+    status = http::HttpStatusCode::LENGTH_REQUIRED;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("PRECONDITION_FAILED");
+
+    status = http::HttpStatusCode::PRECONDITION_FAILED;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("REQUEST_ENTITY_TOO_LARGE");
+
+    status = http::HttpStatusCode::REQUEST_ENTITY_TOO_LARGE;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("REQUEST_URI_TOO_LONG");
+
+    status = http::HttpStatusCode::REQUEST_URI_TOO_LONG;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("UNSUPPORTED_MEDIA_TYPE");
+
+    status = http::HttpStatusCode::UNSUPPORTED_MEDIA_TYPE;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("TOO_MANY_REQUESTS");
+
+    status = http::HttpStatusCode::TOO_MANY_REQUESTS;
+    EXPECT_NO_FATAL_FAILURE(ExecuteRequestTokenWithError(
+        status, kErrorTooManyRequestsFullMessage, kResponseTooManyRequests));
+  }
+
+  {
+    SCOPED_TRACE("INTERNAL_SERVER_ERROR");
+
+    status = http::HttpStatusCode::INTERNAL_SERVER_ERROR;
+    EXPECT_NO_FATAL_FAILURE(ExecuteRequestTokenWithError(
+        status, kErrorInternalServerFullMessage, kResponseInternalServerError));
+  }
+
+  {
+    SCOPED_TRACE("NOT_IMPLEMENTED");
+
+    status = http::HttpStatusCode::NOT_IMPLEMENTED;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("BAD_GATEWAY");
+
+    status = http::HttpStatusCode::BAD_GATEWAY;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("SERVICE_UNAVAILABLE");
+
+    status = http::HttpStatusCode::SERVICE_UNAVAILABLE;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("GATEWAY_TIMEOUT");
+
+    status = http::HttpStatusCode::GATEWAY_TIMEOUT;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("VERSION_NOT_SUPPORTED");
+
+    status = http::HttpStatusCode::VERSION_NOT_SUPPORTED;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("Custom positive status");
+
+    status = 100000;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+
+  {
+    SCOPED_TRACE("Custom negative status");
+
+    status = -100000;
+    EXPECT_NO_FATAL_FAILURE(
+        ExecuteRequestTokenWithError(status, http::HttpErrorToString(status)));
+  }
+}
+
+TEST_F(TokenEndpointTest, UniqueNonce) {
+  std::set<std::string> nonces;
+
+  auto extract_nonce = [&](const http::Headers& headers) {
+    auto auth_it =
+        std::find_if(headers.begin(), headers.end(),
+                     [](const std::pair<std::string, std::string>& header) {
+                       return header.first == http::kAuthorizationHeader;
+                     });
+    if (auth_it == headers.end()) {
+      return;
+    }
+
+    const auto& params = auth_it->second;
+    const auto prefix = "oauth_nonce=\"";
+    auto nonce_begin = params.find(prefix);
+    if (nonce_begin == std::string::npos) {
+      return;
+    }
+    nonce_begin += strlen(prefix);
+    auto nonce_end = params.find("\"", nonce_begin);
+    if (nonce_end == std::string::npos) {
+      return;
+    }
+    auto nonce = params.substr(nonce_begin, nonce_end - nonce_begin);
+    nonces.insert(nonce);
+  };
+
+  EXPECT_CALL(*network_, Send(IsPostRequest(kRequestAuth), _, _, _, _))
+      .Times(3)
+      .WillRepeatedly(testing::WithArgs<0, 2>(
+          [&](http::NetworkRequest request, http::Network::Callback callback) {
+            extract_nonce(request.GetHeaders());
+            callback(http::NetworkResponse()
+                         .WithRequestId(kRequestId)
+                         .WithStatus(http::HttpStatusCode::TOO_MANY_REQUESTS));
+            return http::SendOutcome(kRequestId);
+          }));
+
+  client::CancellationContext context;
+  endpoint_->RequestToken(context);
+  EXPECT_EQ(nonces.size(), kExpectedRetryCount);
+}
+
+TEST_F(TokenEndpointTest, RetrySettings) {
+  settings_.retry_settings.max_attempts = kMaxRetryAttempts;
+  settings_.retry_settings.timeout = kRetryTimeout;
+  PrepareEndpoint();
+
+  const auto retry_predicate = testing::Property(
+      &http::NetworkRequest::GetSettings,
+      testing::AllOf(
+          testing::Property(&http::NetworkSettings::GetConnectionTimeout,
+                            kRetryTimeout),
+          testing::Property(&http::NetworkSettings::GetTransferTimeout,
+                            kRetryTimeout)));
+
+  EXPECT_CALL(*network_, Send(retry_predicate, _, _, _, _))
+      .Times(kMaxRetryAttempts)
+      .WillRepeatedly(ReturnHttpResponse(
+          GetResponse(http::HttpStatusCode::TOO_MANY_REQUESTS)
+              .WithError(kErrorTooManyRequestsFullMessage),
+          kResponseTooManyRequests));
+
+  client::CancellationContext context;
+  const auto token_response = endpoint_->RequestToken(context);
+
+  ASSERT_FALSE(token_response);
+  EXPECT_EQ(token_response.GetError().GetHttpStatusCode(),
+            http::HttpStatusCode::TOO_MANY_REQUESTS);
+}
+
+TEST_F(TokenEndpointTest, ResponseFitsRetryCondition) {
+  settings_.retry_settings.retry_condition =
+      [](const client::HttpResponse& http_response) {
+        return http_response.GetStatus() ==
+               http::HttpStatusCode::TOO_MANY_REQUESTS;
+      };
+
+  PrepareEndpoint();
+
+  EXPECT_CALL(*network_, Send(IsPostRequest(kRequestAuth), _, _, _, _))
+      .Times(kExpectedRetryCount)
+      .WillRepeatedly(ReturnHttpResponse(
+          GetResponse(http::HttpStatusCode::TOO_MANY_REQUESTS)
+              .WithError(kErrorTooManyRequestsFullMessage),
+          kResponseTooManyRequests));
+
+  client::CancellationContext context;
+  const auto token_response = endpoint_->RequestToken(context);
+
+  ASSERT_FALSE(token_response);
+  EXPECT_EQ(token_response.GetError().GetHttpStatusCode(),
+            http::HttpStatusCode::TOO_MANY_REQUESTS);
+}
+
+TEST_F(TokenEndpointTest, ResponseDoesNotFitRetryCondition) {
+  settings_.retry_settings.retry_condition =
+      [](const client::HttpResponse& http_response) {
+        return http_response.GetStatus() !=
+               http::HttpStatusCode::TOO_MANY_REQUESTS;
+      };
+
+  PrepareEndpoint();
+
+  EXPECT_CALL(*network_, Send(IsPostRequest(kRequestAuth), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(
+          GetResponse(http::HttpStatusCode::TOO_MANY_REQUESTS)
+              .WithError(kErrorTooManyRequestsFullMessage),
+          kResponseTooManyRequests));
+
+  client::CancellationContext context;
+  const auto token_response = endpoint_->RequestToken(context);
+
+  ASSERT_FALSE(token_response);
+  EXPECT_EQ(token_response.GetError().GetHttpStatusCode(),
+            http::HttpStatusCode::TOO_MANY_REQUESTS);
+}
+
+TEST_F(TokenEndpointTest, OkRetryCondition) {
+  // The request ended up with `OK` status should not be retriggered even if
+  // `retry_condition` is `true` for this `HttpResponse`.
+
+  settings_.retry_settings.retry_condition =
+      [](const client::HttpResponse& http_response) {
+        return http_response.GetStatus() == http::HttpStatusCode::OK;
+      };
+
+  PrepareEndpoint();
+
+  EXPECT_CALL(*network_, Send(IsPostRequest(kRequestAuth), _, _, _, _))
+      .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
+                                   kResponseValidJson));
+
+  client::CancellationContext context;
+  const auto token_response = endpoint_->RequestToken(context);
+
+  ASSERT_TRUE(token_response);
+  EXPECT_EQ(token_response.GetResult().GetAccessToken(), kResponseToken);
+}
+
+TEST_F(TokenEndpointTest, Timeout) {
+  settings_.retry_settings.timeout = kMinTimeout;
+  PrepareEndpoint();
+
+  std::future<void> async_finish_future;
+
+  EXPECT_CALL(*network_, Send(IsPostRequest(kRequestAuth), _, _, _, _))
+      .WillOnce(testing::WithArg<2>([&](http::Network::Callback callback) {
+        async_finish_future = std::async(std::launch::async, [=]() {
+          // Oversleep the timeout period.
+          std::this_thread::sleep_for(
+              std::chrono::seconds(settings_.retry_settings.timeout * 2));
+          callback(http::NetworkResponse()
+                       .WithStatus(http::HttpStatusCode::OK)
+                       .WithRequestId(kRequestId));
+        });
+
+        return http::SendOutcome(kRequestId);
+      }));
+
+  EXPECT_CALL(*network_, Cancel(_)).Times(1);
+
+  client::CancellationContext context;
+  const auto token_response = endpoint_->RequestToken(context);
+
+  ASSERT_EQ(async_finish_future.wait_for(kWaitTimeout),
+            std::future_status::ready);
+  ASSERT_FALSE(token_response);
+  EXPECT_EQ(token_response.GetError().GetHttpStatusCode(),
+            static_cast<int>(http::ErrorCode::TIMEOUT_ERROR));
+  EXPECT_EQ(token_response.GetError().GetMessage(), kErrorTimeOut);
+}
+
+TEST_F(TokenEndpointTest, Cancel) {
+  std::future<void> async_finish_future;
+  std::promise<void> network_wait_promise;
+
+  client::CancellationContext context;
+  EXPECT_CALL(*network_, Send(IsPostRequest(kRequestAuth), _, _, _, _))
+      .WillOnce(testing::WithArg<2>([&](http::Network::Callback callback) {
+        async_finish_future = std::async(std::launch::async, [&, callback]() {
+          std::this_thread::sleep_for(std::chrono::seconds(kMinTimeout));
+          context.CancelOperation();
+
+          EXPECT_EQ(network_wait_promise.get_future().wait_for(kWaitTimeout),
+                    std::future_status::ready);
+
+          callback(http::NetworkResponse()
+                       .WithStatus(http::HttpStatusCode::OK)
+                       .WithRequestId(kRequestId));
+        });
+
+        return http::SendOutcome(kRequestId);
+      }));
+
+  EXPECT_CALL(*network_, Cancel(kRequestId)).Times(1);
+
+  const auto token_response = endpoint_->RequestToken(context);
+  network_wait_promise.set_value();
+
+  ASSERT_EQ(async_finish_future.wait_for(kWaitTimeout),
+            std::future_status::ready);
+  ASSERT_FALSE(token_response);
+  EXPECT_EQ(token_response.GetError().GetHttpStatusCode(),
+            static_cast<int>(http::ErrorCode::CANCELLED_ERROR));
+  EXPECT_EQ(token_response.GetError().GetMessage(), kErrorCancelled);
+}
+
+PORTING_POP_WARNINGS()


### PR DESCRIPTION
The inner class TokenEndpoint::Impl is extructed from TokenEndpoint.cpp
to separate files TokenEndpointImpl.h and TokenEndpointImpl.cpp.

TokenEndpointImpl is extended with mostly copy-pasted code from
AuthenticationClientImpl, which is supposed to be refactored in
the future to use TokenProvider, and not in the opposite direction,
as it is now. TokenEndpointImpl code is adapted in a way to give an
abilty to pass cancellation context from the new token profider to
OlpClient::CallApi().

A new test class TokenEndpointTest contains adapted tests
copy-pasted from AuthenticationClientTest.

Integration tests for cancellation and timeout are added.

Relates-To: OLPEDGE-2651

Signed-off-by: Mykola Malik <ext-mykola.malik@here.com>