### PR TITLE
Add TokenRequestImpl class

### DIFF
--- a/olp-cpp-sdk-authentication/src/TokenRequest.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenRequest.cpp
@@ -21,10 +21,72 @@
 
 namespace olp {
 namespace authentication {
-TokenRequest::TokenRequest(const std::chrono::seconds& expires_in)
-    : expires_in_(expires_in) {}
 
-std::chrono::seconds TokenRequest::GetExpiresIn() const { return expires_in_; }
+class TokenRequest::TokenRequestImpl {
+ public:
+  TokenRequestImpl(const std::chrono::seconds& expires_in)
+      : expires_in_(expires_in), request_body_(), credentials_("", "") {}
+
+  TokenRequestImpl& WithExpiresIn(const std::chrono::seconds& expires_in) {
+    expires_in_ = std::move(expires_in);
+    return *this;
+  }
+
+  const std::chrono::seconds& GetExpiresIn() const { return expires_in_; }
+
+  const RequestBodyType& GetBody() const { return request_body_; }
+
+  TokenRequestImpl& WithBody(RequestBodyType body) {
+    request_body_ = std::move(body);
+    return *this;
+  }
+
+  TokenRequestImpl& WithCredentials(AuthenticationCredentials credentials) {
+    credentials_ = std::move(credentials);
+    return *this;
+  }
+
+  const AuthenticationCredentials& GetCredentials() const {
+    return credentials_;
+  }
+
+ private:
+  std::chrono::seconds expires_in_;
+  RequestBodyType request_body_;
+  AuthenticationCredentials credentials_;
+};
+
+TokenRequest::TokenRequest(const std::chrono::seconds& expires_in)
+    : impl_(std::make_shared<TokenRequest::TokenRequestImpl>(expires_in)) {}
+
+TokenRequest& TokenRequest::WithExpiresIn(
+    const std::chrono::seconds& expires_in) {
+  *impl_ = impl_->WithExpiresIn(expires_in);
+  return *this;
+}
+
+std::chrono::seconds TokenRequest::GetExpiresIn() const {
+  return impl_->GetExpiresIn();
+}
+
+TokenRequest& TokenRequest::WithCredentials(
+    AuthenticationCredentials credentials) {
+  *impl_ = impl_->WithCredentials(std::move(credentials));
+  return *this;
+}
+
+const AuthenticationCredentials& TokenRequest::GetCredentials() const {
+  return impl_->GetCredentials();
+}
+
+const RequestBodyType& TokenRequest::GetBody() const {
+  return impl_->GetBody();
+}
+
+TokenRequest& TokenRequest::WithBody(RequestBodyType body) {
+  *impl_ = impl_->WithBody(std::move(body));
+  return *this;
+}
 
 }  // namespace authentication
 }  // namespace olp

--- a/olp-cpp-sdk-authentication/src/TokenRequest.h
+++ b/olp-cpp-sdk-authentication/src/TokenRequest.h
@@ -21,11 +21,17 @@
 
 #include <chrono>
 #include <cstdint>
+#include <memory>
+#include <vector>
 
 #include <olp/authentication/AuthenticationApi.h>
