### PR TITLE
Remove retry logic from Android.

### DIFF
--- a/olp-cpp-sdk-core/src/client/OlpClient.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClient.cpp
@@ -301,8 +301,12 @@ HttpResponse SendRequest(const http::NetworkRequest& request,
   }
 
   if (!response_data->condition.Wait(timeout)) {
-    OLP_SDK_LOG_WARNING_F(kLogTag, "Request %" PRIu64 " timed out!",
-                          outcome.GetRequestId());
+    OLP_SDK_LOG_WARNING_F(
+        kLogTag,
+        "Request timed out, request_id=%" PRIu64
+        ", timeout=%i, retry_count=%i, url='%s'",
+        outcome.GetRequestId(), static_cast<int>(timeout.count()),
+        retry_settings.max_attempts, request.GetUrl().c_str());
     context.CancelOperation();
     return ToHttpResponse(kTimeoutErrorResponse);
   }

--- a/olp-cpp-sdk-core/src/http/android/NetworkAndroid.cpp
+++ b/olp-cpp-sdk-core/src/http/android/NetworkAndroid.cpp
@@ -956,8 +956,7 @@ SendOutcome NetworkAndroid::Send(NetworkRequest request,
       static_cast<jint>(request.GetSettings().GetTransferTimeout());
   const jint jproxy_port = static_cast<jint>(proxy_settings.GetPort());
   const jint jproxy_type = static_cast<jint>(proxy_settings.GetType());
-  const jint jmax_retries =
-      static_cast<jint>(request.GetSettings().GetRetries());
+  const jint jmax_retries = 1;
   // Do sending
   {
     std::lock_guard<std::mutex> lock(requests_mutex_);


### PR DESCRIPTION
- Removed retry logic from Android network code because it is not necessary
  due to better retry logic that already exists for all platforms inside
  OlpClient.
- Now log message on connection timeout in OlpClient is more informative
  and prints url, timeout and retry_count of the request.

Resolves: OLPSUP-16639

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>