### PR TITLE
Add continuation functionality

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -153,11 +153,14 @@ set(OLP_SDK_LOGGING_HEADERS
 
 set(OLP_SDK_THREAD_HEADERS
     ./include/olp/core/thread/Atomic.h
+    ./include/olp/core/thread/Continuation.h
+    ./include/olp/core/thread/Continuation.inl
     ./include/olp/core/thread/ExecutionContext.h
     ./include/olp/core/thread/SyncQueue.h
     ./include/olp/core/thread/SyncQueue.inl
     ./include/olp/core/thread/TaskScheduler.h
     ./include/olp/core/thread/ThreadPoolTaskScheduler.h
+    ./include/olp/core/thread/TypeHelpers.h
 )
 
 set(OLP_SDK_GEOCOORDINATES_HEADERS
@@ -343,6 +346,7 @@ set(OLP_SDK_LOGGING_SOURCES
 )
 
 set(OLP_SDK_THREAD_SOURCES
+    ./src/thread/Continuation.cpp
     ./src/thread/ExecutionContext.cpp
     ./src/thread/PriorityQueueExtended.h
     ./src/thread/ThreadPoolTaskScheduler.cpp

--- a/olp-cpp-sdk-core/include/olp/core/thread/Continuation.h
+++ b/olp-cpp-sdk-core/include/olp/core/thread/Continuation.h
@@ -1,0 +1,277 @@
+/*
+ * Copyright (C) 2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <deque>
+#include <functional>
+#include <memory>
+
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/TaskContext.h>
+#include <olp/core/thread/ExecutionContext.h>
+#include <olp/core/thread/TypeHelpers.h>
+
+namespace olp {
+namespace thread {
+
+class TaskScheduler;
+
+namespace internal {
+
+/// An internal implementation of `Continuation`.
+/// It provides mechanisms to create a chain of tasks, start, cancel,
+/// and finalize an execution.
+///
+/// @note This is a private implementation class for internal use only, and not
+/// bound to any API stability promises. Please do not use directly.
+class CORE_API ContinuationImpl final {
+ public:
+  /// An alias of a function which returns an error as a callback.
+  using FailedCallback = std::function<void(client::ApiError)>;
+  /// Type of return value of Continuation Task.
+  using OutResultType = std::unique_ptr<UntypedSmartPointer>;
+
+  /// Type of Continuation Type.
+  using TaskType = std::function<OutResultType(void*)>;
+  /// Default callback type, uses void* as a parameter which is later converted
+  /// to the specific type, callback doesn't have a return type.
+  using CallbackType = std::function<void(void*)>;
+  /// An internal type of tasks in Continuation.
+  using AsyncTaskType = std::function<void(void*, CallbackType)>;
+  /// An alias for a processing tasks finalization type.
+  using FinalCallbackType = std::function<void(void*, bool)>;
+  /// An alias of a pair of Task Continuation types.
+  using ContinuationTask = std::pair<AsyncTaskType, TaskType>;
+
+  /// A default constructor of `ContinuationImpl`.
+  ContinuationImpl() = default;
+
+  /**
+   * @brief A contructor for a continuation using the given parameters.
+   *
+   * @param task_scheduler The `TaskScheduler` instance.
+   * @param context The `ExecutionContext` instance.
+   * @param task The `ContinuationTask` instance.
+   */
+  ContinuationImpl(std::shared_ptr<TaskScheduler> task_scheduler,
+                   ExecutionContext context, ContinuationTask task);
+
+  /**
+   * @brief Adds an asynchronous task (one taking a callback) as the next
+   * task of the `ContinuationImpl`.
+   *
+   * @param task A task for adding to the continuation chain.
+   *
+   * @return The `ContinuationImpl` instance.
+   */
+  ContinuationImpl Then(ContinuationTask task);
+
+  /**
+   * @brief Starts the execution of a task continuation chain.
+   *
+   * @param callback Handles the finalization of a task chain.
+   */
+  void Run(FinalCallbackType callback);
+
+  /**
+   * @brief Provides the execution context object.
+   *
+   * @return The `ExecutionContext` instance.
+   */
+  const ExecutionContext& GetExecutionContext() const;
+
+  /**
+   * @brief Provides cancellation context object.
+   *
+   * @return The `CancellationContext` instance.
+   */
+  const client::CancellationContext& GetContext() const;
+
+  /**
+   * @brief Provides a status whether CancellationContext is cancelled.
+   *
+   * @return True if Continuation is cancelled; false otherwise.
+   */
+  bool Cancelled() const;
+
+  /**
+   * @brief Sets a callback on calling SetError.
+   *
+   * @param callback Handles an execution finalization of a continuation chain.
+   */
+  void SetFailedCallback(FailedCallback callback);
+
+  /**
+   * @brief Clears the continuation chain tasks.
+   */
+  void Clear();
+
+ private:
+  std::shared_ptr<thread::TaskScheduler> task_scheduler_;
+  std::deque<ContinuationTask> tasks_;
+  ExecutionContext execution_context_;
+
+  /// a variable shows whether it is allowed to do the changes to the task
+  /// chain, used to prevent using methods of `Continuation` after it was run.
+  bool change_allowed{true};
+};
+
+}  // namespace internal
+
+/// A Template for Continuation of generic type.
+template <typename ResultType>
+class CORE_API Continuation final {
+  /// Response type alias of template class type.
+  using Response = client::ApiResponse<ResultType, client::ApiError>;
+  /// An alias for finalization callback.
+  using FinallyCallbackType = std::function<void(Response)>;
+
+  /// An alias for `ContinuationImplType::ContinuationImpl`.
+  using ContinuationImplType = internal::ContinuationImpl;
+  /// An alias for `ContinuationImplType::OutResultType`.
+  using OutResultType = ContinuationImplType::OutResultType;
+  /// An alias for `ContinuationImplType::TaskType`.
+  using TaskType = ContinuationImplType::TaskType;
+  /// An alias for `ContinuationImplType::CallbackType`.
+  using CallbackType = ContinuationImplType::CallbackType;
+  /// An alias for a Continuation chain first task.
+  using ContinuationTaskType =
+      std::function<void(ExecutionContext, std::function<void(ResultType)>)>;
+
+ public:
+  /**
+   * @brief A contructor for a continuation using the given parameters.
+   *
+   * @param task_scheduler The `TaskScheduler` instance.
+   * @param context The `ExecutionContext` instance.
+   * @param task Continuation task's callback, constains thr execution context
+   * and returns a value for the next task.
+   */
+  Continuation(std::shared_ptr<thread::TaskScheduler> scheduler,
+               ExecutionContext context, ContinuationTaskType task);
+
+  /**
+   * @brief A contructor for a continuation using the given parameters.
+   *
+   * @param continuation The `ContinuationImpl` instance.
+   */
+  Continuation(ContinuationImplType continuation);
+
+  /**
+   * @brief Adds an asynchronous task (one taking a callback) as the next
+   * step of the `Continuation`.
+   *
+   * @param task A task for adding to the continuation chain.
+   */
+  template <typename Callable>
+  Continuation<internal::DeducedType<Callable>> Then(Callable task);
+
+  /**
+   * @brief Starts an execution of a task continuation chain.
+   */
+  void Run();
+
+  /**
+   * @brief Provides a token to cancel the task.
+   *
+   * @return The `CancellationToken` instance.
+   */
+  client::CancellationToken CancelToken();
+
+  /**
+   * @brief Adds an asynchronous task (one taking a callback) as the next
+   * step of the  Continuation.
+   *
+   * @param execution_func A task for adding to the continuation chain.
+   */
+  template <typename NewType>
+  Continuation<internal::RemoveRefAndConst<NewType>> Then(
+      std::function<void(ExecutionContext, ResultType,
+                         std::function<void(NewType)>)>
+          execution_func);
+
+  /**
+   * @brief Handles the finalization of Continuation, sets a callback
+   * to the existing Continuation instance.
+   *
+   * @param finally_callback Callback that handles both
+   * successful and not successful results.
+   *
+   * @return The `Continuation` instance.
+   */
+  Continuation& Finally(FinallyCallbackType finally_callback);
+
+ private:
+  FinallyCallbackType finally_callback_;
+  ContinuationImplType impl_;
+};
+
+/// A template for Continuation of void type. It has the same
+/// interface as the generic version.
+template <>
+class CORE_API Continuation<void> final {
+ public:
+  /// Deleted `Continuation` constructor as an instance should not be created.
+  Continuation() = delete;
+
+  /**
+   * @brief Adds an asynchronous task (one taking a callback) as the next
+   * step of the  Continuation.
+   *
+   * @param task A task for adding to the continuation chain.
+   *
+   * @return The `Continuation` instance.
+   */
+  template <typename Callable>
+  Continuation<internal::AsyncResultType<Callable>> Then(Callable task);
+
+ private:
+  /// An alias for `internal::ContinuationImpl::CallbackType`.
+  using CallbackType = internal::ContinuationImpl::CallbackType;
+  /// An alias for `internal::ContinuationImpl`.
+  using ContinuationImplType = internal::ContinuationImpl;
+  /// An alias for `ContinuationImplType::OutResultType`.
+  using OutResultType = ContinuationImplType::OutResultType;
+  /// An alias for `ContinuationImplType::TaskType`.
+  using TaskType = ContinuationImplType::TaskType;
+
+  template <typename ResultType>
+  friend class Continuation;
+
+  /**
+   * @brief Creates the ContinuationImplType task based on parameters.
+   *
+   * @param context The `ExecutionContext` instance.
+   * @param task Continuation task callback which constains an execution context
+   * and returns a value for the next task.
+   */
+  template <typename NewType>
+  static ContinuationImplType::ContinuationTask ToAsyncTask(
+      ExecutionContext context,
+      std::function<void(ExecutionContext, std::function<void(NewType)>)> task);
+
+  ContinuationImplType impl_;
+};
+
+}  // namespace thread
+}  // namespace olp
+
+#include "Continuation.inl"

