### PR TITLE
Add functionality for GetCompatibleVersions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,14 +29,14 @@ jobs:
 
 - job: MacOS_build
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   - bash: scripts/macos/psv/azure_macos_build_psv.sh
     displayName: 'MacOS Build'
 
 - job: iOS_build
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   - bash: scripts/ios/azure_ios_build_psv.sh
     displayName: 'iOS Build'
@@ -55,7 +55,7 @@ jobs:
 
 - job: Android_Emulator
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   condition: eq(variables['Build.Reason'], 'Manual')
   variables:
     ANDROID_NDK_HOME: $(ANDROID_HOME)/ndk-bundle

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogClient.h
@@ -189,6 +189,40 @@ class DATASERVICE_READ_API CatalogClient final {
   client::CancellableFuture<VersionsResponse> ListVersions(
       VersionsRequest request);
 
+  /**
+   * @brief Gets the list of the current catalog versions that are compatible
+   * with the dependencies provided by the request.
+   *
+   * @note This request is online only. It does not support
+   * multiple pages and returns only the first page.
+   *
+   * @param request The `CompatibleVersionsRequest` instance that contains a
+   * complete set of the request parameters.
+   * @param callback The `CompatibleVersionsCallback` object that is invoked if
+   * the compatible versions are available or an error occurred.
+   *
+   * @return A token that can be used to cancel this request.
+   */
+  client::CancellationToken GetCompatibleVersions(
+      CompatibleVersionsRequest request, CompatibleVersionsCallback callback);
+
+  /**
+   * @brief Gets the list of the current catalog versions that are compatible
+   * with the dependencies provided by the request.
+   *
+   * @note This request is online only. It does not support
+   * multiple pages and returns only the first page.
+   *
+   * @param request The `CompatibleVersionsRequest` instance that contains a
+   * complete set of the request parameters.
+   *
+   * @return `CancellableFuture` that contains the `VersionsResponse`
+   * instance with the list of versions or an error. You can also
+   * use `CancellableFuture` to cancel this request.
+   */
+  client::CancellableFuture<CompatibleVersionsResponse> GetCompatibleVersions(
+      CompatibleVersionsRequest request);
+
  private:
   std::unique_ptr<CatalogClientImpl> impl_;
 };

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -138,8 +138,16 @@ using VersionsResponse = Response<VersionsResult>;
 /// The versions list of metadata callback type for the versioned client.
 using VersionsResponseCallback = Callback<VersionsResult>;
 
+/// An alias for the compatible versions response.
+using CompatibleVersionsResult = model::VersionsResponse;
+/// The compatible versions list response type for the versioned client.
+using CompatibleVersionsResponse = Response<CompatibleVersionsResult>;
+/// The compatible versions list response type for the versioned client.
+using CompatibleVersionsCallback = Callback<CompatibleVersionsResult>;
+
 /// The list of tile keys.
 using TileKeys = std::vector<geo::TileKey>;
+
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,17 @@ client::CancellableFuture<VersionsResponse> CatalogClient::ListVersions(
     VersionsRequest request) {
   return impl_->ListVersions(std::move(request));
 }
+
+client::CancellationToken CatalogClient::GetCompatibleVersions(
+    CompatibleVersionsRequest request, CompatibleVersionsCallback callback) {
+  return impl_->GetCompatibleVersions(std::move(request), std::move(callback));
+}
+
+client::CancellableFuture<CompatibleVersionsResponse>
+CatalogClient::GetCompatibleVersions(CompatibleVersionsRequest request) {
+  return impl_->GetCompatibleVersions(std::move(request));
+}
+
 }  // namespace read
 }  // namespace dataservice
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/dataservice/read/CatalogRequest.h>
 #include <olp/dataservice/read/CatalogVersionRequest.h>
+#include <olp/dataservice/read/CompatibleVersionsRequest.h>
 #include <olp/dataservice/read/Types.h>
 #include <olp/dataservice/read/VersionsRequest.h>
 
