### PR TITLE
Change SignUpHereUser method to a sync task

### DIFF
--- a/olp-cpp-sdk-authentication/tests/AuthenticationClientTest.cpp
+++ b/olp-cpp-sdk-authentication/tests/AuthenticationClientTest.cpp
@@ -88,7 +88,7 @@ TEST(AuthenticationClientTest, AuthenticationWithoutNetwork) {
   }
 }
 
-TEST(AuthenticationClientTest, AuthenticationWithUnsuccessfulSend) {
+TEST(AuthenticationClientTest, SignUpWithUnsuccessfulSend) {
   using testing::_;
 
   auth::AuthenticationSettings settings;
@@ -108,29 +108,13 @@ TEST(AuthenticationClientTest, AuthenticationWithUnsuccessfulSend) {
 
   const auth::AuthenticationCredentials credentials("", "");
 
-  {
-    SCOPED_TRACE("SignUpHereUser, Unsuccessful send");
-
-    auth_impl.SignUpHereUser(
-        credentials, {},
-        [=](const auth::AuthenticationClient::SignUpResponse& response) {
-          EXPECT_FALSE(response.IsSuccessful());
-          EXPECT_EQ(response.GetError().GetErrorCode(),
-                    client::ErrorCode::Unknown);
-        });
-  }
-
-  {
-    SCOPED_TRACE("SignOut, Unsuccessful send");
-
-    auth_impl.SignOut(
-        credentials, {},
-        [=](const auth::AuthenticationClient::SignOutUserResponse& response) {
-          EXPECT_FALSE(response.IsSuccessful());
-          EXPECT_EQ(response.GetError().GetErrorCode(),
-                    client::ErrorCode::Unknown);
-        });
-  }
+  auth_impl.SignUpHereUser(
+      credentials, {},
+      [=](const auth::AuthenticationClient::SignUpResponse& response) {
+        EXPECT_FALSE(response.IsSuccessful());
+        EXPECT_EQ(response.GetError().GetErrorCode(),
+                  client::ErrorCode::Unknown);
+      });
 }
 
 TEST(AuthenticationClientTest, Timestamp) {


### PR DESCRIPTION
Change using Network object directly to using
OlpClient's CallApi method to make requests.
Additionally added a check for a valid network_request_handler
variable. Move the request to a lambda function wich is
executed by TaskScheduler.

Add a test for checking SignUpHereUser method
with default credentials and properties parameters.

Remove a test which checks Network class(send method)
as these calls aren't a part of AuthenticationClientImpl now.

Relates-To: OLPEDGE-2020

Signed-off-by: Yevhenii Dudnyk <ext-yevhenii.dudnyk@here.com>