### PR TITLE
Change handling token_endpoint_url

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationCredentials.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationCredentials.h
@@ -95,6 +95,16 @@ class AUTHENTICATION_API AuthenticationCredentials {
   AuthenticationCredentials(std::string key, std::string secret);
 
   /**
+   * @brief Creates the `AuthenticationCredentials` instance.
+   *
+   * @param key The access key ID.
+   * @param secret The access key secret.
+   * @param endpoint_url The token endpoint URL.
+   */
+  AuthenticationCredentials(std::string key, std::string secret,
+                            std::string endpoint_url);
+
+  /**
    * @brief Gets the access key ID from the `AuthenticationCredentials`
    * instance.
    *
@@ -110,9 +120,18 @@ class AUTHENTICATION_API AuthenticationCredentials {
    */
   const std::string& GetSecret() const;
 
+  /**
+   * @brief Gets the token endpoint URL from the `AuthenticationCredentials`
+   * instance.
+   *
+   * @return A const reference to the access token endpoint URL member.
+   */
+  const std::string& GetEndpointUrl() const;
+
  private:
   std::string key_;
   std::string secret_;
+  std::string endpoint_url_;
 };
 
 }  // namespace authentication

--- a/olp-cpp-sdk-authentication/src/AuthenticationCredentials.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationCredentials.cpp
@@ -28,6 +28,7 @@ namespace {
 const std::regex kRegex{"\\s*=\\s*"};
 const std::string kHereAccessKeyId = "here.access.key.id";
 const std::string kHereAccessKeySecret = "here.access.key.secret";
+const std::string kHereTokenEndpointUrl = "here.token.endpoint.url";
 
 /// Forms a default path that is valid for the current OS.
 std::string GetDefaultPath() {
@@ -57,6 +58,7 @@ boost::optional<AuthenticationCredentials>
 AuthenticationCredentials::ReadFromStream(std::istream& stream) {
   std::string access_key_id;
   std::string access_key_secret;
+  std::string token_endpoint_url;
   std::string line;
 
   while (std::getline(stream, line)) {
@@ -72,12 +74,15 @@ AuthenticationCredentials::ReadFromStream(std::istream& stream) {
       access_key_id = token[1];
     } else if (token[0] == kHereAccessKeySecret) {
       access_key_secret = token[1];
+    } else if (token[0] == kHereTokenEndpointUrl) {
+      token_endpoint_url = token[1];
     }
   }
 
   return (!access_key_id.empty() && !access_key_secret.empty())
              ? boost::make_optional<AuthenticationCredentials>(
-                   {std::move(access_key_id), std::move(access_key_secret)})
+                   {std::move(access_key_id), std::move(access_key_secret),
+                    std::move(token_endpoint_url)})
              : boost::none;
 }
 
@@ -95,10 +100,22 @@ AuthenticationCredentials::AuthenticationCredentials(std::string key,
                                                      std::string secret)
     : key_(std::move(key)), secret_(std::move(secret)) {}
 
+AuthenticationCredentials::AuthenticationCredentials(std::string key,
+                                                     std::string secret,
+                                                     std::string endpoint_url)
+    : key_(std::move(key)),
+      secret_(std::move(secret)),
+      endpoint_url_(std::move(endpoint_url)) {}
+
 const std::string& AuthenticationCredentials::GetKey() const { return key_; }
 
 const std::string& AuthenticationCredentials::GetSecret() const {
   return secret_;
 }
+
+const std::string& AuthenticationCredentials::GetEndpointUrl() const {
+  return endpoint_url_;
+}
+
 }  // namespace authentication
 }  // namespace olp

