### PR TITLE
Move AutoRefreshingToken, TokenEndpoint, and TokenRequest

### DIFF
--- a/olp-cpp-sdk-authentication/src/AutoRefreshingToken.cpp
+++ b/olp-cpp-sdk-authentication/src/AutoRefreshingToken.cpp
@@ -17,15 +17,15 @@
  * License-Filename: LICENSE
  */
 
-#include "olp/authentication/AutoRefreshingToken.h"
+#include "AutoRefreshingToken.h"
 
 #include <chrono>
 #include <iostream>
 
-#include "olp/authentication/TokenEndpoint.h"
-#include "olp/core/client/CancellationToken.h"
-#include "olp/core/logging/Log.h"
-#include "olp/core/porting/warning_disable.h"
+#include <olp/core/client/CancellationToken.h>
+#include <olp/core/logging/Log.h>
+#include "TokenEndpoint.h"
+#include "TokenRequest.h"
 
 namespace {
 constexpr auto kLogTag = "authentication::AutoRefreshingToken";
@@ -47,8 +47,6 @@ std::chrono::steady_clock::time_point ComputeRefreshTime(
 
 namespace olp {
 namespace authentication {
-PORTING_PUSH_WARNINGS()
-PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
 
 struct AutoRefreshingToken::Impl {
   Impl(TokenEndpoint token_endpoint, TokenRequest token_request)
@@ -207,7 +205,6 @@ client::CancellationToken AutoRefreshingToken::GetToken(
     const std::chrono::seconds& minimum_validity) const {
   return impl_->GetToken(callback, minimum_validity);
 }
-PORTING_POP_WARNINGS()
 
 }  // namespace authentication
 }  // namespace olp

--- a/olp-cpp-sdk-authentication/src/AutoRefreshingToken.h
+++ b/olp-cpp-sdk-authentication/src/AutoRefreshingToken.h
@@ -23,22 +23,13 @@
 #include <functional>
 #include <memory>
 
-#include "AuthenticationApi.h"
+#include <olp/authentication/AuthenticationApi.h>
+#include <olp/core/client/CancellationContext.h>
+#include <olp/core/client/CancellationToken.h>
 #include "TokenEndpoint.h"
-#include "TokenRequest.h"
-#include "TokenResult.h"
-
-#include "olp/core/client/CancellationContext.h"
-#include "olp/core/client/CancellationToken.h"
-#include "olp/core/porting/warning_disable.h"
 
 namespace olp {
 namespace authentication {
-
-static constexpr auto kDefaultMinimumValidity = 300ll;
-static constexpr auto kDefaultMinimumValiditySeconds =
-    std::chrono::seconds(kDefaultMinimumValidity);
-static constexpr auto kForceRefresh = std::chrono::seconds(0);
 
 /**
  * @brief Manages token requests.
@@ -46,13 +37,8 @@ static constexpr auto kForceRefresh = std::chrono::seconds(0);
  * Requests a new token from the token endpoint and automatically refreshes it
  * when the token is about to expire.
  */
-class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed by 10.2020.")
-    AutoRefreshingToken {
+class AutoRefreshingToken {
  public:
-  // Needed to avoid endless warnings from TokenRequest/TokenResult
-  PORTING_PUSH_WARNINGS()
-  PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
-
   /**
    * @brief Specifies the callback signature that is required
    * when the get token request is completed.
@@ -79,8 +65,7 @@ class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed by 10.2020.")
    * Otherwise, returns the cached `TokenResponse` instance.
    */
   TokenResponse GetToken(client::CancellationToken& cancellation_token,
-                         const std::chrono::seconds& minimum_validity =
-                             kDefaultMinimumValiditySeconds) const;
+                         const std::chrono::seconds& minimum_validity) const;
 
   /**
    * @brief Synchronously gets a token that is always fresh.
@@ -101,8 +86,7 @@ class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed by 10.2020.")
    * Otherwise, returns the cached `TokenResponse` instance.
    */
   TokenResponse GetToken(client::CancellationContext& context,
-                         const std::chrono::seconds& minimum_validity =
-                             kDefaultMinimumValiditySeconds) const;
+                         const std::chrono::seconds& minimum_validity) const;
 
   /**
    * @brief Synchronously gets a token that is always fresh.
@@ -121,8 +105,7 @@ class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed by 10.2020.")
    * @return The `TokenResponse` instance if the old one is expired.
    * Otherwise, the cached `TokenResponse` instance.
    */
-  TokenResponse GetToken(const std::chrono::seconds& minimum_validity =
-                             kDefaultMinimumValiditySeconds) const;
+  TokenResponse GetToken(const std::chrono::seconds& minimum_validity) const;
 
   /**
    * @brief Asynchronously gets a token that is always fresh.
@@ -141,8 +124,7 @@ class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed by 10.2020.")
    */
   client::CancellationToken GetToken(
       const GetTokenCallback& callback,
-      const std::chrono::seconds& minimum_validity =
-          kDefaultMinimumValiditySeconds) const;
+      const std::chrono::seconds& minimum_validity) const;
 
   /**
    * @brief Creates the `AutoRefreshingToken` instance.
@@ -152,8 +134,6 @@ class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed by 10.2020.")
    * @param token_request The token request that is sent to the token endpoint.
    */
   AutoRefreshingToken(TokenEndpoint token_endpoint, TokenRequest token_request);
-
-  PORTING_POP_WARNINGS()
 
  private:
   struct Impl;

--- a/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
@@ -17,15 +17,13 @@
  * License-Filename: LICENSE
  */
 
-#include <olp/authentication/TokenEndpoint.h>
-
-PORTING_PUSH_WARNINGS()
-PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+#include "TokenEndpoint.h"
 
 #include <olp/authentication/AuthenticationClient.h>
-#include <olp/authentication/AutoRefreshingToken.h>
 #include <olp/core/logging/Log.h>
+#include "AutoRefreshingToken.h"
 #include "TokenEndpointImpl.h"
+#include "TokenRequest.h"
 
 namespace olp {
 namespace authentication {
@@ -82,6 +80,5 @@ AutoRefreshingToken TokenEndpoint::RequestAutoRefreshingToken(
   return AutoRefreshingToken(*this, token_request);
 }
 
-PORTING_POP_WARNINGS()
 }  // namespace authentication
 }  // namespace olp

--- a/olp-cpp-sdk-authentication/src/TokenEndpoint.h
+++ b/olp-cpp-sdk-authentication/src/TokenEndpoint.h
@@ -26,13 +26,11 @@
 #include <olp/authentication/AuthenticationCredentials.h>
 #include <olp/authentication/AuthenticationError.h>
 #include <olp/authentication/Settings.h>
-#include <olp/authentication/TokenRequest.h>
-#include <olp/authentication/TokenResult.h>
 #include <olp/authentication/Types.h>
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/CancellationToken.h>
-#include <olp/core/porting/warning_disable.h>
+#include "TokenRequest.h"
 
 namespace olp {
 namespace authentication {
@@ -43,13 +41,8 @@ class TokenEndpointImpl;
  * @brief Corresponds to the token endpoint as specified in the OAuth2.0
  * specification.
  */
-class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed in 10.2020")
-    TokenEndpoint {
+class TokenEndpoint {
  public:
-  // Needed to avoid endless warnings from TokenRequest/TokenResult
-  PORTING_PUSH_WARNINGS()
-  PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
-
   /// Defines the signature used to return the response to the client.
   using TokenResponse = Response<TokenResult>;
   /// Defines the callback that is invoked when the response on
@@ -60,8 +53,8 @@ class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed in 10.2020")
    * @brief Executes the POST request method to the token endpoint.
    *
    * The request gets the HERE Access token that is used to access the HERE
-   * platform Services. Returns the token that is used as the `Authorization:
-   * Bearer` token value.
+   * platform Services. Returns the token that is used as
+   * the `Authorization: Bearer` token value.
    *
    * @param token_request The `TokenRequest` instance.
    * @param callback The `RequestTokenCallback` instance that passes
@@ -77,9 +70,9 @@ class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed in 10.2020")
   /**
    * @brief Executes the POST request method to the token endpoint.
    *
-   * The request gets the HERE Access token that is used to access the HERE platform
-   * Services. Returns the token that is used as the `Authorization: Bearer`
-   * token value.
+   * The request gets the HERE Access token that is used to access the HERE
+   * platform Services. Returns the token that is used as
+   * the `Authorization: Bearer` token value.
    *
    * @param cancellation_token The `CancellationToken` instance that can be used
    * to cancel the request.
@@ -95,8 +88,8 @@ class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed in 10.2020")
    * @brief Executes the POST request method to the token endpoint.
    *
    * The request gets the HERE Access token that is used to access the HERE
-   * platform Services. Returns the token that is used as the `Authorization:
-   * Bearer` token value.
+   * platform Services. Returns the token that is used as
+   * the `Authorization: Bearer` token value.
    *
    * @param context Used to cancel the pending token request.
    * @param token_request The `TokenRequest` instance.
@@ -110,9 +103,9 @@ class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed in 10.2020")
   /**
    * Executes the POST request method to the token endpoint.
    *
-   * The request gets the HERE Access token that is used to access the HERE platform
-   * Services. Returns the token that is used as the `Authorization: Bearer`
-   * token value.
+   * The request gets the HERE Access token that is used to access the HERE
+   * platform Services. Returns the token that is used as
+   * the `Authorization: Bearer` token value.
    *
    * @param token_request The `TokenRequest` instance.
    *
@@ -132,8 +125,6 @@ class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed in 10.2020")
    */
   AutoRefreshingToken RequestAutoRefreshingToken(
       const TokenRequest& token_request = TokenRequest());
-
-  PORTING_POP_WARNINGS()
 
   /**
    * @brief Creates the `TokenEndpoint` instance with the given `settings`

--- a/olp-cpp-sdk-authentication/src/TokenEndpointImpl.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenEndpointImpl.cpp
@@ -107,10 +107,6 @@ std::string GenerateUid() {
   });
 }
 
-// Needed to avoid endless warnings from TokenRequest
-PORTING_PUSH_WARNINGS()
-PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
-
 client::OlpClient::RequestBodyType GenerateClientBody(
     const TokenRequest& token_request) {
   rapidjson::StringBuffer data;
@@ -131,18 +127,12 @@ client::OlpClient::RequestBodyType GenerateClientBody(
   auto content = data.GetString();
   return std::make_shared<RequestBodyData>(content, content + data.GetSize());
 }
-
-PORTING_POP_WARNINGS()
 }  // namespace
 
 TokenEndpointImpl::TokenEndpointImpl(Settings settings)
     : credentials_(std::move(settings.credentials)),
       settings_(ConvertSettings(std::move(settings))),
       auth_client_(settings_) {}
-
-// Needed to avoid endless warnings from TokenRequest
-PORTING_PUSH_WARNINGS()
-PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
 
 client::CancellationToken TokenEndpointImpl::RequestToken(
     const TokenRequest& token_request, const RequestTokenCallback& callback) {
@@ -281,8 +271,6 @@ SignInResponse TokenEndpointImpl::SignInClient(
 
   return response;
 }
-
-PORTING_POP_WARNINGS()
 
 SignInResult TokenEndpointImpl::ParseAuthResponse(
     int status, std::stringstream& auth_response) {

--- a/olp-cpp-sdk-authentication/src/TokenEndpointImpl.h
+++ b/olp-cpp-sdk-authentication/src/TokenEndpointImpl.h
@@ -24,11 +24,10 @@
 #include <olp/authentication/AuthenticationSettings.h>
 #include <olp/authentication/Settings.h>
 #include <olp/authentication/SignInResult.h>
-#include <olp/authentication/TokenRequest.h>
 #include <olp/authentication/Types.h>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/OlpClient.h>
-#include <olp/core/porting/warning_disable.h>
+#include "TokenRequest.h"
 
 namespace olp {
 namespace authentication {
@@ -42,10 +41,6 @@ class TokenEndpointImpl {
 
   /// @copydoc TokenEndpoint::TokenEndpoint()
   explicit TokenEndpointImpl(Settings settings);
-
-  // Needed to avoid endless warnings from TokenRequest
-  PORTING_PUSH_WARNINGS()
-  PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
 
   /// @copydoc TokenEndpoint::RequestToken(const TokenRequest&, const
   /// RequestTokenCallback&)
@@ -64,8 +59,6 @@ class TokenEndpointImpl {
       client::CancellationContext& context,
       const TokenRequest& token_request = TokenRequest()) const;
 
-  PORTING_POP_WARNINGS()
-
  private:
   class RequestTimer {
    public:
@@ -81,14 +74,8 @@ class TokenEndpointImpl {
   static SignInResult ParseAuthResponse(int status,
                                         std::stringstream& auth_response);
 
-  // Needed to avoid endless warnings from TokenRequest
-  PORTING_PUSH_WARNINGS()
-  PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
-
   Response<SignInResult> SignInClient(client::CancellationContext& context,
                                       const TokenRequest& token_request) const;
-
-  PORTING_POP_WARNINGS()
 
   client::HttpResponse CallAuth(const client::OlpClient& client,
                                 const std::string& endpoint,

--- a/olp-cpp-sdk-authentication/src/TokenProvider.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenProvider.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2019-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/authentication/TokenProvider.h>
+
+#include <olp/core/porting/warning_disable.h>
+#include "AutoRefreshingToken.h"
+#include "TokenEndpoint.h"
+
+namespace olp {
+namespace authentication {
+namespace internal {
+
+class TokenProviderPrivate {
+ public:
+  TokenProviderPrivate(Settings settings, std::chrono::seconds minimum_validity)
+      : minimum_validity_{minimum_validity},
+        token_(std::make_shared<AutoRefreshingToken>(
+            TokenEndpoint(std::move(settings)).RequestAutoRefreshingToken())) {}
+
+  std::string operator()() const {
+    client::CancellationContext context;
+    const auto response = GetResponse(context);
+    return response ? response.GetResult().GetAccessToken() : "";
+  }
+
+  client::OauthTokenResponse operator()(
+      client::CancellationContext& context) const {
+    const auto response = GetResponse(context);
+    return response ? client::OauthTokenResponse(
+                          {response.GetResult().GetAccessToken(),
+                           response.GetResult().GetExpiryTime()})
+                    : client::OauthTokenResponse(response.GetError());
+  }
+
+  PORTING_PUSH_WARNINGS()
+  PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+  ErrorResponse GetErrorResponse() const {
+    client::CancellationContext context;
+    const auto response = GetResponse(context);
+    return response ? response.GetResult().GetErrorResponse() : ErrorResponse{};
+  }
+
+  int GetHttpStatusCode() const {
+    client::CancellationContext context;
+    const auto response = GetResponse(context);
+    return response ? response.GetResult().GetHttpStatus()
+                    : response.GetError().GetHttpStatusCode();
+  }
+  PORTING_POP_WARNINGS()
+
+  TokenResponse GetResponse(client::CancellationContext& context) const {
+    // Prevents multiple authorization requests that can
+    // happen when the token is not available, and multiple consumers
+    // request it.
+    std::lock_guard<std::mutex> lock(request_mutex_);
+    return token_->GetToken(context, minimum_validity_);
+  }
+
+  /// Checks whether the available token response is valid.
+  bool IsTokenResponseOK() const {
+    client::CancellationContext context;
+
+    // The token response is successful only if the token is valid.
+    return GetResponse(context).IsSuccessful();
+  }
+
+ private:
+  std::chrono::seconds minimum_validity_;
+  std::shared_ptr<AutoRefreshingToken> token_;
+  mutable std::mutex request_mutex_;
+};
+
+TokenProviderImpl::TokenProviderImpl(Settings settings,
+                                     std::chrono::seconds minimum_validity)
+    : impl_(std::make_shared<TokenProviderPrivate>(
+          std::move(settings), std::chrono::seconds(minimum_validity))) {}
+
+std::string TokenProviderImpl::operator()() const {
+  return impl_->operator()();
+}
+
+client::OauthTokenResponse TokenProviderImpl::operator()(
+    client::CancellationContext& context) const {
+  return impl_->operator()(context);
+}
+
+ErrorResponse TokenProviderImpl::GetErrorResponse() const {
+  return impl_->GetErrorResponse();
+}
+
+int TokenProviderImpl::GetHttpStatusCode() const {
+  return impl_->GetHttpStatusCode();
+}
+
+TokenResponse TokenProviderImpl::GetResponse(
+    client::CancellationContext& context) const {
+  return impl_->GetResponse(context);
+}
+
+bool TokenProviderImpl::IsTokenResponseOK() const {
+  return impl_->IsTokenResponseOK();
+}
+
+}  // namespace internal
+}  // namespace authentication
+}  // namespace olp

--- a/olp-cpp-sdk-authentication/src/TokenRequest.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenRequest.cpp
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-#include "olp/authentication/TokenRequest.h"
+#include "TokenRequest.h"
 
 namespace olp {
 namespace authentication {

--- a/olp-cpp-sdk-authentication/src/TokenRequest.h
+++ b/olp-cpp-sdk-authentication/src/TokenRequest.h
@@ -22,8 +22,7 @@
 #include <chrono>
 #include <cstdint>
 
-#include <olp/core/porting/deprecated.h>
-#include "AuthenticationApi.h"
+#include <olp/authentication/AuthenticationApi.h>
 
 namespace olp {
 namespace authentication {
@@ -31,8 +30,7 @@ namespace authentication {
  * @brief Holds the parameters of the OAuth2.0 Authorization
  * Grant request.
  */
-class AUTHENTICATION_API OLP_SDK_DEPRECATED("Will be removed in 10.2020")
-    TokenRequest {
+class TokenRequest {
  public:
   /**
    * @brief Creates the `TokenRequest` instance.

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -61,6 +61,7 @@ if (ANDROID OR IOS)
         ${OLP_SDK_FUNCTIONAL_TESTS_HEADERS})
     target_include_directories(${OLP_SDK_FUNCTIONAL_TESTS_LIB}
         PRIVATE
+            ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-authentication/src
             ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-dataservice-read/src
             ${PROJECT_SOURCE_DIR}/tests/utils/mock-server-client/
             utils
@@ -96,6 +97,7 @@ else()
         ${OLP_SDK_FUNCTIONAL_TESTS_HEADERS})
     target_include_directories(olp-cpp-sdk-functional-tests
     PRIVATE
+        ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-authentication/src
         ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-dataservice-read/src
         ${PROJECT_SOURCE_DIR}/tests/utils/mock-server-client/
         utils

--- a/tests/functional/olp-cpp-sdk-authentication/HereAccountOauth2ProductionTest.cpp
+++ b/tests/functional/olp-cpp-sdk-authentication/HereAccountOauth2ProductionTest.cpp
@@ -22,17 +22,15 @@
 #include <gmock/gmock.h>
 #include <olp/authentication/AuthenticationClient.h>
 #include <olp/authentication/AuthenticationCredentials.h>
-#include <olp/authentication/AutoRefreshingToken.h>
 #include <olp/authentication/Settings.h>
-#include <olp/authentication/TokenEndpoint.h>
 #include <olp/authentication/TokenProvider.h>
-#include <olp/authentication/TokenRequest.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
 #include <olp/core/http/HttpStatusCode.h>
 #include <olp/core/http/NetworkProxySettings.h>
 #include <olp/core/porting/warning_disable.h>
 #include <testutils/CustomParameters.hpp>
-
+#include "AutoRefreshingToken.h"
+#include "TokenRequest.h"
 #include "Utils.h"
 
 namespace authentication = ::olp::authentication;

--- a/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
@@ -26,9 +26,7 @@
 
 #include <olp/authentication/AuthenticationCredentials.h>
 #include <olp/authentication/Settings.h>
-#include <olp/authentication/TokenEndpoint.h>
 #include <olp/authentication/TokenProvider.h>
-#include <olp/authentication/TokenResult.h>
 #include <olp/core/cache/CacheSettings.h>
 #include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/client/ApiError.h>

--- a/tests/functional/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/CatalogClientTest.cpp
@@ -29,9 +29,7 @@
 
 #include <olp/authentication/AuthenticationCredentials.h>
 #include <olp/authentication/Settings.h>
-#include <olp/authentication/TokenEndpoint.h>
 #include <olp/authentication/TokenProvider.h>
-#include <olp/authentication/TokenResult.h>
 #include <olp/core/cache/DefaultCache.h>
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -75,8 +75,9 @@ if (ANDROID OR IOS)
 
     target_include_directories(${OLP_SDK_INTEGRATION_TESTS_LIB}
         PRIVATE
-            ${CMAKE_SOURCE_DIR}/../../olp-cpp-sdk-core/src
-			${PROJECT_SOURCE_DIR}/olp-cpp-sdk-dataservice-write/src
+            ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-authentication/src
+            ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-core/src
+            ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-dataservice-write/src
     )
 
 else()
@@ -93,7 +94,8 @@ else()
 
     target_include_directories(olp-cpp-sdk-integration-tests
         PRIVATE
-            ${CMAKE_SOURCE_DIR}/../../olp-cpp-sdk-core/src
-			${PROJECT_SOURCE_DIR}/olp-cpp-sdk-dataservice-write/src
+            ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-authentication/src
+            ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-core/src
+            ${PROJECT_SOURCE_DIR}/olp-cpp-sdk-dataservice-write/src
     )
 endif()

--- a/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
@@ -23,13 +23,13 @@
 #include <matchers/NetworkUrlMatchers.h>
 #include <mocks/NetworkMock.h>
 #include <olp/authentication/AuthenticationClient.h>
-#include <olp/authentication/AutoRefreshingToken.h>
+#include <olp/authentication/TokenProvider.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
 #include <olp/core/http/HttpStatusCode.h>
 #include <olp/core/porting/make_unique.h>
 #include <olp/core/porting/warning_disable.h>
-
 #include "AuthenticationMockedResponses.h"
+#include "AutoRefreshingToken.h"
 
 //  OLPEDGE-1797
 PORTING_PUSH_WARNINGS()

--- a/tests/integration/olp-cpp-sdk-authentication/TokenEndpointTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/TokenEndpointTest.cpp
@@ -17,8 +17,6 @@
  * License-Filename: LICENSE
  */
 
-#include <olp/authentication/TokenEndpoint.h>
-
 #include <future>
 #include <memory>
 
@@ -31,6 +29,8 @@
 #include <olp/core/http/NetworkUtils.h>
 #include <olp/core/porting/make_unique.h>
 #include "AuthenticationMockedResponses.h"
+#include "TokenEndpoint.h"
+#include "TokenRequest.h"
 
 namespace auth = olp::authentication;
 namespace client = olp::client;
@@ -109,9 +109,6 @@ void ExpectTimestampRequest(NetworkMock& network) {
                                    kResponseTime));
 }
 }  // namespace
-
-PORTING_PUSH_WARNINGS()
-PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
 
 class TokenEndpointTest : public testing::Test {
  public:
@@ -797,5 +794,3 @@ TEST_F(TokenEndpointTest, Cancel) {
             static_cast<int>(http::ErrorCode::CANCELLED_ERROR));
   EXPECT_EQ(token_response.GetError().GetMessage(), kErrorCancelled);
 }
-
-PORTING_POP_WARNINGS()

--- a/tests/integration/olp-cpp-sdk-authentication/TokenProviderTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/TokenProviderTest.cpp
@@ -25,6 +25,7 @@
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
 #include <olp/core/porting/make_unique.h>
+#include <olp/core/porting/warning_disable.h>
 #include <olp/dataservice/read/VersionedLayerClient.h>
 #include "../olp-cpp-sdk-dataservice-read/HttpResponses.h"
 #include "AuthenticationMockedResponses.h"
@@ -393,6 +394,13 @@ TEST_F(TokenProviderTest, CancellableProvider) {
 
     EXPECT_TRUE(token_provider);
     EXPECT_EQ(token_provider.GetHttpStatusCode(), status_code);
+
+    EXPECT_EQ(token_provider.GetErrorResponse().code, 0);
+
+    PORTING_PUSH_WARNINGS()
+    PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
+    EXPECT_EQ(token_provider(), kResponseToken);
+    PORTING_POP_WARNINGS()
 
     testing::Mock::VerifyAndClearExpectations(network_mock_.get());
   }


### PR DESCRIPTION
Move AutoRefreshingToken, TokenEndpoint, and TokenRequest
files to src folder.

Remove deprecated warnings

Move kDefaultMinimumValidity, kDefaultMinimumValiditySeconds, and
kForceRefresh constants from AutoRefreshingToken to TokenProvider

Move internal implementation of TokenProvider(TokenProviderImpl class) to
"internal" namespace.

Relates-To: OLPEDGE-1880

Signed-off-by: Yevhenii Dudnyk <ext-yevhenii.dudnyk@here.com>