--- a/olp-cpp-sdk-core/include/olp/core/thread/Continuation.inl
+++ b/olp-cpp-sdk-core/include/olp/core/thread/Continuation.inl
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <memory>
+
+namespace olp {
+namespace thread {
+
+class ExecutionContext;
+class TaskScheduler;
+
+template <typename ResultType>
+void Continuation<ResultType>::Run() {
+  if (!finally_callback_) {
+    impl_.Clear();
+    return;
+  }
+
+  if (impl_.Cancelled()) {
+    finally_callback_(client::ApiError::Cancelled());
+    impl_.Clear();
+    finally_callback_ = nullptr;
+    return;
+  }
+
+  impl_.Run([this](void* input, bool cancelled) {
+    if (cancelled) {
+      finally_callback_(client::ApiError::Cancelled());
+    } else {
+      auto value = std::move(*static_cast<ResultType*>(input));
+      finally_callback_(std::move(value));
+    }
+    finally_callback_ = nullptr;
+  });
+}
+
+template <typename ResultType>
+Continuation<ResultType>& Continuation<ResultType>::Finally(
+    FinallyCallbackType finally_callback) {
+  finally_callback_ = std::move(finally_callback);
+  impl_.SetFailedCallback(
+      [this](client::ApiError error) { finally_callback_(std::move(error)); });
+  return *this;
+}
+
+template <typename NewType>
+internal::ContinuationImpl::ContinuationTask Continuation<void>::ToAsyncTask(
+    ExecutionContext context,
+    std::function<void(ExecutionContext, std::function<void(NewType)>)> func) {
+  using NewResultType = internal::RemoveRefAndConst<NewType>;
+  return {[=](void*, CallbackType callback) {
+            func(context, [callback](NewResultType input) {
+              callback(static_cast<NewResultType*>(&input));
+            });
+          },
+          [](void* input) {
+            auto in = *static_cast<NewResultType*>(input);
+            auto result = std::make_unique<NewResultType>(std::move(in));
+            return internal::MakeUntypedUnique(std::move(result));
+          }};
+}
+
+template <typename Callable>
+Continuation<internal::AsyncResultType<Callable>> Continuation<void>::Then(
+    Callable task) {
+  using NewResultType = internal::AsyncResultType<Callable>;
+  using Function = internal::TypeToFunctionInput<NewResultType>;
+  return Then(std::function<void(Function)>(std::forward<Callable>(task)));
+}
+
+template <typename ResultType>
+template <typename Callable>
+Continuation<internal::DeducedType<Callable>> Continuation<ResultType>::Then(
+    Callable task) {
+  using NewResultType = internal::DeducedType<Callable>;
+  using Function = internal::TypeToFunctionInput<NewResultType>;
+  return Then(std::function<void(ExecutionContext, ResultType, Function)>(
+      std::move(task)));
+}
+
+template <typename ResultType>
+template <typename NewType>
+Continuation<internal::RemoveRefAndConst<NewType>>
+Continuation<ResultType>::Then(std::function<void(ExecutionContext, ResultType,
+                                                  std::function<void(NewType)>)>
+                                   task) {
+  using NewResultType = internal::RemoveRefAndConst<NewType>;
+  auto context = impl_.GetExecutionContext();
+
+  return impl_.Then({[=](void* input, CallbackType callback) {
+                       auto in = *static_cast<ResultType*>(input);
+                       task(std::move(context), std::move(in),
+                            [callback, context](NewResultType arg) {
+                              callback(static_cast<void*>(&arg));
+                            });
+                     },
+                     [](void* input) {
+                       auto in = *static_cast<NewResultType*>(input);
+                       auto result =
+                           std::make_unique<NewResultType>(std::move(in));
+                       return internal::MakeUntypedUnique(std::move(result));
+                     }});
+}
+
+template <typename ResultType>
+client::CancellationToken Continuation<ResultType>::CancelToken() {
+  if (!finally_callback_) {
+    return client::CancellationToken();
+  }
+
+  auto context = impl_.GetContext();
+  return client::CancellationToken(
+      [context]() mutable { context.CancelOperation(); });
+}
+
+template <typename ResultType>
+Continuation<ResultType>::Continuation(
+    std::shared_ptr<TaskScheduler> scheduler, ExecutionContext context,
+    std::function<void(ExecutionContext, std::function<void(ResultType)>)> task)
+    : impl_(scheduler, context,
+            Continuation<void>::ToAsyncTask(context, std::move(task))) {}
+
+template <typename ResultType>
+Continuation<ResultType>::Continuation(ContinuationImplType continuation)
+    : impl_(std::move(continuation)) {}
+
+}  // namespace thread
+}  // namespace olp