--- a/olp-cpp-sdk-authentication/src/AutoRefreshingToken.cpp
+++ b/olp-cpp-sdk-authentication/src/AutoRefreshingToken.cpp
@@ -28,7 +28,7 @@
 #include "TokenRequest.h"
 
 namespace {
-constexpr auto kLogTag = "authentication::AutoRefreshingToken";
+constexpr auto kLogTag = "AutoRefreshingToken";
 
 std::chrono::steady_clock::time_point ComputeRefreshTime(
     const olp::authentication::TokenResponse& current_token,

--- a/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
@@ -28,28 +28,8 @@
 namespace olp {
 namespace authentication {
 
-namespace {
-static const std::string kOauth2TokenEndpoint = "/oauth2/token";
-static constexpr auto kLogTag = "TokenEndpoint";
-}  // namespace
-
-TokenEndpoint::TokenEndpoint(Settings settings) {
-  // The underlying auth library expects a base URL and appends /oauth2/token
-  // endpoint to it. Therefore if /oauth2/token is found it is stripped from the
-  // endpoint URL provided. The underlying auth library should be updated to
-  // support an arbitrary token endpoint URL.
-  auto pos = settings.token_endpoint_url.find(kOauth2TokenEndpoint);
-  if (pos != std::string::npos) {
-    settings.token_endpoint_url.erase(pos, kOauth2TokenEndpoint.size());
-  } else {
-    OLP_SDK_LOG_ERROR(
-        kLogTag,
-        "Expected '/oauth2/token' endpoint in the token_endpoint_url. Only "
-        "standard OAuth2 token endpoint URLs are supported.");
-  }
-
-  impl_ = std::make_shared<TokenEndpointImpl>(std::move(settings));
-}
+TokenEndpoint::TokenEndpoint(Settings settings)
+    : impl_(std::make_shared<TokenEndpointImpl>(std::move(settings))) {}
 
 client::CancellationToken TokenEndpoint::RequestToken(
     const TokenRequest& token_request,

--- a/olp-cpp-sdk-authentication/src/TokenEndpointImpl.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenEndpointImpl.cpp
@@ -51,13 +51,29 @@ constexpr auto kClientGrantType = "client_credentials";
 constexpr auto kLogTag = "TokenEndpointImpl";
 constexpr auto kErrorWrongTimestamp = 401204;
 
+std::string GetBasePath(const std::string& base_string) {
+  // Remove /oauth2/token from url to make sure only the base url is used
+  auto new_base_string = base_string;
+  auto pos = new_base_string.find(kOauthEndpoint);
+  if (pos != std::string::npos) {
+    new_base_string.erase(pos, std::strlen(kOauthEndpoint));
+  }
+
+  OLP_SDK_LOG_INFO_F(
+      kLogTag,
+      "GetBasePath: old_token_endpoint_url='%s', token_endpoint_url='%s'",
+      base_string.c_str(), new_base_string.c_str());
+
+  return new_base_string;
+}
+
 AuthenticationSettings ConvertSettings(Settings settings) {
   AuthenticationSettings auth_settings;
   auth_settings.network_proxy_settings =
       std::move(settings.network_proxy_settings);
   auth_settings.network_request_handler =
       std::move(settings.network_request_handler);
-  auth_settings.token_endpoint_url = std::move(settings.token_endpoint_url);
+  auth_settings.token_endpoint_url = GetBasePath(settings.token_endpoint_url);
   auth_settings.use_system_time = settings.use_system_time;
   auth_settings.retry_settings = std::move(settings.retry_settings);
 

--- a/olp-cpp-sdk-authentication/tests/AuthenticationCredentialsTest.cpp
+++ b/olp-cpp-sdk-authentication/tests/AuthenticationCredentialsTest.cpp
@@ -23,18 +23,18 @@
 #include <gtest/gtest.h>
 #include "olp/authentication/AuthenticationCredentials.h"
 
-using namespace olp::authentication;
+namespace auth = olp::authentication;
 
 namespace {
-const std::string valid_file_path = "existing.file";
-const std::string invalid_file_path = "nonexisting.file";
-const std::string valid_credentials =
+constexpr auto valid_file_path = "existing.file";
+constexpr auto invalid_file_path = "nonexisting.file";
+constexpr auto valid_credentials =
     "here.user.id = HERE-111\n"
     "here.client.id = 123\n"
     "here.access.key.id = 234\n"
     "here.access.key.secret = 345\n"
     "here.token.endpoint.url = https://account.api.here.com/oauth2/token";
-const std::string invalid_credentials =
+constexpr auto invalid_credentials =
     "here.user.id = HERE-111\n"
     "here.client.id = 222\n"
     "here.access.key.id = 333\n"
@@ -47,7 +47,8 @@ TEST(AuthenticationCredentialsTest, ReadFromStream) {
     SCOPED_TRACE("Credentials parse succeeds");
 
     std::stringstream ss(valid_credentials);
-    const auto credentials = AuthenticationCredentials::ReadFromStream(ss);
+    const auto credentials =
+        auth::AuthenticationCredentials::ReadFromStream(ss);
 
     EXPECT_TRUE(credentials);
 
@@ -58,7 +59,8 @@ TEST(AuthenticationCredentialsTest, ReadFromStream) {
     SCOPED_TRACE("Bad content in the stream");
 
     std::stringstream ss(invalid_credentials);
-    const auto credentials = AuthenticationCredentials::ReadFromStream(ss);
+    const auto credentials =
+        auth::AuthenticationCredentials::ReadFromStream(ss);
 
     EXPECT_FALSE(credentials);
   }
@@ -74,18 +76,19 @@ TEST(AuthenticationCredentialsTest, ReadFromFile) {
     stream.close();
 
     const auto credentials =
-        AuthenticationCredentials::ReadFromFile(valid_file_path);
+        auth::AuthenticationCredentials::ReadFromFile(valid_file_path);
 
     EXPECT_TRUE(credentials);
+    EXPECT_NE(credentials.value().GetEndpointUrl(), "");
 
     // Remove the file.
-    remove(valid_file_path.c_str());
+    remove(valid_file_path);
   }
   {
     SCOPED_TRACE("Missing credential file");
 
     const auto credentials =
-        AuthenticationCredentials::ReadFromFile(invalid_file_path);
+        auth::AuthenticationCredentials::ReadFromFile(invalid_file_path);
 
     EXPECT_FALSE(credentials);
   }
@@ -93,8 +96,8 @@ TEST(AuthenticationCredentialsTest, ReadFromFile) {
 
 
 TEST(AuthenticationCredentialsTest, CanBeCopied) {
-  AuthenticationCredentials credentials("test_key", "test_secred");
-  AuthenticationCredentials copy = credentials;
+  auth::AuthenticationCredentials credentials("test_key", "test_secret");
+  auth::AuthenticationCredentials copy = credentials;
   EXPECT_EQ(credentials.GetKey(), copy.GetKey());
   EXPECT_EQ(credentials.GetSecret(), copy.GetSecret());
 }

--- a/olp-cpp-sdk-core/tests/client/OlpClientTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/OlpClientTest.cpp
@@ -687,7 +687,7 @@ TEST_P(OlpClientTest, HttpResponse) {
 
 TEST_P(OlpClientTest, Paths) {
   auto network = network_;
-  client_.SetBaseUrl("here.com");
+  client_.SetBaseUrl("https://here.com");
   client_.SetSettings(client_settings_);
 
   std::future<void> future;
@@ -699,7 +699,7 @@ TEST_P(OlpClientTest, Paths) {
                     olp::http::Network::Callback callback,
                     olp::http::Network::HeaderCallback /*header_callback*/,
                     olp::http::Network::DataCallback /*data_callback*/) {
-        EXPECT_EQ("here.com/index", request.GetUrl());
+        EXPECT_EQ("https://here.com/index", request.GetUrl());
         auto current_request_id = request_id++;
 
         future = std::async(std::launch::async, [=]() {
@@ -1624,7 +1624,7 @@ TEST_P(OlpClientTest, ApiKey) {
                     olp::http::Network::Callback callback,
                     olp::http::Network::HeaderCallback /*header_callback*/,
                     olp::http::Network::DataCallback /*data_callback*/) {
-        EXPECT_EQ(request.GetUrl(), "here.com?apiKey=test-key");
+        EXPECT_EQ(request.GetUrl(), "https://here.com?apiKey=test-key");
         auto current_request_id = request_id++;
 
         future = std::async(std::launch::async, [=]() {
@@ -1637,8 +1637,8 @@ TEST_P(OlpClientTest, ApiKey) {
         return olp::http::SendOutcome(current_request_id);
       });
 
-  auto response =
-      call_wrapper_->CallApi("here.com", "GET", {}, {}, {}, nullptr, {});
+  auto response = call_wrapper_->CallApi("https://here.com", "GET", {}, {}, {},
+                                         nullptr, {});
 
   future.wait();
   testing::Mock::VerifyAndClearExpectations(network.get());
@@ -1657,8 +1657,8 @@ TEST_P(OlpClientTest, TokenDeprecatedProvider) {
 
     EXPECT_CALL(*network, Send(_, _, _, _, _)).Times(0);
 
-    auto response =
-        call_wrapper_->CallApi("here.com", "GET", {}, {}, {}, nullptr, {});
+    auto response = call_wrapper_->CallApi("https://here.com", "GET", {}, {},
+                                           {}, nullptr, {});
     EXPECT_EQ(response.GetStatus(),
               static_cast<int>(http::ErrorCode::AUTHORIZATION_ERROR));
 
@@ -1682,8 +1682,8 @@ TEST_P(OlpClientTest, TokenDeprecatedProvider) {
                                  testing::InvokeArgument<2>(response),
                                  testing::Return(olp::http::SendOutcome(0))));
 
-    auto api_response =
-        call_wrapper_->CallApi("here.com", "GET", {}, {}, {}, nullptr, {});
+    auto api_response = call_wrapper_->CallApi("https://here.com", "GET", {},
+                                               {}, {}, nullptr, {});
 
     auto headers = request.GetHeaders();
 
@@ -1714,8 +1714,8 @@ TEST_P(OlpClientTest, EmptyBearerToken) {
 
   EXPECT_CALL(*network, Send(_, _, _, _, _)).Times(0);
 
-  auto response =
-      call_wrapper_->CallApi("here.com", "GET", {}, {}, {}, nullptr, {});
+  auto response = call_wrapper_->CallApi("https://here.com", "GET", {}, {}, {},
+                                         nullptr, {});
   EXPECT_EQ(response.GetStatus(),
             static_cast<int>(http::ErrorCode::AUTHORIZATION_ERROR));
 
@@ -1739,8 +1739,8 @@ TEST_P(OlpClientTest, ErrorOnTokenRequest) {
 
   EXPECT_CALL(*network, Send(_, _, _, _, _)).Times(0);
 
-  auto response =
-      call_wrapper_->CallApi("here.com", "GET", {}, {}, {}, nullptr, {});
+  auto response = call_wrapper_->CallApi("https://here.com", "GET", {}, {}, {},
+                                         nullptr, {});
   EXPECT_EQ(response.GetStatus(),
             static_cast<int>(http::ErrorCode::NETWORK_OVERLOAD_ERROR));
 
@@ -2159,6 +2159,19 @@ TEST_F(OlpClientMergeTest, NoMergeMultipleCallbacks) {
     }
 
     release_and_wait(3u, index);
+  }
+}
+
+TEST_P(OlpClientTest, UrlWithoutProtocol) {
+  {
+    SCOPED_TRACE("Url without protocol");
+
+    client_.SetBaseUrl("here.com");
+    client_.SetSettings(client_settings_);
+
+    auto response = call_wrapper_->CallApi("", "GET", {}, {}, {}, nullptr, {});
+    EXPECT_EQ(response.GetStatus(),
+              static_cast<int>(http::ErrorCode::INVALID_URL_ERROR));
   }
 }
 


### PR DESCRIPTION
Move removing url handling from TokenEndpoint to TokenEndpointImpl
Added reading token_endpoint_url from 	credentials.properties

Resolves: OLPEDGE-1029

Signed-off-by: Yevhenii Dudnyk ext-yevhenii.dudnyk@here.com