### PR TITLE
Log to stderr instead of stdout

### DIFF
--- a/olp-cpp-sdk-core/src/logging/ConsoleAppender.cpp
+++ b/olp-cpp-sdk-core/src/logging/ConsoleAppender.cpp
@@ -75,7 +75,7 @@ IAppender& ConsoleAppender::append(const LogMessage& message) {
 #ifdef PORTING_PLATFORM_ANDROID
   android_append_in_chunks(message.level, message.tag, formattedMessage);
 #else
-  std::cout << formattedMessage << std::endl;
+  std::clog << formattedMessage << std::endl;
 #endif
   return *this;
 }

--- a/olp-cpp-sdk-core/tests/logging/LogTest.cpp
+++ b/olp-cpp-sdk-core/tests/logging/LogTest.cpp
@@ -154,9 +154,9 @@ TEST(LogTest, DifferentLevelsForConsoleAndFileLogging) {
   }
   olp::logging::Log::setLevel(olp::logging::Level::Trace);
 
-  // redirecting cout to stringstream
+  // redirecting clog to stringstream
   std::stringstream string_stream;
-  auto default_cout_buffer = std::cout.rdbuf(string_stream.rdbuf());
+  auto default_clog_buffer = std::clog.rdbuf(string_stream.rdbuf());
 
   OLP_SDK_LOG_INFO("info", "Info "
                                << "message");
@@ -169,8 +169,8 @@ TEST(LogTest, DifferentLevelsForConsoleAndFileLogging) {
   OLP_SDK_LOG_FATAL("fatal", "Fatal "
                                  << "message");
 
-  // resetting cout
-  std::cout.rdbuf(default_cout_buffer);
+  // resetting clog
+  std::clog.rdbuf(default_clog_buffer);
 
   // Clear out configuration so the file file handles are closed.
   olp::logging::Log::configure(olp::logging::Configuration::createDefault());


### PR DESCRIPTION
In POSIX systems, logging should always go to stderr.
Logging to stdout will cause problems for applications that
write data to stdout.

Signed-off-by: Christian Ocker <christian.ocker@here.com>