--- a/olp-cpp-sdk-core/include/olp/core/thread/ExecutionContext.h
+++ b/olp-cpp-sdk-core/include/olp/core/thread/ExecutionContext.h
@@ -78,7 +78,7 @@ class CORE_API ExecutionContext final {
    *
    * @return The `CancellationContext` instance.
    */
-  client::CancellationContext GetContext() const;
+  const client::CancellationContext& GetContext() const;
 
  private:
   class ExecutionContextImpl;

--- a/olp-cpp-sdk-core/include/olp/core/thread/TypeHelpers.h
+++ b/olp-cpp-sdk-core/include/olp/core/thread/TypeHelpers.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <functional>
+#include <type_traits>
+#include <vector>
+
+#include <olp/core/client/ApiError.h>
+#include <olp/core/porting/make_unique.h>
+
+namespace olp {
+namespace thread {
+namespace internal {
+
+/// A helper class removes type qualifiers and provides a type.
+template <typename Type>
+struct RemoveRefAndConstImpl {
+  using type =
+      typename std::remove_cv<typename std::remove_reference<Type>::type>::type;
+};
+
+/// A template for a type without type qualifiers
+template <typename Type>
+using RemoveRefAndConst = typename RemoveRefAndConstImpl<Type>::type;
+
+/// Helper class which provides a type only
+/// if `Type` and std::vector<void> name the same
+/// type (taking into account const/volatile qualifications).
+template <typename Type>
+struct ReduceVoidVector {
+  using type =
+      typename std::conditional<std::is_same<Type, std::vector<void>>::value,
+                                void, Type>::type;
+};
+
+/// A class for wrapping a type with std::function.
+template <typename Type>
+struct TypeToFunctionInputImpl {
+  using type = std::function<void(Type)>;
+};
+
+/// A class for wrapping a void type with std::function.
+template <>
+struct TypeToFunctionInputImpl<void> {
+  using type = std::function<void()>;
+};
+
+template <typename Type>
+/// An alias for a std::function wrapper around the `Type`.
+using TypeToFunctionInput = typename TypeToFunctionInputImpl<Type>::type;
+
+template <typename Class, typename ExecutionContext, typename Arg>
+/// A const function pointer with two parameters used to declare a type.
+Arg SecondArgType(void (Class::*)(ExecutionContext, Arg) const);
+
+template <typename Class, typename ExecutionContext, typename Arg>
+/// A function pointer with two parameters used to declare a type.
+Arg SecondArgType(void (Class::*)(ExecutionContext, Arg));
+
+template <typename Class, typename Some, typename ExecutionContext,
+          typename Arg>
+/// A const function pointer with three parameters used to declare a type.
+Arg ThirdArgType(void (Class::*)(Some, ExecutionContext, Arg) const);
+
+template <typename Class, typename Some, typename ExecutionContext,
+          typename Arg>
+/// A function pointer with three parameters used to declare a type.
+Arg ThirdArgType(void (Class::*)(Some, ExecutionContext, Arg));
+
+/// A function declaration with std::function<void> parameter.
+void FuncArgType(std::function<void()>);
+
+/// A template function declaration with std::function<Arg> parameter.
+template <typename Arg>
+Arg FuncArgType(std::function<void(Arg)>);
+
+template <typename Callable>
+/// Declares the type of a callable with two parameters.
+struct AsyncResultTypeImpl {
+  using FirstArgType =
+      RemoveRefAndConst<decltype(SecondArgType(&Callable::operator()))>;
+  using type = RemoveRefAndConst<decltype(FuncArgType(FirstArgType()))>;
+};
+
+template <typename Callable>
+/// An alias for the `Type` from callable object with two parameters.
+using AsyncResultType = typename AsyncResultTypeImpl<Callable>::type;
+
+template <typename Callable>
+/// Declares the type of a callable with three parameters.
+struct DeducedTypeImpl {
+  using ThirdArgTypeParam =
+      RemoveRefAndConst<decltype(ThirdArgType(&Callable::operator()))>;
+  using type = RemoveRefAndConst<decltype(FuncArgType(ThirdArgTypeParam()))>;
+};
+
+template <typename Callable>
+/// An alias for the `Type` from callable object with three parameters.
+using DeducedType = typename DeducedTypeImpl<Callable>::type;
+
+/// An interface for untyped pointer which allows
+/// to convert any data type to a void pointer.
+struct UntypedSmartPointer {
+  virtual void* Get() const = 0;
+  virtual ~UntypedSmartPointer() = default;
+};
+
+/// An implementation of `UntypedSmartPointer` interface.
+template <typename SmartPointer>
+struct TypedSmartPointer : UntypedSmartPointer {
+  /// A move contructor.
+  explicit TypedSmartPointer(SmartPointer&& pointer)
+      : pointer_(std::move(pointer)) {}
+
+  /// Method converts data to a void pointer.
+  void* Get() const override { return static_cast<void*>(pointer_.get()); }
+
+  SmartPointer pointer_;
+};
+
+/// A function wraps a void pointer with a unique pointer.
+template <typename SmartPointer>
+inline std::unique_ptr<UntypedSmartPointer> MakeUntypedUnique(
+    SmartPointer&& ptr) {
+  return std::make_unique<TypedSmartPointer<SmartPointer>>(std::move(ptr));
+}
+
+}  // namespace internal
+}  // namespace thread
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/thread/Continuation.cpp
+++ b/olp-cpp-sdk-core/src/thread/Continuation.cpp
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/core/thread/Continuation.h>
+
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <utility>
+
+#include <olp/core/client/CancellationToken.h>
+#include <olp/core/thread/SyncQueue.h>
+#include <olp/core/thread/TaskScheduler.h>
+
+namespace olp {
+namespace thread {
+
+using internal::ContinuationImpl;
+
+namespace internal {
+
+class Processor {
+  using Task = std::function<void()>;
+  struct ProcessorInternal;
+
+ public:
+  Processor(ExecutionContext execution_context,
+            std::deque<ContinuationImpl::ContinuationTask> tasks,
+            ContinuationImpl::FinalCallbackType final_callback)
+      : processor_(std::make_shared<ProcessorInternal>(
+            std::move(tasks), std::move(final_callback),
+            std::move(execution_context))) {}
+
+  // returns false when the current task is over and the queue should proceed
+  // further, true means do nothing
+  bool ProcessAsyncTask(std::shared_ptr<ProcessorInternal> process,
+                        std::pair<ContinuationImpl::AsyncTaskType,
+                                  ContinuationImpl::TaskType>& task) {
+    auto& current_task = task;
+    if (!current_task.first) {
+      // go to the next task in the queue to finilize the task
+      process->tasks_.pop_front();
+      return false;
+    }
+
+    auto callback = [=](void* arg) mutable {
+      // limit lifetime of the context shared_ptr to the function scope, for
+      // extra safety in case user's async function stores callback somewhere
+      // for forever.
+      auto context = process;
+      // save the arg (the identity function)
+      context->last_output_ = current_task.second(arg);
+
+      // re-enter ProcessAsyncTask() in order to finilize the task.
+      if (context->last_output_) {
+        ProcessNextTask(context);
+      }
+    };
+
+    auto func = std::move(current_task.first);
+    current_task.first = nullptr;
+    func(process->LastOutput(), std::move(callback));
+
+    return true;
+  }
+
+  void FinishQueueExecution(const std::shared_ptr<ProcessorInternal>& context) {
+    if (context->final_callback_) {
+      // the final execution context, all tasks are done or the execution
+      // is cancelled
+      context->final_callback_(context->LastOutput(), context->IsCancelled());
+      context->final_callback_ = nullptr;
+      context->tasks_.clear();
+    }
+  }
+
+  // the function is called iteratively for the same ExecutionContext until all
+  // tasks are processed
+  void ProcessNextTask(const std::shared_ptr<ProcessorInternal>& context) {
+    if (!context->tasks_.empty() && !context->IsCancelled()) {
+      // run the task
+      auto& task = context->tasks_.front();
+      if (ProcessAsyncTask(context, task)) {
+        return;
+      }
+    }
+
+    if (context->tasks_.empty() || context->IsCancelled()) {
+      FinishQueueExecution(context);
+    } else {
+      auto task_to_execute = CreateFollowingTask(context);
+      task_to_execute();
+    }
+  }
+
+  // creates a task for execution by TaskContinuation
+  Task CreateFollowingTask(const std::shared_ptr<ProcessorInternal>& context) {
+    return [this, context] { ProcessNextTask(context); };
+  }
+
+  // starts the first task in a chain
+  void Start() {
+    auto current_task_queue_element = CreateFollowingTask(processor_);
+    current_task_queue_element();
+  }
+
+ private:
+  struct ProcessorInternal {
+    // a chain of tasks to execute
+    std::deque<ContinuationImpl::ContinuationTask> tasks_;
+
+    // a callback is being be executed at the end of the queue
+    ContinuationImpl::FinalCallbackType final_callback_;
+
+    // the result of the previous task, used as an input for the current task
+    ContinuationImpl::OutResultType last_output_;
+
+    // the public execution context provides functionality to cancel or finish
+    // an execution
+    ExecutionContext public_execution_context_;
+
+    ProcessorInternal(std::deque<ContinuationImpl::ContinuationTask> tasks,
+                      ContinuationImpl::FinalCallbackType&& final_callback,
+                      ExecutionContext execution_context)
+        : tasks_(std::move(tasks)),
+          final_callback_(std::move(final_callback)),
+          public_execution_context_(execution_context) {}
+
+    // checks whether the Continuation is cancelled
+    bool IsCancelled() const { return public_execution_context_.Cancelled(); }
+
+    const ExecutionContext& GetExecutionContext() {
+      return public_execution_context_;
+    }
+
+    // An input argument used by the current task in the queue, it's the result
+    // of the previous task
+    void* LastOutput() const {
+      return last_output_ ? last_output_->Get() : nullptr;
+    }
+  };
+
+  std::shared_ptr<TaskScheduler> task_scheduler_;
+  std::shared_ptr<ProcessorInternal> processor_;
+};
+
+ContinuationImpl::ContinuationImpl(
+    std::shared_ptr<TaskScheduler> task_scheduler, ExecutionContext context,
+    ContinuationTask task)
+    : task_scheduler_(std::move(task_scheduler)), execution_context_(context) {
+  if (change_allowed) {
+    tasks_.push_back(std::move(task));
+  }
+}
+
+ContinuationImpl ContinuationImpl::Then(ContinuationTask task) {
+  if (change_allowed) {
+    tasks_.push_back(std::move(task));
+  }
+  return *this;
+}
+
+void ContinuationImpl::Run(FinalCallbackType callback) {
+  if (change_allowed) {
+    change_allowed = false;
+    task_scheduler_->ScheduleTask([this, callback]() {
+      Processor processor(execution_context_, std::move(tasks_),
+                          std::move(callback));
+      processor.Start();
+    });
+  }
+}
+
+const ExecutionContext& ContinuationImpl::GetExecutionContext() const {
+  return execution_context_;
+}
+
+const client::CancellationContext& ContinuationImpl::GetContext() const {
+  return execution_context_.GetContext();
+}
+
+bool ContinuationImpl::Cancelled() const {
+  return execution_context_.Cancelled();
+}
+
+void ContinuationImpl::SetFailedCallback(FailedCallback callback) {
+  if (change_allowed) {
+    execution_context_.SetFailedCallback(std::move(callback));
+  }
+}
+
+void ContinuationImpl::Clear() {
+  if (change_allowed) {
+    tasks_.clear();
+    change_allowed = false;
+  }
+}
+
+}  // namespace internal
+}  // namespace thread
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/thread/ExecutionContext.cpp
+++ b/olp-cpp-sdk-core/src/thread/ExecutionContext.cpp
@@ -44,7 +44,7 @@ class ExecutionContext::ExecutionContextImpl {
     failed_callback_ = std::move(callback);
   }
 
-  client::CancellationContext GetContext() const { return context_; }
+  const client::CancellationContext& GetContext() const { return context_; }
 
  private:
   client::CancellationContext context_;
@@ -71,7 +71,7 @@ void ExecutionContext::SetFailedCallback(FailedCallback callback) {
   impl_->SetFailedCallback(std::move(callback));
 }
 
-client::CancellationContext ExecutionContext::GetContext() const {
+const client::CancellationContext& ExecutionContext::GetContext() const {
   return impl_->GetContext();
 }
 

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ set(OLP_CPP_SDK_CORE_TESTS_SOURCES
     ./logging/MessageFormatterTest.cpp
     ./logging/MockAppender.cpp
 
+    ./thread/ContinuationTest.cpp
     ./thread/ExecutionContextTest.cpp
     ./thread/PriorityQueueExtendedTest.cpp
     ./thread/SyncQueueTest.cpp

--- a/olp-cpp-sdk-core/tests/thread/ContinuationTest.cpp
+++ b/olp-cpp-sdk-core/tests/thread/ContinuationTest.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <future>
+
+#include <gtest/gtest.h>
+
+#include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/thread/Continuation.h>
+#include <olp/core/thread/ExecutionContext.h>
+
+namespace {
+template <typename ResultType>
+using Response = olp::client::ApiResponse<ResultType, olp::client::ApiError>;
+
+class ContinuationTest : public testing::Test {
+ public:
+  void SetUp() override {
+    task_scheduler =
+        olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler();
+  }
+
+ protected:
+  template <typename Callable>
+  olp::thread::Continuation<olp::thread::internal::AsyncResultType<Callable>>
+  Create(Callable func) {
+    using NewResultType = olp::thread::internal::AsyncResultType<Callable>;
+
+    using Function = olp::thread::internal::TypeToFunctionInput<NewResultType>;
+    return {std::move(task_scheduler), std::move(execution_context),
+            std::function<void(olp::thread::ExecutionContext, Function)>(
+                std::move(func))};
+  }
+
+  std::shared_ptr<olp::thread::TaskScheduler> task_scheduler;
+  olp::thread::ExecutionContext execution_context;
+};
+
+TEST_F(ContinuationTest, MultipleThen) {
+  std::promise<int> promise;
+  auto future = promise.get_future();
+
+  auto continuation = Create([](olp::thread::ExecutionContext,
+                                std::function<void(int)> next) { next(1); })
+                          .Then([](olp::thread::ExecutionContext, int,
+                                   std::function<void(int)> next) { next(2); })
+                          .Finally([&promise](Response<int> response) {
+                            promise.set_value(response.GetResult());
+                          });
+  continuation.Run();
+
+  EXPECT_EQ(future.get(), 2);
+}
+
+TEST_F(ContinuationTest, CancelBeforeRun) {
+  std::promise<olp::client::ApiError> promise;
+  auto future = promise.get_future();
+
+  auto continuation = Create([](olp::thread::ExecutionContext,
+                                std::function<void(int)> next) { next(3); })
+                          .Then([](olp::thread::ExecutionContext, int,
+                                   std::function<void(int)> next) { next(3); })
+                          .Finally([&promise](Response<int> response) {
+                            promise.set_value(response.GetError());
+                          });
+
+  continuation.CancelToken().Cancel();
+  continuation.Run();
+
+  EXPECT_EQ(future.get().GetErrorCode(), olp::client::ErrorCode::Cancelled);
+}
+
+TEST_F(ContinuationTest, CancelAfterRun) {
+  std::promise<olp::client::ApiError> promise;
+  auto future = promise.get_future();
+
+  auto continuation = Create([](olp::thread::ExecutionContext,
+                                std::function<void(int)> next) { next(3); })
+                          .Then([](olp::thread::ExecutionContext, int,
+                                   std::function<void(int)> next) { next(3); })
+                          .Finally([&promise](Response<int> response) {
+                            promise.set_value(response.GetError());
+                          });
+
+  continuation.Run();
+  continuation.CancelToken().Cancel();
+
+  EXPECT_EQ(future.get().GetErrorCode(), olp::client::ErrorCode::Cancelled);
+}
+
+TEST_F(ContinuationTest, CancelExecution) {
+  std::promise<void> promise;
+  auto future = promise.get_future();
+
+  olp::client::ApiResponse<olp::client::HttpResponse, olp::client::ApiError>
+      result;
+
+  auto cont =
+      Create([](olp::thread::ExecutionContext, std::function<void(int)> next) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        next(1);
+      })
+          .Finally([&promise, &result](
+                       olp::client::ApiResponse<int, olp::client::ApiError>
+                           response) {
+            result = response.GetError();
+            promise.set_value();
+          });
+
+  cont.Run();
+  std::this_thread::sleep_for(
+      std::chrono::milliseconds(50));  // simulate some delay
+
+  cont.CancelToken().Cancel();
+
+  EXPECT_EQ(future.wait_for(std::chrono::milliseconds(1000)),
+            std::future_status::ready);
+
+  future.get();
+
+  EXPECT_FALSE(result.IsSuccessful());
+  EXPECT_EQ(result.GetError().GetHttpStatusCode(),
+            static_cast<int>(olp::http::ErrorCode::CANCELLED_ERROR));
+}
+
+TEST_F(ContinuationTest, FinallyNotSet) {
+  auto cont =
+      Create([](olp::thread::ExecutionContext, std::function<void(int)>) {});
+
+  cont.Run();
+}
+
+TEST_F(ContinuationTest, CancelWithFinallyNotSet) {
+  auto cont =
+      Create([](olp::thread::ExecutionContext, std::function<void(int)>) {});
+
+  cont.CancelToken().Cancel();
+  cont.Run();
+}
+
+TEST_F(ContinuationTest, Failed) {
+  std::promise<olp::client::ApiError> api_error_promise;
+  auto future = api_error_promise.get_future();
+
+  auto cont = Create([](olp::thread::ExecutionContext context,
+                        std::function<void(int)>) {
+                context.SetError(olp::client::ApiError::NetworkConnection());
+              }).Finally([&api_error_promise](Response<int> response) {
+    api_error_promise.set_value(response.GetError());
+  });
+
+  cont.Run();
+  auto result = future.get();
+
+  EXPECT_EQ(result.GetErrorCode(), olp::client::ErrorCode::NetworkConnection);
+}
+
+TEST_F(ContinuationTest, NoCrashAfterCallingMethodsAfterRun) {
+  std::promise<olp::client::ApiError> api_error_promise;
+  auto future = api_error_promise.get_future();
+
+  auto cont = Create([](olp::thread::ExecutionContext context,
+                        std::function<void(int)>) {
+                context.SetError(olp::client::ApiError::NetworkConnection());
+              }).Finally([&api_error_promise](Response<int> response) {
+    api_error_promise.set_value(response.GetError());
+  });
+
+  cont.Run();
+  auto result = future.get();
+
+  EXPECT_EQ(result.GetErrorCode(), olp::client::ErrorCode::NetworkConnection);
+
+  cont.Then([](olp::thread::ExecutionContext, int, std::function<void(int)>) {
+        FAIL();
+      })
+      .Finally([](Response<int>) { FAIL(); });
+  cont.Run();
+}
+
+}  // namespace


### PR DESCRIPTION
Add Continuation template classes and implementation
which provide functionality to create a chain of tasks,
and execute tasks.
Add continuation unit tests.

Relates-To: OLPEDGE-2077

Signed-off-by: Yevhenii Dudnyk <ext-yevhenii.dudnyk@here.com>