### PR TITLE
Break circular dependency between classes

### DIFF
--- a/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
@@ -75,10 +75,5 @@ std::future<TokenResponse> TokenEndpoint::RequestToken(
   return impl_->RequestToken(cancellation_token, token_request);
 }
 
-AutoRefreshingToken TokenEndpoint::RequestAutoRefreshingToken(
-    const TokenRequest& token_request) {
-  return AutoRefreshingToken(*this, token_request);
-}
-
 }  // namespace authentication
 }  // namespace olp

--- a/olp-cpp-sdk-authentication/src/TokenEndpoint.h
+++ b/olp-cpp-sdk-authentication/src/TokenEndpoint.h
@@ -115,18 +115,6 @@ class TokenEndpoint {
       const TokenRequest& token_request = TokenRequest()) const;
 
   /**
-   * @brief Gets the `AutoRefreshingToken` instance that caches the requested
-   * token and refreshes it when needed.
-   *
-   * @param token_request The `TokenRequest` instance.
-   *
-   * @return The `AutoRefreshingToken` instance that caches the requested
-   * token and refreshes it when needed.
-   */
-  AutoRefreshingToken RequestAutoRefreshingToken(
-      const TokenRequest& token_request = TokenRequest());
-
-  /**
    * @brief Creates the `TokenEndpoint` instance with the given `settings`
    * parameter.
    *

--- a/olp-cpp-sdk-authentication/src/TokenProvider.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenProvider.cpp
@@ -32,7 +32,7 @@ class TokenProviderPrivate {
   TokenProviderPrivate(Settings settings, std::chrono::seconds minimum_validity)
       : minimum_validity_{minimum_validity},
         token_(std::make_shared<AutoRefreshingToken>(
-            TokenEndpoint(std::move(settings)).RequestAutoRefreshingToken())) {}
+            TokenEndpoint(std::move(settings)), TokenRequest())) {}
 
   std::string operator()() const {
     client::CancellationContext context;

--- a/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
@@ -74,7 +74,7 @@ void TestAutoRefreshingTokenCancel(
                             const auth::AutoRefreshingToken& autoToken,
                             const std::chrono::seconds minimumValidity)>
         func) {
-  auto autoToken = token_endpoint.RequestAutoRefreshingToken();
+  auto autoToken = auth::AutoRefreshingToken(token_endpoint, {});
 
   std::thread threads[2];
   auto tokenResponses = std::vector<auth::TokenResponse>();
@@ -214,7 +214,7 @@ TEST_F(HereAccountOauth2Test, AutoRefreshingTokenBackendError) {
   olp::client::CancellationToken cancellationToken;
 
   auto token = GetTokenFromSyncRequest(
-      cancellationToken, token_endpoint.RequestAutoRefreshingToken(),
+      cancellationToken, auth::AutoRefreshingToken(token_endpoint, {}),
       auth::kDefaultMinimumValiditySeconds);
 
   EXPECT_FALSE(token);


### PR DESCRIPTION
Break dependency between TokenEndpoint and AutoRefreshingToken
Remove RequestAutoRefreshingToken method from TokenEndpoint.

Resolves: OLPEDGE-1030

Signed-off-by: Yevhenii Dudnyk <ext-yevhenii.dudnyk@here.com>