+#include <olp/authentication/AuthenticationCredentials.h>
 
 namespace olp {
 namespace authentication {
+
+using RequestBodyType = std::shared_ptr<const std::vector<std::uint8_t>>;
+
 /**
  * @brief Holds the parameters of the OAuth2.0 Authorization
  * Grant request.
@@ -42,6 +48,17 @@ class TokenRequest {
       const std::chrono::seconds& expires_in = std::chrono::seconds(0));
 
   /**
+   * @brief Sets the expiration time.
+   *
+   * @param expires_in (Optional) The number of seconds left before the new
+   * access token expires.
+   *
+   * @return A reference to *this.
+   */
+  TokenRequest& WithExpiresIn(
+      const std::chrono::seconds& expires_in = std::chrono::seconds(0));
+
+  /**
    * @brief The number of seconds left before the token expires.
    *
    * Ignored if it is zero or greater than the default expiration time supported
@@ -51,8 +68,43 @@ class TokenRequest {
    */
   std::chrono::seconds GetExpiresIn() const;
 
+  /**
+   * @brief Sets authentication credentials.
+   *
+   * @param credentials Client credentials obtained when registering application
+   * on HERE developer portal.
+   *
+   * @return A reference to *this.
+   */
+  TokenRequest& WithCredentials(AuthenticationCredentials credentials);
+
+  /**
+   * @brief Gets the authentication credentials
+   *
+   * @return reference to `AuthenticationCredentials` instance.
+   */
+  const AuthenticationCredentials& GetCredentials() const;
+
+  /**
+   * @brief Sets the request body.
+   *
+   * @param body The shared pointer to the vector that contains the request
+   * body.
+   *
+   * @return A reference to *this.
+   */
+  TokenRequest& WithBody(RequestBodyType body);
+
+  /**
+   * @brief Gets the request body.
+   *
+   * @return The shared pointer to the vector that contains the request body.
+   */
+  const RequestBodyType& GetBody() const;
+
  private:
-  std::chrono::seconds expires_in_;
+  class TokenRequestImpl;
+  std::shared_ptr<TokenRequestImpl> impl_;
 };
 
 }  // namespace authentication

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -20,6 +20,7 @@ set(OLP_SDK_INTEGRATIONAL_TESTS_SOURCES
     ./olp-cpp-sdk-authentication/HereAccountOauth2Test.cpp
     ./olp-cpp-sdk-authentication/TokenEndpointTest.cpp
     ./olp-cpp-sdk-authentication/TokenProviderTest.cpp
+    ./olp-cpp-sdk-authentication/TokenRequestTest.cpp
     ./olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
     ./olp-cpp-sdk-dataservice-read/VolatileLayerClientCacheTest.cpp
     ./olp-cpp-sdk-dataservice-read/VersionedLayerClientCacheTest.cpp

--- a/tests/integration/olp-cpp-sdk-authentication/TokenRequestTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/TokenRequestTest.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+#include "TokenRequest.h"
+
+namespace auth = olp::authentication;
+
+class TokenRequestTest : public ::testing::Test {
+ public:
+  auth::TokenRequest request;
+};
+
+TEST_F(TokenRequestTest, CheckExpireIn) {
+  EXPECT_EQ(request.GetExpiresIn().count(), 0);
+
+  request = request.WithExpiresIn(std::chrono::seconds(42));
+  EXPECT_EQ(request.GetExpiresIn().count(), 42);
+}
+
+TEST_F(TokenRequestTest, CheckBody) {
+  EXPECT_EQ(request.GetBody(), auth::RequestBodyType());
+
+  auto requestBody = std::make_shared<std::vector<std::uint8_t>>(42);
+  request = request.WithBody(requestBody);
+  EXPECT_EQ(*request.GetBody(),
+            *std::make_shared<std::vector<std::uint8_t>>(42));
+}
+
+TEST_F(TokenRequestTest, CheckAuthenticationCredentials) {
+  auto defaultCredentials = auth::AuthenticationCredentials("", "");
+  EXPECT_EQ(request.GetCredentials().GetKey(), defaultCredentials.GetKey());
+  EXPECT_EQ(request.GetCredentials().GetSecret(),
+            defaultCredentials.GetSecret());
+
+  auto authenticationCredentials =
+      auth::AuthenticationCredentials("key", "secret");
+  request = request.WithCredentials(authenticationCredentials);
+  EXPECT_EQ(request.GetCredentials().GetKey(),
+            authenticationCredentials.GetKey());
+  EXPECT_EQ(request.GetCredentials().GetSecret(),
+            authenticationCredentials.GetSecret());
+}
+
+TEST_F(TokenRequestTest, CheckBuilder) {
+  request =
+      request.WithExpiresIn(std::chrono::seconds(42))
+          .WithBody(std::make_shared<std::vector<std::uint8_t>>(42))
+          .WithCredentials(auth::AuthenticationCredentials("key", "secret"));
+
+  EXPECT_EQ(request.GetExpiresIn().count(), 42);
+  EXPECT_EQ(*request.GetBody(),
+            *std::make_shared<std::vector<std::uint8_t>>(42));
+  EXPECT_EQ(request.GetCredentials().GetKey(), "key");
+  EXPECT_EQ(request.GetCredentials().GetSecret(), "secret");
+}


### PR DESCRIPTION
Move internal implementation of TokenRequest to
TokenRequestImpl
Add methods for setup credentials, expiry, body.
Add unit tests

Resolves: OLPEDGE-1265

Signed-off-by: Yevhenii Dudnyk <ext-yevhenii.dudnyk@here.com>