### PR TITLE
Move ExecuteOrSchedule function to TaskScheduler

### DIFF
--- a/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.cpp
@@ -551,7 +551,7 @@ client::CancellationToken AuthenticationClientImpl::SignUpHereUser(
     const AuthenticationCredentials& credentials,
     const SignUpProperties& properties, const SignUpCallback& callback) {
   if (!settings_.network_request_handler) {
-    ExecuteOrSchedule(settings_.task_scheduler, [callback] {
+    thread::ExecuteOrSchedule(settings_.task_scheduler, [callback] {
       callback(
           client::ApiError::NetworkConnection("Cannot sign up while offline"));
     });
@@ -606,7 +606,8 @@ client::CancellationToken AuthenticationClientImpl::SignUpHereUser(
       });
 
   if (!send_outcome.IsSuccessful()) {
-    ExecuteOrSchedule(settings_.task_scheduler, [send_outcome, callback] {
+    thread::ExecuteOrSchedule(settings_.task_scheduler, [send_outcome,
+                                                         callback] {
       std::string error_message =
           ErrorCodeToString(send_outcome.GetErrorCode());
       AuthenticationError result({static_cast<int>(send_outcome.GetErrorCode()),
@@ -630,7 +631,7 @@ client::CancellationToken AuthenticationClientImpl::SignOut(
     const AuthenticationCredentials& credentials,
     const std::string& access_token, const SignOutUserCallback& callback) {
   if (!settings_.network_request_handler) {
-    ExecuteOrSchedule(settings_.task_scheduler, [callback] {
+    thread::ExecuteOrSchedule(settings_.task_scheduler, [callback] {
       callback(
           client::ApiError::NetworkConnection("Cannot sign out while offline"));
     });
@@ -680,7 +681,8 @@ client::CancellationToken AuthenticationClientImpl::SignOut(
       });
 
   if (!send_outcome.IsSuccessful()) {
-    ExecuteOrSchedule(settings_.task_scheduler, [send_outcome, callback] {
+    thread::ExecuteOrSchedule(settings_.task_scheduler, [send_outcome,
+                                                         callback] {
       std::string error_message =
           ErrorCodeToString(send_outcome.GetErrorCode());
       AuthenticationError result({static_cast<int>(send_outcome.GetErrorCode()),

--- a/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.cpp
@@ -119,19 +119,6 @@ boost::optional<std::time_t> GetTimestampFromHeaders(
   return boost::none;
 }
 
-void ExecuteOrSchedule(
-    const std::shared_ptr<olp::thread::TaskScheduler>& task_scheduler,
-    olp::thread::TaskScheduler::CallFuncType&& func) {
-  if (!task_scheduler) {
-    // User didn't specify a TaskScheduler, execute sync
-    func();
-    return;
-  }
-
-  // Schedule for async execution
-  task_scheduler->ScheduleTask(std::move(func));
-}
-
 IntrospectAppResult GetIntrospectAppResult(const rapidjson::Document& doc) {
   return ResponseFromJsonBuilder<IntrospectAppResult>::Build(doc)
       .Value(Constants::CLIENT_ID, &IntrospectAppResult::SetClientId)

--- a/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.h
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,16 +37,6 @@ namespace olp {
 namespace authentication {
 
 /*
- * @brief Common function used to add a lambda function and  schedule this to a
- * task scheduler.
- * @param task_scheduler Task scheduler instance.
- * @param func Function that will be executed.
- */
-void ExecuteOrSchedule(
-    const std::shared_ptr<thread::TaskScheduler>& task_scheduler,
-    thread::TaskScheduler::CallFuncType&& func);
-
-/*
  * @brief Common function used to wrap a lambda function and a callback that
  * consumes the function result with a TaskContext class and schedule this to a
  * task scheduler.
@@ -67,7 +57,7 @@ inline client::CancellationToken AddTask(
       std::move(task), std::move(callback), std::forward<Args>(args)...);
   pending_requests->Insert(context);
 
-  ExecuteOrSchedule(task_scheduler, [=] {
+  thread::ExecuteOrSchedule(task_scheduler, [=] {
     context.Execute();
     pending_requests->Remove(context);
   });

--- a/olp-cpp-sdk-core/include/olp/core/thread/TaskScheduler.h
+++ b/olp-cpp-sdk-core/include/olp/core/thread/TaskScheduler.h
@@ -96,7 +96,7 @@ class CORE_API TaskScheduler {
     auto task = [func, context]() {
       if (!context.IsCancelled()) {
         func(context);
-      };
+      }
     };
     EnqueueTask(std::move(task));
     return context;
@@ -137,6 +137,26 @@ class CORE_API TaskScheduler {
     EnqueueTask(std::forward<CallFuncType>(func));
   }
 };
+
+/**
+ * @brief Common function used to add a lambda function and schedule this to a
+ * task scheduler.
+ *
+ * @param task_scheduler Task scheduler instance.
+ * @param func Function that will be executed.
+ */
+inline CORE_API void ExecuteOrSchedule(
+    const std::shared_ptr<TaskScheduler>& scheduler,
+    TaskScheduler::CallFuncType&& func) {
+  if (!scheduler) {
+    // User didn't specify a TaskScheduler, execute sync
+    func();
+    return;
+  }
+
+  // Schedule for async execution
+  scheduler->ScheduleTask(std::move(func));
+}
 
 }  // namespace thread
 }  // namespace olp

--- a/olp-cpp-sdk-core/tests/thread/ThreadPoolTaskSchedulerTest.cpp
+++ b/olp-cpp-sdk-core/tests/thread/ThreadPoolTaskSchedulerTest.cpp
@@ -25,6 +25,7 @@
 
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/thread/ThreadPoolTaskScheduler.h>
+#include "mocks/TaskSchedulerMock.h"
 
 using SyncTaskType = std::function<void()>;
 using CancellationContext = olp::client::CancellationContext;
@@ -279,4 +280,24 @@ TEST(ThreadPoolTaskSchedulerTest, Move) {
   // SyncQueue and threads join should be done in destructor.
   thread_pool.reset();
   testing::Mock::VerifyAndClearExpectations(&mockop);
+}
+
+TEST(ThreadPoolTaskSchedulerTest, ExecuteOrSchedule) {
+  {
+    using testing::_;
+    SCOPED_TRACE("Schedule Task, ExecuteOrSchedule");
+
+    auto scheduler = std::make_shared<TaskSchedulerMock>();
+    EXPECT_CALL(*scheduler, EnqueueTask(_)).Times(1);
+
+    olp::thread::ExecuteOrSchedule(scheduler, []() {});
+  }
+
+  {
+    SCOPED_TRACE("Execute task immediately, ExecuteOrSchedule");
+
+    auto counter(0u);
+    olp::thread::ExecuteOrSchedule(nullptr, [&counter]() { counter++; });
+    EXPECT_EQ(counter, 1);
+  }
 }

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -17,8 +17,9 @@
 
 set(OLP_SDK_TESTS_COMMON_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/matchers/NetworkUrlMatchers.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/mocks/NetworkMock.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mocks/CacheMock.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/mocks/NetworkMock.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/mocks/TaskSchedulerMock.h
     ${CMAKE_CURRENT_SOURCE_DIR}/ApiDefaultResponses.h
     ${CMAKE_CURRENT_SOURCE_DIR}/KeyValueCacheTestable.h
     ${CMAKE_CURRENT_SOURCE_DIR}/PlatformUrlsGenerator.h

--- a/tests/common/mocks/TaskSchedulerMock.h
+++ b/tests/common/mocks/TaskSchedulerMock.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include <olp/core/thread/TaskScheduler.h>
+
+class TaskSchedulerMock : public olp::thread::TaskScheduler {
+ public:
+  MOCK_METHOD(void, EnqueueTask, (olp::thread::TaskScheduler::CallFuncType &&),
+              (override));
+
+  MOCK_METHOD(void, EnqueueTask, (CallFuncType&&, uint32_t), (override));
+};


### PR DESCRIPTION
Move ExecuteOrSchedule function to TaskScheduler
Remove ExecuteOrSchedule in other places

Resolves: OLPEDGE-1171

Signed-off-by: Yevhenii Dudnyk <ext-yevhenii.dudnyk@here.com>