@@ -68,6 +69,12 @@ class CatalogClientImpl final {
 
   client::CancellableFuture<VersionsResponse> ListVersions(
       VersionsRequest request);
+
+  client::CancellationToken GetCompatibleVersions(
+      CompatibleVersionsRequest request, CompatibleVersionsCallback callback);
+
+  client::CancellableFuture<CompatibleVersionsResponse> GetCompatibleVersions(
+      CompatibleVersionsRequest request);
 
  private:
   client::HRN catalog_;

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/MetadataApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/MetadataApi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,11 +27,14 @@
 #include <olp/core/client/OlpClient.h>
 
 // clang-format off
+#include "generated/parser/VersionsResponseParser.h"
 #include "generated/parser/LayerVersionsParser.h"
 #include "generated/parser/PartitionsParser.h"
 #include "generated/parser/VersionResponseParser.h"
 #include "generated/parser/VersionInfosParser.h"
 #include "JsonResultParser.h"
+#include "generated/serializer/CatalogVersionsSerializer.h"
+#include "generated/serializer/JsonSerializer.h"
 // clang-format on
 
 namespace {
@@ -178,6 +181,36 @@ MetadataApi::VersionsResponse MetadataApi::ListVersions(
     return {{api_response.status, api_response.response.str()}};
   }
   return parser::parse_result<VersionsResponse>(api_response.response);
+}
+
+MetadataApi::CompatibleVersionsResponse MetadataApi::GetCompatibleVersions(
+    const client::OlpClient& client, const CatalogVersions& dependencies,
+    int32_t limit, const client::CancellationContext& context) {
+  std::string metadata_uri = "/versions/compatibles";
+
+  std::multimap<std::string, std::string> header_params;
+  header_params.emplace("Accept", "application/json");
+
+  std::multimap<std::string, std::string> query_params;
+  query_params.emplace("limit", std::to_string(limit));
+
+  rapidjson::Value value;
+
+  const auto serialized_dependencies = serializer::serialize(dependencies);
+
+  const auto data = std::make_shared<std::vector<unsigned char>>(
+      serialized_dependencies.begin(), serialized_dependencies.end());
+
+  auto api_response =
+      client.CallApi(metadata_uri, "POST", query_params, header_params, {},
+                     data, "application/json", context);
+
+  if (api_response.status != http::HttpStatusCode::OK) {
+    return {{api_response.status, api_response.response.str()}};
+  }
+
+  return parser::parse_result<CompatibleVersionsResponse>(
+      api_response.response);
 }
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/MetadataApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/MetadataApi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@
 #include "olp/dataservice/read/model/Partitions.h"
 #include "olp/dataservice/read/model/VersionInfos.h"
 #include "olp/dataservice/read/model/VersionResponse.h"
+#include "olp/dataservice/read/model/VersionsResponse.h"
 
 namespace olp {
 namespace client {
@@ -56,6 +57,11 @@ class MetadataApi {
   using PartitionsExtendedResponse =
       ExtendedApiResponse<model::Partitions, client::ApiError,
                           client::NetworkStatistics>;
+
+  using CatalogVersions = std::vector<model::CatalogVersion>;
+
+  using CompatibleVersionsResponse =
+      client::ApiResponse<model::VersionsResponse, client::ApiError>;
 
   /**
    * @brief Retrieves the latest metadata version for each layer of a specified
@@ -128,6 +134,10 @@ class MetadataApi {
       const client::OlpClient& client, int64_t start_version,
       int64_t end_version, boost::optional<std::string> billing_tag,
       const client::CancellationContext& context);
+
+  static CompatibleVersionsResponse GetCompatibleVersions(
+      const client::OlpClient& client, const CatalogVersions& dependencies,
+      int32_t limit, const client::CancellationContext& context);
 };
 
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/VersionsResponseParser.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/VersionsResponseParser.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "VersionsResponseParser.h"
+
+#include <olp/core/generated/parser/ParserWrapper.h>
+
+namespace olp {
+namespace parser {
+
+using VersionsResponse = olp::dataservice::read::model::VersionsResponse;
+using VersionsResponseEntry =
+    olp::dataservice::read::model::VersionsResponseEntry;
+using CatalogVersion = olp::dataservice::read::model::CatalogVersion;
+
+void from_json(const rapidjson::Value& value, CatalogVersion& x) {
+  x.SetHrn(parse<std::string>(value, "hrn"));
+  x.SetVersion(parse<int64_t>(value, "version"));
+}
+
+void from_json(const rapidjson::Value& value, VersionsResponseEntry& x) {
+  x.SetVersion(parse<int64_t>(value, "version"));
+  x.SetCatalogVersions(
+      parse<std::vector<CatalogVersion>>(value, "sharedDependencies"));
+}
+
+void from_json(const rapidjson::Value& value, VersionsResponse& x) {
+  x.SetVersionResponseEntries(
+      parse<std::vector<VersionsResponseEntry>>(value, "versions"));
+}
+
+}  // namespace parser
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/VersionsResponseParser.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/VersionsResponseParser.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+
+#include <rapidjson/document.h>
+#include "olp/dataservice/read/model/VersionsResponse.h"
+
+
+namespace olp {
+namespace parser {
+
+void from_json(const rapidjson::Value& value,
+               olp::dataservice::read::model::CatalogVersion& x);
+void from_json(const rapidjson::Value& value,
+               olp::dataservice::read::model::VersionsResponseEntry& x);
+void from_json(const rapidjson::Value& value,
+               olp::dataservice::read::model::VersionsResponse& x);
+
+}  // namespace parser
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/generated/serializer/CatalogVersionsSerializer.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/serializer/CatalogVersionsSerializer.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <olp/dataservice/read/model/CatalogVersion.h>
+#include <rapidjson/document.h>
+
+namespace olp {
+namespace serializer {
+
+inline void to_json(const dataservice::read::model::CatalogVersion& x,
+                    rapidjson::Value& value,
+                    rapidjson::Document::AllocatorType& allocator) {
+  value.SetObject();
+  serialize("hrn", x.GetHrn(), value, allocator);
+  serialize("version", x.GetVersion(), value, allocator);
+}
+
+template <>
+inline void to_json<dataservice::read::model::CatalogVersion>(
+    const std::vector<dataservice::read::model::CatalogVersion>& x,
+    rapidjson::Value& value, rapidjson::Document::AllocatorType& allocator) {
+  value.SetObject();
+
+  rapidjson::Value array_value;
+  array_value.SetArray();
+  for (auto itr = x.begin(); itr != x.end(); ++itr) {
+    rapidjson::Value item_value;
+    to_json(*itr, item_value, allocator);
+    array_value.PushBack(std::move(item_value), allocator);
+  }
+  value.AddMember("dependencies", std::move(array_value), allocator);
+}
+
+}  // namespace serializer
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
@@ -31,6 +31,7 @@
 #include "generated/api/MetadataApi.h"
 #include "olp/dataservice/read/CatalogRequest.h"
 #include "olp/dataservice/read/CatalogVersionRequest.h"
+#include "olp/dataservice/read/CompatibleVersionsRequest.h"
 #include "olp/dataservice/read/VersionsRequest.h"
 
 namespace {
@@ -213,6 +214,22 @@ CatalogVersionResponse CatalogRepository::GetLatestVersionOnline(
 
   return MetadataApi::GetLatestCatalogVersion(metadata_client, -1, billing_tag,
                                               context);
+}
+
+CompatibleVersionsResponse CatalogRepository::GetCompatibleVersions(
+    const CompatibleVersionsRequest& request,
+    client::CancellationContext context) {
+  auto metadata_api =
+      lookup_client_.LookupApi("metadata", "v1", client::OnlineOnly, context);
+
+  if (!metadata_api.IsSuccessful()) {
+    return metadata_api.GetError();
+  }
+
+  const client::OlpClient& metadata_client = metadata_api.GetResult();
+
+  return MetadataApi::GetCompatibleVersions(
+      metadata_client, request.GetDependencies(), request.GetLimit(), context);
 }
 
 }  // namespace repository

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.h
@@ -33,6 +33,7 @@ namespace read {
 
 class CatalogRequest;
 class CatalogVersionRequest;
+class CompatibleVersionsRequest;
 class VersionsRequest;
 
 namespace repository {
@@ -50,6 +51,10 @@ class CatalogRepository final {
 
   VersionsResponse GetVersionsList(const VersionsRequest& request,
                                    client::CancellationContext context);
+
+  CompatibleVersionsResponse GetCompatibleVersions(
+      const CompatibleVersionsRequest& request,
+      client::CancellationContext context);
 
  private:
   CatalogVersionResponse GetLatestVersionOnline(

--- a/scripts/ios/azure_ios_build_psv.sh
+++ b/scripts/ios/azure_ios_build_psv.sh
@@ -17,6 +17,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
+# Due to some bug which is cmake cannot detect compiler while called
+# from cmake itself when project is compiled with XCode 12.4 we must
+# switch to old XCode as a workaround.
+sudo xcode-select -s /Applications/Xcode_11.7.app
 
 mkdir -p build && cd build
 cmake ../ -GXcode \


### PR DESCRIPTION
- Add functionality to allow to query compatible
  versions for the given catalog.
- Update Azure Pipelines to use new macOS-10.15 version

Resolves: OAM-1338

Signed-off-by: Serhii Lozynskyi <ext-serhii.lozynskyi@here.com>