### PR TITLE
Add task continuation implementation

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -158,6 +158,8 @@ set(OLP_SDK_THREAD_HEADERS
     ./include/olp/core/thread/ExecutionContext.h
     ./include/olp/core/thread/SyncQueue.h
     ./include/olp/core/thread/SyncQueue.inl
+    ./include/olp/core/thread/TaskContinuation.h
+    ./include/olp/core/thread/TaskContinuation.inl
     ./include/olp/core/thread/TaskScheduler.h
     ./include/olp/core/thread/ThreadPoolTaskScheduler.h
     ./include/olp/core/thread/TypeHelpers.h

--- a/olp-cpp-sdk-core/include/olp/core/thread/Continuation.inl
+++ b/olp-cpp-sdk-core/include/olp/core/thread/Continuation.inl
@@ -34,6 +34,9 @@ void Continuation<ResultType>::Run() {
     return;
   }
 
+  impl_.SetFailedCallback(
+      [this](client::ApiError error) { finally_callback_(std::move(error)); });
+
   if (impl_.Cancelled()) {
     finally_callback_(client::ApiError::Cancelled());
     impl_.Clear();
@@ -56,8 +59,6 @@ template <typename ResultType>
 Continuation<ResultType>& Continuation<ResultType>::Finally(
     FinallyCallbackType finally_callback) {
   finally_callback_ = std::move(finally_callback);
-  impl_.SetFailedCallback(
-      [this](client::ApiError error) { finally_callback_(std::move(error)); });
   return *this;
 }
 

--- a/olp-cpp-sdk-core/include/olp/core/thread/TaskContinuation.h
+++ b/olp-cpp-sdk-core/include/olp/core/thread/TaskContinuation.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <deque>
+#include <functional>
+#include <memory>
+
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/TaskContext.h>
+#include <olp/core/thread/Continuation.h>
+#include <olp/core/thread/ExecutionContext.h>
+#include <olp/core/thread/TypeHelpers.h>
+
+namespace olp {
+namespace thread {
+
+class TaskScheduler;
+
+/// Creates a chain of tasks for an asynchronous execution.
+class CORE_API TaskContinuation final {
+ public:
+  /**
+   * @brief Creates the `TaskContinuation` instance.
+   *
+   * @param scheduler The `TaskScheduler` instance.
+   */
+  explicit TaskContinuation(std::shared_ptr<thread::TaskScheduler> scheduler);
+
+  /**
+   * @brief Initializes the `Continuation` object.
+   *
+   * It creates the `Continuation` instance with a template callback
+   * as a parameter, which is the first task in the task continuation chain.
+   *
+   * @param task A task you want to add to the continuation chain.
+   */
+  template <typename Callable>
+  Continuation<internal::AsyncResultType<Callable>> Then(Callable task);
+
+ private:
+  std::shared_ptr<thread::TaskScheduler> task_scheduler_;
+  ExecutionContext execution_context_;
+};
+
+}  // namespace thread
+}  // namespace olp
+
+#include "TaskContinuation.inl"

--- a/olp-cpp-sdk-core/include/olp/core/thread/TaskContinuation.inl
+++ b/olp-cpp-sdk-core/include/olp/core/thread/TaskContinuation.inl
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+namespace olp {
+namespace thread {
+
+template <typename Callable>
+Continuation<internal::AsyncResultType<Callable>> TaskContinuation::Then(
+    Callable task) {
+  using NewResultType = internal::AsyncResultType<Callable>;
+  using Function = internal::TypeToFunctionInput<NewResultType>;
+  return {task_scheduler_, execution_context_,
+          std::function<void(ExecutionContext, Function)>(std::move(task))};
+}
+
+TaskContinuation::TaskContinuation(std::shared_ptr<TaskScheduler> scheduler)
+    : task_scheduler_(std::move(scheduler)),
+      execution_context_(ExecutionContext()) {}
+
+}  // namespace thread
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/thread/Continuation.cpp
+++ b/olp-cpp-sdk-core/src/thread/Continuation.cpp
@@ -76,6 +76,9 @@ class Processor {
     auto func = std::move(current_task.first);
     current_task.first = nullptr;
     func(process->LastOutput(), std::move(callback));
+    if (process->public_execution_context_.Cancelled()) {
+      return false;
+    }
 
     return true;
   }
@@ -156,7 +159,6 @@ class Processor {
     }
   };
 
-  std::shared_ptr<TaskScheduler> task_scheduler_;
   std::shared_ptr<ProcessorInternal> processor_;
 };
 

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ set(OLP_CPP_SDK_CORE_TESTS_SOURCES
     ./thread/ExecutionContextTest.cpp
     ./thread/PriorityQueueExtendedTest.cpp
     ./thread/SyncQueueTest.cpp
+    ./thread/TaskContinuationTest.cpp
     ./thread/ThreadPoolTaskSchedulerTest.cpp
     ./http/NetworkUtils.cpp
 )

--- a/olp-cpp-sdk-core/tests/thread/TaskContinuationTest.cpp
+++ b/olp-cpp-sdk-core/tests/thread/TaskContinuationTest.cpp
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include <olp/core/client/HttpResponse.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/thread/TaskContinuation.h>
+
+const std::string BAD_REQUEST_MESSAGE = "Bad Request";
+
+class TaskContinuationFixture : public ::testing::Test {
+ public:
+  void SetUp() override {
+    scheduler =
+        olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
+  }
+
+ protected:
+  std::unique_ptr<olp::thread::TaskScheduler> scheduler;
+};
+
+TEST_F(TaskContinuationFixture, MultipleSequentialThen) {
+  std::promise<void> promise;
+  auto future = promise.get_future();
+
+  olp::client::ApiResponse<int, olp::client::ApiError> result;
+
+  auto cont =
+      olp::thread::TaskContinuation(std::move(scheduler))
+          .Then([](olp::thread::ExecutionContext,
+                   std::function<void(int)> next) { next(1); })
+          .Then([](olp::thread::ExecutionContext, int value,
+                   std::function<void(int)> next) {
+            EXPECT_EQ(value, 1);
+            next(2);
+          })
+          .Then([](olp::thread::ExecutionContext, int value,
+                   std::function<void(int)> next) {
+            EXPECT_EQ(value, 2);
+            next(3);
+          })
+          .Then([](olp::thread::ExecutionContext, int,
+                   std::function<void(int)> next) { next(3); })
+          .Finally([&promise, &result](
+                       olp::client::ApiResponse<int, olp::client::ApiError>
+                           response) {
+            result = response.MoveResult();
+            promise.set_value();
+          });
+
+  cont.Run();
+
+  future.get();
+
+  EXPECT_TRUE(result.IsSuccessful());
+  EXPECT_EQ(result.GetResult(), 3);
+}
+
+TEST_F(TaskContinuationFixture, FinallyNotSet) {
+  auto cont = olp::thread::TaskContinuation(std::move(scheduler))
+                  .Then([](olp::thread::ExecutionContext,
+                           std::function<void(int)>) { FAIL(); });
+
+  cont.Run();
+}
+
+TEST_F(TaskContinuationFixture, CancelBeforeRun) {
+  std::promise<void> promise;
+  auto future = promise.get_future();
+
+  olp::client::ApiResponse<olp::client::HttpResponse, olp::client::ApiError>
+      result;
+
+  auto cont =
+      olp::thread::TaskContinuation(std::move(scheduler))
+          .Then([](olp::thread::ExecutionContext,
+                   std::function<void(int)> next) { next(1); })
+          .Finally([&promise, &result](
+                       olp::client::ApiResponse<int, olp::client::ApiError>
+                           response) {
+            result = response.GetError();
+            promise.set_value();
+          });
+
+  cont.CancelToken().Cancel();
+
+  cont.Run();
+
+  EXPECT_EQ(future.wait_for(std::chrono::milliseconds(1000)),
+            std::future_status::ready);
+
+  future.get();
+
+  EXPECT_FALSE(result.IsSuccessful());
+  EXPECT_EQ(result.GetError().GetHttpStatusCode(),
+            static_cast<int>(olp::http::ErrorCode::CANCELLED_ERROR));
+}
+
+TEST_F(TaskContinuationFixture, CancelAfterRun) {
+  std::promise<void> promise;
+  auto future = promise.get_future();
+
+  olp::client::ApiResponse<olp::client::HttpResponse, olp::client::ApiError>
+      result;
+
+  auto cont =
+      olp::thread::TaskContinuation(std::move(scheduler))
+          .Then([](olp::thread::ExecutionContext,
+                   std::function<void(int)> next) { next(1); })
+          .Then([](olp::thread::ExecutionContext, int,
+                   std::function<void(olp::client::HttpResponse)> next) {
+            next(olp::client::HttpResponse(200, "OK"));
+          })
+          .Finally([&promise,
+                    &result](olp::client::ApiResponse<olp::client::HttpResponse,
+                                                      olp::client::ApiError>
+                                 response) {
+            result = response.GetResult();
+            promise.set_value();
+          });
+
+  cont.Run();
+  std::this_thread::sleep_for(
+      std::chrono::milliseconds(50));  // simulate some delay
+
+  cont.CancelToken().Cancel();
+
+  EXPECT_EQ(future.wait_for(std::chrono::milliseconds(1000)),
+            std::future_status::ready);
+
+  future.get();
+
+  EXPECT_TRUE(result.IsSuccessful());
+  EXPECT_EQ(result.GetError().GetHttpStatusCode(),
+            static_cast<int>(olp::http::ErrorCode::UNKNOWN_ERROR));
+}
+
+TEST_F(TaskContinuationFixture, CallExecute) {
+  std::promise<void> promise;
+  auto future = promise.get_future();
+
+  olp::client::ApiResponse<olp::client::HttpResponse, olp::client::ApiError>
+      result;
+
+  auto cont =
+      olp::thread::TaskContinuation(std::move(scheduler))
+          .Then([](olp::thread::ExecutionContext,
+                   std::function<void(int)> next) { next(1); })
+          .Then([](olp::thread::ExecutionContext context, int,
+                   std::function<void(olp::client::HttpResponse)> next) {
+            context.ExecuteOrCancelled([next]() {
+              next(olp::client::HttpResponse(200, "OK"));
+              return olp::client::CancellationToken();
+            });
+          })
+          .Finally([&promise,
+                    &result](olp::client::ApiResponse<olp::client::HttpResponse,
+                                                      olp::client::ApiError>
+                                 response) {
+            result = response.GetResult();
+            promise.set_value();
+          });
+
+  cont.Run();
+
+  EXPECT_EQ(future.wait_for(std::chrono::milliseconds(1000)),
+            std::future_status::ready);
+
+  future.get();
+
+  EXPECT_TRUE(result.IsSuccessful());
+}
+
+TEST_F(TaskContinuationFixture, CallCancel) {
+  std::promise<void> promise;
+  auto future = promise.get_future();
+
+  olp::client::ApiResponse<olp::client::HttpResponse, olp::client::ApiError>
+      result;
+
+  auto cont =
+      olp::thread::TaskContinuation(std::move(scheduler))
+          .Then([](olp::thread::ExecutionContext,
+                   std::function<void(int)> next) { next(1); })
+          .Then([](olp::thread::ExecutionContext context, int,
+                   std::function<void(olp::client::HttpResponse)>) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            context.ExecuteOrCancelled(
+                []() { return olp::client::CancellationToken(); },
+                []() { return olp::client::CancellationToken(); });
+          })
+          .Finally([&promise,
+                    &result](olp::client::ApiResponse<olp::client::HttpResponse,
+                                                      olp::client::ApiError>
+                                 response) {
+            result = response.GetResult();
+            promise.set_value();
+          });
+
+  cont.Run();
+  std::this_thread::sleep_for(
+      std::chrono::milliseconds(50));  // simulate some delay
+
+  cont.CancelToken().Cancel();
+
+  EXPECT_EQ(future.wait_for(std::chrono::milliseconds(1000)),
+            std::future_status::ready);
+
+  future.get();
+
+  EXPECT_TRUE(result.IsSuccessful());
+}


### PR DESCRIPTION
Add task continuation classes which provides
possibility to create and run multiple asynchronous tasks.
Add unit tests for task continuation.

Relates-To: OLPEDGE-2077

Signed-off-by: Yevhenii Dudnyk <ext-yevhenii.dudnyk@here.com>