### PR TITLE
Make sign in timeout error distinguishable

### DIFF
--- a/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.h
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,6 +177,11 @@ class AuthenticationClientImpl {
 
   SignInUserResult ParseUserAuthResponse(int status,
                                          std::stringstream& auth_response);
+
+  template <typename SignInResponseType>
+  Response<SignInResponseType> GetSignInResponse(
+      const client::HttpResponse& auth_response,
+      const client::CancellationContext& context, const std::string& key);
 
   template <typename SignInResponseType>
   boost::optional<SignInResponseType> FindInCache(const std::string& key);

--- a/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
@@ -180,7 +180,7 @@ class CORE_API HttpResponse {
    *
    * @param output Reference to a string.
    */
-  void GetResponse(std::string& output) { output = response.str(); }
+  void GetResponse(std::string& output) const { output = response.str(); }
 
   /**
    * @brief Return the const reference to the response headers.


### PR DESCRIPTION
If a timeout occurred, the cancellation is done through the context.
So this case needs to be handled independently of context state,
instead of blindely return Cancelled error if context is cancelled.

Relates-To: OLPEDGE-2656

Signed-off-by: Mykola Malik <ext-mykola.malik@here.com>