### PR TITLE
Remove unsupported SonarQube property

### DIFF
--- a/scripts/linux/nv/sonar-project.propertiesValgrind
+++ b/scripts/linux/nv/sonar-project.propertiesValgrind
@@ -10,5 +10,4 @@ sonar.cxx.file.suffixes=.cxx,.cpp,.cc,.hxx,.hpp,.hh,.h
 sonar.cxx.cppcheck.reportPaths=./reports/cppcheck/cppcheck.xml
 sonar.cxx.xunit.reportPaths=./reports/*report.xml
 sonar.cxx.valgrind.reportPaths=./reports/valgrind/*memcheck.xml
-sonar.branch.name=master
 sonar.scm.exclusions.disabled=true


### PR DESCRIPTION
By default branch will be master, nevertheless.

Resolves: OAM-1420

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>