### PR TITLE
Add execution context functionality

### DIFF
--- a/olp-cpp-sdk-authentication/src/TokenEndpointImpl.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenEndpointImpl.cpp
@@ -19,6 +19,8 @@
 
 #include "TokenEndpointImpl.h"
 
+#include <thread>
+
 #include <olp/authentication/SignInResult.h>
 #include <olp/core/http/HttpStatusCode.h>
 #include <olp/core/http/NetworkConstants.h>

--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -153,6 +153,7 @@ set(OLP_SDK_LOGGING_HEADERS
 
 set(OLP_SDK_THREAD_HEADERS
     ./include/olp/core/thread/Atomic.h
+    ./include/olp/core/thread/ExecutionContext.h
     ./include/olp/core/thread/SyncQueue.h
     ./include/olp/core/thread/SyncQueue.inl
     ./include/olp/core/thread/TaskScheduler.h
@@ -342,6 +343,7 @@ set(OLP_SDK_LOGGING_SOURCES
 )
 
 set(OLP_SDK_THREAD_SOURCES
+    ./src/thread/ExecutionContext.cpp
     ./src/thread/PriorityQueueExtended.h
     ./src/thread/ThreadPoolTaskScheduler.cpp
 )

--- a/olp-cpp-sdk-core/include/olp/core/thread/ExecutionContext.h
+++ b/olp-cpp-sdk-core/include/olp/core/thread/ExecutionContext.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <utility>
+
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/CancellationContext.h>
+
+namespace olp {
+namespace thread {
+
+/// Handles the cancellation and final mechanisms.
+class CORE_API ExecutionContext final {
+  using CancelFuncType = std::function<void()>;
+  using ExecuteFuncType = std::function<client::CancellationToken()>;
+  using FailedCallback = std::function<void(client::ApiError)>;
+
+ public:
+  /// A default contructor, initializes the `ExecutionContextImpl` instance.
+  ExecutionContext();
+
+  /**
+   * @brief Checks whether `CancellationContext` is cancelled.
+   *
+   * @return True if `CancellationContext` is cancelled; false otherwise.
+   */
+  bool Cancelled() const;
+
+  /// @copydoc CancellationContext::CancelOperation()
+  void CancelOperation();
+
+  /// @copydoc CancellationContext::ExecuteOrCancelled()
+  void ExecuteOrCancelled(const ExecuteFuncType& execute_fn,
+                          const CancelFuncType& cancel_fn = nullptr);
+
+  /**
+   * @brief Sets the error that is returned in the `Finally`
+   * method of the execution.
+   *
+   * It immediately finishes the task execution and provides an error
+   * via the `SetFailedCallback` callback of `ExecutionContext`.
+   *
+   * @param error The `ApiError` instance containing the error information.
+   */
+  void SetError(client::ApiError error);
+
+  /**
+   * @brief Sets a callback for `SetError`.
+   *
+   * @param callback Handles the finalization of the execution
+   * in case of an error.
+   */
+  void SetFailedCallback(FailedCallback callback);
+
+  /**
+   * @brief Gets the `CancellationContext` object associated
+   * with this `ExecutionContext` instance.
+   *
+   * The caller can use it to cancel the ongoing operation.
+   *
+   * @return The `CancellationContext` instance.
+   */
+  client::CancellationContext GetContext() const;
+
+ private:
+  class ExecutionContextImpl;
+  std::shared_ptr<ExecutionContextImpl> impl_;
+};
+
+}  // namespace thread
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/thread/ExecutionContext.cpp
+++ b/olp-cpp-sdk-core/src/thread/ExecutionContext.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/core/thread/ExecutionContext.h>
+
+namespace olp {
+namespace thread {
+
+class ExecutionContext::ExecutionContextImpl {
+ public:
+  bool IsCancelled() const { return context_.IsCancelled(); }
+
+  void CancelOperation() { context_.CancelOperation(); }
+
+  void ExecuteOrCancelled(const ExecuteFuncType& execute_fn,
+                          const CancelFuncType& cancel_fn) {
+    context_.ExecuteOrCancelled(execute_fn, cancel_fn);
+  }
+
+  void SetError(client::ApiError error) {
+    if (failed_callback_) {
+      failed_callback_(std::move(error));
+      failed_callback_ = nullptr;
+    }
+  }
+
+  void SetFailedCallback(FailedCallback callback) {
+    failed_callback_ = std::move(callback);
+  }
+
+  client::CancellationContext GetContext() const { return context_; }
+
+ private:
+  client::CancellationContext context_;
+  FailedCallback failed_callback_;
+};
+
+ExecutionContext::ExecutionContext()
+    : impl_(std::make_shared<ExecutionContextImpl>()) {}
+
+void ExecutionContext::SetError(client::ApiError error) {
+  impl_->SetError(std::move(error));
+}
+
+bool ExecutionContext::Cancelled() const { return impl_->IsCancelled(); }
+
+void ExecutionContext::CancelOperation() { return impl_->CancelOperation(); }
+
+void ExecutionContext::ExecuteOrCancelled(const ExecuteFuncType& execute_fn,
+                                          const CancelFuncType& cancel_fn) {
+  impl_->ExecuteOrCancelled(execute_fn, cancel_fn);
+}
+
+void ExecutionContext::SetFailedCallback(FailedCallback callback) {
+  impl_->SetFailedCallback(std::move(callback));
+}
+
+client::CancellationContext ExecutionContext::GetContext() const {
+  return impl_->GetContext();
+}
+
+}  // namespace thread
+}  // namespace olp

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ set(OLP_CPP_SDK_CORE_TESTS_SOURCES
     ./logging/MessageFormatterTest.cpp
     ./logging/MockAppender.cpp
 
+    ./thread/ExecutionContextTest.cpp
     ./thread/PriorityQueueExtendedTest.cpp
     ./thread/SyncQueueTest.cpp
     ./thread/ThreadPoolTaskSchedulerTest.cpp

--- a/olp-cpp-sdk-core/tests/thread/ExecutionContextTest.cpp
+++ b/olp-cpp-sdk-core/tests/thread/ExecutionContextTest.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gtest/gtest.h>
+
+#include <olp/core/thread/ExecutionContext.h>
+
+namespace {
+using ExecutionContext = olp::thread::ExecutionContext;
+
+TEST(ExecutionContextTest, Cancel) {
+  ExecutionContext execution_context;
+
+  EXPECT_FALSE(execution_context.Cancelled());
+  execution_context.CancelOperation();
+  EXPECT_TRUE(execution_context.Cancelled());
+}
+
+TEST(ExecutionContextTest, ExecuteOrCancelled) {
+  ExecutionContext execution_context;
+
+  {
+    SCOPED_TRACE("Execute");
+
+    bool executed = false;
+    bool cancelled = false;
+    execution_context.ExecuteOrCancelled(
+        [&executed]() {
+          executed = true;
+          return olp::client::CancellationToken();
+        },
+        [&cancelled]() { cancelled = true; });
+
+    EXPECT_TRUE(executed);
+    EXPECT_FALSE(cancelled);
+  }
+
+  {
+    SCOPED_TRACE("Cancel");
+
+    bool executed = false;
+    bool cancelled = false;
+    execution_context.CancelOperation();
+    execution_context.ExecuteOrCancelled(
+        [&]() {
+          executed = true;
+          return olp::client::CancellationToken();
+        },
+        [&cancelled]() { cancelled = true; });
+
+    EXPECT_FALSE(executed);
+    EXPECT_TRUE(cancelled);
+  }
+}
+
+TEST(ExecutionContextTest, SetFailedCallback) {
+  ExecutionContext execution_context;
+
+  olp::client::ApiError api_error;
+  execution_context.SetFailedCallback(
+      [&](olp::client::ApiError error) { api_error = std::move(error); });
+  execution_context.SetError(olp::client::ApiError::NetworkConnection());
+
+  EXPECT_EQ(api_error.GetErrorCode(),
+            olp::client::ErrorCode::NetworkConnection);
+}
+
+TEST(ExecutionContextTest, GetContext) {
+  ExecutionContext execution_context;
+
+  EXPECT_FALSE(execution_context.GetContext().IsCancelled());
+  execution_context.CancelOperation();
+  EXPECT_TRUE(execution_context.GetContext().IsCancelled());
+}
+
+}  // namespace


### PR DESCRIPTION
Add execution context classes which provides
functionality to cancel operation, setting errors,
and execute tasks.

Relates-To: OLPEDGE-2077

Signed-off-by: Yevhenii Dudnyk ext-yevhenii.dudnyk@here.com