### PR TITLE
 Change SignOut method to a sync task

### DIFF
--- a/olp-cpp-sdk-authentication/tests/AuthenticationClientTest.cpp
+++ b/olp-cpp-sdk-authentication/tests/AuthenticationClientTest.cpp
@@ -117,6 +117,25 @@ TEST(AuthenticationClientTest, SignUpWithUnsuccessfulSend) {
       });
 }
 
+TEST(AuthenticationClientTest, SignOutAccessDenied) {
+  using testing::_;
+
+  auth::AuthenticationSettings settings;
+  settings.network_request_handler = std::make_shared<NetworkMock>();
+
+  AuthenticationClientImplTestable auth_impl(settings);
+
+  const auth::AuthenticationCredentials credentials("", "");
+
+  auth_impl.SignOut(
+      credentials, {},
+      [=](const auth::AuthenticationClient::SignOutUserResponse& response) {
+        EXPECT_FALSE(response.IsSuccessful());
+        EXPECT_EQ(response.GetError().GetErrorCode(),
+                  client::ErrorCode::AccessDenied);
+      });
+}
+
 TEST(AuthenticationClientTest, Timestamp) {
   using testing::_;
 


### PR DESCRIPTION
Change using Network object directly to using
OlpClient's CallApi method to make requests.
Additionally added a check for a network_request_handler
variable. Move the request to a lambda function wich is
executed by TaskScheduler.

Mark credentials object as unused.

Add a test for checking SignOut method
with an empty access_token as a parameter.

Remove a test which checks Network class(send method)
as it isn't a part of AuthenticationClientImpl now.

Relates-To: OLPEDGE-2021

Signed-off-by: Yevhenii Dudnyk <ext-yevhenii.dudnyk@here.com>