### PR TITLE
Export TokenProviderImpl class.

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenProvider.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenProvider.h
@@ -47,7 +47,7 @@ class TokenProviderPrivate;
 /// An implementation of `TokenProvider`.
 /// @note This is a private implementation class for internal use only, and not
 /// bound to any API stability promises. Please do not use directly.
-class TokenProviderImpl {
+class AUTHENTICATION_API TokenProviderImpl {
  public:
   /**
    * @brief Creates the `TokenProviderImpl` instance.


### PR DESCRIPTION
Despite TokenProviderImpl is for internal use only, its declared in
public TokeProvider.h header. Thus, its symbols must be exported to be
able to use shared authentication lib.

Relates-To: OAM-1387

Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>