### PR TITLE
Add libcurl support for android.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ option(OLP_SDK_MSVC_PARALLEL_BUILD_ENABLE "Enable parallel build on MSVC" ON)
 option(OLP_SDK_DISABLE_DEBUG_LOGGING "Disable debug and trace level logging" OFF)
 option(OLP_SDK_ENABLE_DEFAULT_CACHE "Enable default cache implementation based on LevelDB" ON)
 option(OLP_SDK_ENABLE_DEFAULT_CACHE_LMDB "Enable default cache implementation based on LMDB" OFF)
+option(OLP_SDK_ENABLE_ANDROID_CURL "Enable curl based network layer for Android" OFF)
 
 # C++ standard version. Minimum supported version is 11.
 set(CMAKE_CXX_STANDARD 11)
@@ -76,6 +77,7 @@ if (OLP_SDK_BUILD_EXTERNAL_DEPS)
     set(EXTERNAL_BINARY_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/install)
     add_subdirectory(external)
     list(APPEND CMAKE_PREFIX_PATH ${EXTERNAL_BINARY_INSTALL_DIR})
+    list(APPEND CMAKE_FIND_ROOT_PATH "${EXTERNAL_BINARY_INSTALL_DIR}/")
 endif()
 
 # Add the sdks

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ cmake --build . --target docs
 | `OLP_SDK_DISABLE_DEBUG_LOGGING`| Defaults to `OFF`. If enabled, the debug and trace level log messages are not printed. |
 | `OLP_SDK_ENABLE_DEFAULT_CACHE `| Defaults to `ON`. If enabled, the default cache implementation based on the LevelDB backend is enabled. |
 | `OLP_SDK_ENABLE_DEFAULT_CACHE_LMDB `| Defaults to `OFF`. If enabled, the default cache implementation based on the LMDB backend is enabled. |
+| `OLP_SDK_ENABLE_ANDROID_CURL`| Defaults to `OFF`. If enabled, libcurl will be used instead of the Android native HTTP client. |
 
 ## Use the SDK
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -34,7 +34,8 @@ elseif(ANDROID)
     include(./cmake/gen_android_example.cmake.in)
 
     set(OLP_SDK_EXAMPLE_PACKAGE_NAME "dataservice_example")
-    set(OLP_SDK_EXAMPLE_PACKAGE_JNI_NAME "dataservice_example")
+    # If JNI function contains underscore symbol, java will search for "_1" instead
+    set(OLP_SDK_EXAMPLE_PACKAGE_JNI_NAME "dataservice_1example")
     gen_android_example_application(${OLP_SDK_DATASERVICE_EXAMPLE_TARGET}
                                     ${OLP_SDK_EXAMPLE_PACKAGE_NAME}
                                     ${OLP_SDK_EXAMPLE_PACKAGE_JNI_NAME}

--- a/examples/android/app/CMakeLists.txt.in
+++ b/examples/android/app/CMakeLists.txt.in
@@ -24,7 +24,7 @@ if (DEFINED OLP_SDK_HTTP_CLIENT_JAR)
     if (NOT EXISTS "${OLP_SDK_HTTP_CLIENT_JAR_FULL_PATH}")
         message(FATAL_ERROR "Can't find OlpHttpClient.jar - the path ${OLP_SDK_HTTP_CLIENT_JAR_FULL_PATH} is invalid!")
     endif()
-else()
+elseif(NOT OLP_SDK_ENABLE_ANDROID_CURL)
     message(FATAL_ERROR "The OLP_SDK_HTTP_CLIENT_JAR variable is not defined."
                         "Please, specify this variable with the path to the built OlpHttpClient.jar.")
 endif()
@@ -52,15 +52,17 @@ add_library(@OLP_SDK_EXAMPLE_TARGET_NAME@ SHARED
         ${CMAKE_CURRENT_SOURCE_DIR}/src/main/cpp/ReadExample.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/main/cpp/MainActivityNative.cpp)
 
-# Find and copy the OlpHttpClient.jar into the corresponding libs directory
-get_filename_component(OLP_SDK_HTTP_CLIENT_JAR_NAME ${OLP_SDK_HTTP_CLIENT_JAR_FULL_PATH} NAME)
+if (NOT OLP_SDK_ENABLE_ANDROID_CURL)
+    # Find and copy the OlpHttpClient.jar into the corresponding libs directory
+    get_filename_component(OLP_SDK_HTTP_CLIENT_JAR_NAME ${OLP_SDK_HTTP_CLIENT_JAR_FULL_PATH} NAME)
 
-add_custom_command(
-    TARGET @OLP_SDK_EXAMPLE_TARGET_NAME@ POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${OLP_SDK_HTTP_CLIENT_JAR_FULL_PATH}
-        ${CMAKE_CURRENT_SOURCE_DIR}/libs/${OLP_SDK_HTTP_CLIENT_JAR_NAME}
-)
+    add_custom_command(
+        TARGET @OLP_SDK_EXAMPLE_TARGET_NAME@ POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${OLP_SDK_HTTP_CLIENT_JAR_FULL_PATH}
+            ${CMAKE_CURRENT_SOURCE_DIR}/libs/${OLP_SDK_HTTP_CLIENT_JAR_NAME}
+    )
+endif()
 
 # In case when the OLP libraries are built as shared libraries,
 # it is required to copy those libraries into the example's apk archive,

--- a/examples/android/app/build.gradle.in
+++ b/examples/android/app/build.gradle.in
@@ -36,7 +36,9 @@ android {
                         "-DBOOST_ROOT=@BOOST_ROOT@",
                         "-DBoost_INCLUDE_DIR=@BOOST_ROOT@",
                         "-DBoost_LIBRARY_DIR=@BOOST_ROOT@",
-                        "-DANDROID_PLATFORM=@ANDROID_PLATFORM@"
+                        "-DANDROID_PLATFORM=@ANDROID_PLATFORM@",
+                        // to know what network backend used
+                        "-DOLP_SDK_ENABLE_ANDROID_CURL=@OLP_SDK_ENABLE_ANDROID_CURL@"
 
                 cppFlags "-std=c++11"
                 targets "@OLP_SDK_EXAMPLE_TARGET_NAME@"

--- a/examples/cmake/gen_android_example.cmake.in
+++ b/examples/cmake/gen_android_example.cmake.in
@@ -44,17 +44,18 @@ function(gen_android_example_application
         set(OLP_SDK_EXAMPLE_ANDROID_TOOLCHAIN_FILE "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
     endif()
 
-    set(OLP_SDK_EXAMPLE_HTTP_CLIENT_JAR "-DOLP_SDK_HTTP_CLIENT_JAR='full path to the OlpHttpClient.jar in the <olp-sdk-build-folder>/olp-cpp-sdk-core/ folder'")
-    # Try to find the path to the built OlpHttpClient.jar archive
-    if (DEFINED olp-cpp-sdk-core_BINARY_DIR)
-        set(OLP_SDK_HTTP_CLIENT_PATH ${olp-cpp-sdk-core_BINARY_DIR})
-        # User can change the install path of the OlpHttpClient.jar via CMAKE_JAVA_TARGET_OUTPUT_DIR variable
-        if (DEFINED CMAKE_JAVA_TARGET_OUTPUT_DIR)
-            set(OLP_SDK_HTTP_CLIENT_PATH ${CMAKE_JAVA_TARGET_OUTPUT_DIR})
+    if(NOT OLP_SDK_ENABLE_ANDROID_CURL)
+        set(OLP_SDK_EXAMPLE_HTTP_CLIENT_JAR "-DOLP_SDK_HTTP_CLIENT_JAR='full path to the OlpHttpClient.jar in the <olp-sdk-build-folder>/olp-cpp-sdk-core/ folder'")
+        # Try to find the path to the built OlpHttpClient.jar archive
+        if (DEFINED olp-cpp-sdk-core_BINARY_DIR)
+            set(OLP_SDK_HTTP_CLIENT_PATH ${olp-cpp-sdk-core_BINARY_DIR})
+            # User can change the install path of the OlpHttpClient.jar via CMAKE_JAVA_TARGET_OUTPUT_DIR variable
+            if (DEFINED CMAKE_JAVA_TARGET_OUTPUT_DIR)
+                set(OLP_SDK_HTTP_CLIENT_PATH ${CMAKE_JAVA_TARGET_OUTPUT_DIR})
+            endif()
+            set(OLP_SDK_EXAMPLE_HTTP_CLIENT_JAR "-DOLP_SDK_HTTP_CLIENT_JAR=${OLP_SDK_HTTP_CLIENT_PATH}/OlpHttpClient.jar")
         endif()
-        set(OLP_SDK_EXAMPLE_HTTP_CLIENT_JAR "-DOLP_SDK_HTTP_CLIENT_JAR=${OLP_SDK_HTTP_CLIENT_PATH}/OlpHttpClient.jar")
     endif()
-
 
     set(OLP_SDK_EXAMPLE_LEVELDB_DIR "-Dleveldb_DIR='path to the directory which contains LevelDB cmake config files'")
     if (DEFINED leveldb_DIR)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -57,6 +57,15 @@ set(OLP_SDK_CPP_BOOST_TAG "boost-1.72.0")
 set(OLP_SDK_CPP_LMDB_URL "https://github.com/LMDB/lmdb.git")
 set(OLP_SDK_CPP_LMDB_TAG "LMDB_0.9.29")
 
+set(OLP_SDK_CPP_ZLIB_URL "https://sdk.amazonaws.com/cpp/builds/zlib-1.2.11.tar.gz")
+set(OLP_SDK_CPP_ZLIB_HASH "SHA256=c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1")
+
+set(OLP_SDK_CPP_OPENSSL_URL "https://github.com/openssl/openssl.git")
+set(OLP_SDK_CPP_OPENSSL_TAG "OpenSSL_1_1_1g")
+
+set(OLP_SDK_CPP_CURL_URL "https://github.com/bagder/curl.git")
+set(OLP_SDK_CPP_CURL_TAG "curl-7_52_1")
+
 # Add external projects
 find_package(GTest QUIET)
 if(NOT TARGET GTest AND NOT GTest_FOUND)
@@ -93,4 +102,14 @@ if(NOT TARGET Boost AND NOT Boost_FOUND)
     set(BOOST_ROOT ${EXTERNAL_BOOST_ROOT} PARENT_SCOPE)
     set(Boost_INCLUDE_DIR ${EXTERNAL_BOOST_ROOT_INCLUDE} PARENT_SCOPE)
     set(Boost_LIBRARY_DIR ${EXTERNAL_BOOST_ROOT_LIB} PARENT_SCOPE)
+endif()
+
+if(OLP_SDK_ENABLE_ANDROID_CURL)
+    find_package(CURL 7.47.0 QUIET)
+    if(NOT TARGET CURL AND NOT CURL_FOUND)
+        add_subdirectory(curl)
+        set(CURL_DIR ${EXTERNAL_CURL_DIR} PARENT_SCOPE)
+        set(CURL_INCLUDE_DIR ${EXTERNAL_CURL_INCLUDE_DIR} PARENT_SCOPE)
+        set(CURL_LIBRARY ${EXTERNAL_BINARY_INSTALL_DIR}/lib/libcurl.so PARENT_SCOPE)
+    endif()
 endif()

--- a/external/curl/CMakeLists.txt
+++ b/external/curl/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright (C) 2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+
+# Download and unpack curl at configure time
+configure_file(CMakeLists.txt.curl.in download/CMakeLists.txt)
+
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" . ${COMMON_GENERATE_FLAGS}
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/download)
+if(result)
+  message(FATAL_ERROR "CMake step for curl failed: ${result}")
+endif()
+
+# Copy CMakeLists
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/CurlAndroidCrossCompile.cmake
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/config/curl)
+
+execute_process(COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_BUILD_TYPE}
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/download)
+if(result)
+  message(FATAL_ERROR "Build step for curl failed: ${result}")
+endif()
+
+# Provide the dir to the curl cmake configuration files
+set(EXTERNAL_CURL_DIR ${EXTERNAL_BINARY_INSTALL_DIR}/lib/cmake/curl PARENT_SCOPE)
+set(EXTERNAL_CURL_INCLUDE_DIR ${EXTERNAL_BINARY_INSTALL_DIR}/include PARENT_SCOPE)

--- a/external/curl/CMakeLists.txt.curl.in
+++ b/external/curl/CMakeLists.txt.curl.in
@@ -1,0 +1,86 @@
+# Copyright (C) 2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required(VERSION 3.15)
+
+project(curl-download NONE)
+
+include(ExternalProject)
+
+find_package(zlib QUIET)
+if(NOT TARGET zlib AND NOT ZLIB_FOUND)
+    ExternalProject_Add(zlib
+        SOURCE_DIR ${ZLIB_SOURCE_DIR}
+        URL             @OLP_SDK_CPP_ZLIB_URL@
+        URL_HASH        @OLP_SDK_CPP_ZLIB_HASH@
+        INSTALL_DIR       "@EXTERNAL_BINARY_INSTALL_DIR@"
+        UPDATE_COMMAND ""
+        PATCH_COMMAND ""
+        CMAKE_ARGS
+        @COMMON_PLATFORM_FLAGS@
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        )
+endif()
+
+#find_package(OpenSSL QUIET)
+#message(FATAL_ERROR OPENSSL_FOUND=${OPENSSL_FOUND} " " OpenSSL=${OpenSSL})
+
+if(NOT TARGET OpenSSL AND NOT OPENSSL_FOUND)
+    ExternalProject_Add(OpenSSL
+        SOURCE_DIR ${OPENSSL_SOURCE_DIR}
+        GIT_REPOSITORY @OLP_SDK_CPP_OPENSSL_URL@
+        GIT_TAG        @OLP_SDK_CPP_OPENSSL_TAG@
+        GIT_SHALLOW    1
+        INSTALL_DIR    "@EXTERNAL_BINARY_INSTALL_DIR@"
+        UPDATE_COMMAND ""
+        # Add our own cmake files as OpenSSL doesn't provide any.
+        PATCH_COMMAND "${CMAKE_COMMAND}" -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/openssl" "${CMAKE_CURRENT_BINARY_DIR}/download/OpenSSL-prefix/src/OpenSSL"
+              # Make openssl 1.1.1 to us MD5 hash instead of SHA-1 for certificate file names.
+              COMMAND sed -i "s/h = X509_NAME_hash(name)/h = X509_NAME_hash_old(name)/g" ${CMAKE_CURRENT_BINARY_DIR}/download/OpenSSL-prefix/src/OpenSSL/crypto/x509/by_dir.c
+        CMAKE_ARGS
+        @COMMON_PLATFORM_FLAGS@
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        )
+endif()
+
+ExternalProject_Add(CURL
+    GIT_REPOSITORY  @OLP_SDK_CPP_CURL_URL@
+    GIT_TAG         @OLP_SDK_CPP_CURL_TAG@
+    GIT_SHALLOW     1
+    INSTALL_DIR    "@EXTERNAL_BINARY_INSTALL_DIR@"
+
+    UPDATE_COMMAND ""
+    # Curl use try_compile() for internal checks, 'LINK_LIBRARIES' will make it work with cmake import/export targets.
+    PATCH_COMMAND sed -i "/CMake.CurlTests.c/a LINK_LIBRARIES crypto ssl" "${CMAKE_CURRENT_BINARY_DIR}/download/CURL-prefix/src/CURL/CMake/Macros.cmake"
+    CMAKE_ARGS
+    @COMMON_PLATFORM_FLAGS@
+    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    -C ${CMAKE_CURRENT_BINARY_DIR}/config/curl/CurlAndroidCrossCompile.cmake
+
+    -DCMAKE_FIND_ROOT_PATH=${EXTERNAL_BINARY_INSTALL_DIR}
+    -DCMAKE_SYSTEM_PREFIX_PATH=<INSTALL_DIR>
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+
+    -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=TRUE
+    -DBUILD_CURL_EXE=OFF
+    -DBUILD_CURL_TESTS=OFF
+    -DCURL_ZLIB=ON
+    )
+
+ExternalProject_Add_StepDependencies(CURL build zlib OpenSSL)

--- a/external/curl/CurlAndroidCrossCompile.cmake
+++ b/external/curl/CurlAndroidCrossCompile.cmake
@@ -1,0 +1,27 @@
+# Copyright (C) 2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+SET( HAVE_GLIBC_STRERROR_R 1 CACHE STRING "Result from TRY_RUN" FORCE)
+SET( HAVE_GLIBC_STRERROR_R__TRYRUN_OUTPUT "" CACHE STRING "Output from TRY_RUN" FORCE)
+
+SET( HAVE_POLL_FINE_EXITCODE 0 CACHE STRING "Result from TRY_RUN" FORCE )
+SET( HAVE_POLL_FINE_EXITCODE__TRYRUN_OUTPUT "" CACHE STRING "Output from TRY_RUN" FORCE)
+
+SET( HAVE_POSIX_STRERROR_R 0 CACHE STRING "Result from TRY_RUN" FORCE)
+SET( HAVE_POSIX_STRERROR_R__TRYRUN_OUTPUT "" CACHE STRING "Output from TRY_RUN" FORCE)
+SET( HAVE_POSIX_FALLOCATE 0 CACHE STRING "Result from TRY_RUN" FORCE)
+SET( HAVE_POSIX_FALLOCATE__TRYRUN_OUTPUT "" CACHE STRING "Output from TRY_RUN" FORCE)

--- a/external/curl/openssl/CMakeLists.txt
+++ b/external/curl/openssl/CMakeLists.txt
@@ -1,0 +1,251 @@
+# Based on original work by David Manura
+# Copyright (C) 2007-2012 LuaDist.
+# Copyright (C) 2013 Brian Sidebotham
+# Copyright (C) 2016-2019 Jean-Luc Barriere
+
+# Redistribution and use of this file is allowed according to the terms of the
+# MIT license.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+# Modified by Pushen to cross compile openssl 1.1.1g for Android:
+# 1. Remove c_rehash and apps.
+# 2. Hard code opensslconf.h, bn_conf.h and dso_conf.h for Android build.
+
+include(CMakePackageConfigHelpers)
+set( CMAKE_LEGACY_CYGWIN_WIN32 0 )
+project( openssl )
+cmake_minimum_required( VERSION 3.1.0 )
+
+set( CMAKE_DISABLE_SOURCE_CHANGES ON )
+set( CMAKE_DISABLE_IN_SOURCE_BUILD ON )
+
+set( CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" )
+
+# OpenSSL version detection imported from FindOpenSSL.cmake
+
+file( STRINGS "${PROJECT_SOURCE_DIR}/include/openssl/opensslv.h" openssl_version_str
+  REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])+.*" )
+
+function(from_hex HEX DEC)
+  string( TOUPPER "${HEX}" HEX )
+  set( _res 0 )
+  string( LENGTH "${HEX}" _strlen )
+
+  while( _strlen GREATER 0 )
+    math( EXPR _res "${_res} * 16" )
+    string( SUBSTRING "${HEX}" 0 1 NIBBLE )
+    string( SUBSTRING "${HEX}" 1 -1 HEX )
+    if( NIBBLE STREQUAL "A" )
+      math( EXPR _res "${_res} + 10" )
+    elseif( NIBBLE STREQUAL "B" )
+      math( EXPR _res "${_res} + 11" )
+    elseif( NIBBLE STREQUAL "C" )
+      math( EXPR _res "${_res} + 12" )
+    elseif( NIBBLE STREQUAL "D" )
+      math( EXPR _res "${_res} + 13" )
+    elseif( NIBBLE STREQUAL "E" )
+      math( EXPR _res "${_res} + 14" )
+    elseif( NIBBLE STREQUAL "F" )
+      math( EXPR _res "${_res} + 15" )
+    else()
+      math( EXPR _res "${_res} + ${NIBBLE}" )
+    endif()
+
+    string( LENGTH "${HEX}" _strlen )
+  endwhile()
+
+  set( ${DEC} ${_res} PARENT_SCOPE )
+endfunction()
+
+string( REGEX REPLACE "^.*OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F]).*$"
+  "\\1;\\2;\\3;\\4;\\5" OPENSSL_VERSION_LIST "${openssl_version_str}" )
+  list( GET OPENSSL_VERSION_LIST 0 OPENSSL_VERSION_MAJOR )
+  list( GET OPENSSL_VERSION_LIST 1 OPENSSL_VERSION_MINOR )
+  from_hex( "${OPENSSL_VERSION_MINOR}" OPENSSL_VERSION_MINOR )
+  list( GET OPENSSL_VERSION_LIST 2 OPENSSL_VERSION_FIX )
+  from_hex( "${OPENSSL_VERSION_FIX}" OPENSSL_VERSION_FIX )
+  list( GET OPENSSL_VERSION_LIST 3 OPENSSL_VERSION_PATCH )
+
+if( NOT OPENSSL_VERSION_PATCH STREQUAL "00" )
+  from_hex( "${OPENSSL_VERSION_PATCH}" _tmp )
+  # 96 is the ASCII code of 'a' minus 1
+  math( EXPR OPENSSL_VERSION_PATCH_ASCII "${_tmp} + 96" )
+  unset( _tmp )
+  string( ASCII "${OPENSSL_VERSION_PATCH_ASCII}" OPENSSL_VERSION_PATCH_STRING )
+endif()
+
+set( OPENSSL_VERSION "${OPENSSL_VERSION_MAJOR}.${OPENSSL_VERSION_MINOR}.${OPENSSL_VERSION_FIX}${OPENSSL_VERSION_PATCH_STRING}" )
+
+message( STATUS "OpenSSL version ${OPENSSL_VERSION}" )
+
+set( VERSION_MAJOR ${OPENSSL_VERSION_MAJOR} )
+set( VERSION_MINOR ${OPENSSL_VERSION_MINOR} )
+set( VERSION_PATCH ${OPENSSL_VERSION_FIX} )
+
+set( VERSION_STRING ${OPENSSL_VERSION} )
+set( LIB_VERSION ${VERSION_MAJOR}.${VERSION_MINOR} )
+set( LIB_SOVERSION ${VERSION_MAJOR}.${VERSION_MINOR} )
+
+add_definitions( -DOPENSSL_NO_ASM )
+add_definitions( -DOPENSSL_NO_STATIC_ENGINE )
+
+if( MSVC )
+  include( MSVCRuntime )
+  configure_msvc_runtime()
+  set( OPENSSLDIR "C:/ssl" )
+  set( ENGINESDIR "C:/engines-1.1" )
+else()
+  set( OPENSSLDIR "/usr/local/ssl" )
+  set( ENGINESDIR "/usr/local/engines-1.1" )
+endif()
+add_definitions( "-DOPENSSLDIR=\"${OPENSSLDIR}\"" )
+add_definitions( "-DENGINESDIR=\"${ENGINESDIR}\"" )
+
+if( APPLE )
+  set( CMAKE_MACOSX_RPATH ON )
+  add_definitions( -DOPENSSL_SYSNAME_MACOSX )
+endif()
+
+if( WIN32 )
+  set( CMAKE_SHARED_LIBRARY_PREFIX "lib" )
+  set( CMAKE_STATIC_LIBRARY_PREFIX "lib" )
+endif()
+
+if( WIN32 AND NOT CYGWIN )
+  add_definitions( -DOPENSSL_SYSNAME_WIN32 )
+  add_definitions( -DWIN32_LEAN_AND_MEAN )
+  add_definitions( -D_CRT_SECURE_NO_WARNINGS )
+
+  if(BUILD_SHARED_LIBS)
+    # avoid conflict: ocsp.h and wincrypt.h
+    add_definitions( -D_WINDLL )
+  endif()
+endif()
+
+if( MINGW )
+  set( CMAKE_SHARED_LINKER_FLAGS "-Wl,--export-all" )
+endif()
+
+include( CheckTypeSize )
+check_type_size( "long" LONG_INT )
+check_type_size( "long long" LONG_LONG_INT )
+check_type_size( "int" INT )
+if( HAVE_LONG_INT AND (${LONG_INT} EQUAL 8) )
+  set( SIXTY_FOUR_BIT_LONG ON )
+  set( BN_CONF "# define SIXTY_FOUR_BIT_LONG")
+elseif( HAVE_LONG_LONG_INT AND (${LONG_LONG_INT} EQUAL 8) )
+  set( SIXTY_FOUR_BIT ON )
+  set( BN_CONF "# define SIXTY_FOUR_BIT")
+else()
+  set( THIRTY_TWO_BIT ON )
+  set( BN_CONF "# define THIRTY_TWO_BIT")
+endif()
+
+if( MSVC OR ( WIN32 AND MINGW AND NOT CYGWIN ) )
+  set( OPENSSL_EXPORT_VAR_AS_FUNCTION 1 )
+endif()
+
+# Begin configure public headers
+file( COPY ${PROJECT_SOURCE_DIR}/include/internal DESTINATION include )
+file( COPY ${PROJECT_SOURCE_DIR}/include/crypto DESTINATION include )
+file( COPY ${PROJECT_SOURCE_DIR}/include/openssl DESTINATION include )
+
+set( CONF "
+# include <openssl/opensslv.h>
+# define OPENSSL_NO_RFC3779
+# define OPENSSL_NO_MD2
+# define OPENSSL_NO_RC5
+# define OPENSSL_THREADS
+# define OPENSSL_RAND_SEED_OS
+# define OPENSSL_NO_ASAN
+# define OPENSSL_NO_ASM
+# define OPENSSL_NO_CRYPTO_MDEBUG
+# define OPENSSL_NO_CRYPTO_MDEBUG_BACKTRACE
+# define OPENSSL_NO_DEVCRYPTOENG
+# define OPENSSL_NO_EC_NISTP_64_GCC_128
+# define OPENSSL_NO_EGD
+# define OPENSSL_NO_EXTERNAL_TESTS
+# define OPENSSL_NO_FUZZ_AFL
+# define OPENSSL_NO_FUZZ_LIBFUZZER
+# define OPENSSL_NO_HEARTBEATS
+# define OPENSSL_NO_MSAN
+# define OPENSSL_NO_SCTP
+# define OPENSSL_NO_SSL_TRACE
+# define OPENSSL_NO_SSL3
+# define OPENSSL_NO_SSL3_METHOD
+# define OPENSSL_NO_UBSAN
+# define OPENSSL_NO_UNIT_TEST
+# define OPENSSL_NO_WEAK_SSL_CIPHERS
+# define OPENSSL_NO_STATIC_ENGINE
+# define OPENSSL_NO_AFALGENG
+# define NON_EMPTY_TRANSLATION_UNIT static void *dummy = &dummy;
+# define DECLARE_DEPRECATED(f)   f __attribute__ ((deprecated));
+# define OPENSSL_MIN_API 0
+# define OPENSSL_API_COMPAT 0
+# define DEPRECATEDIN_1_2_0(f)   f;
+# define DEPRECATEDIN_1_1_0(f)   DECLARE_DEPRECATED(f)
+# define DEPRECATEDIN_1_0_0(f)   DECLARE_DEPRECATED(f)
+# define DEPRECATEDIN_0_9_8(f)   DECLARE_DEPRECATED(f)
+# define OPENSSL_FILE __FILE__
+# define OPENSSL_LINE __LINE__
+# undef OPENSSL_UNISTD
+# define OPENSSL_UNISTD <unistd.h>
+# undef OPENSSL_EXPORT_VAR_AS_FUNCTION
+# undef BN_LLONG
+# undef SIXTY_FOUR_BIT_LONG
+# undef SIXTY_FOUR_BIT
+# undef THIRTY_TWO_BIT
+${BN_CONF}
+# define RC4_INT unsigned int")
+
+file( WRITE ${PROJECT_BINARY_DIR}/opensslconf.h.cmake "${CONF}")
+
+configure_file( ${PROJECT_BINARY_DIR}/opensslconf.h.cmake
+  ${PROJECT_BINARY_DIR}/include/openssl/opensslconf.h )
+# End configure public headers
+
+add_subdirectory(crypto)
+add_subdirectory(ssl)
+
+file( GLOB PUBLIC_HEADERS "${PROJECT_BINARY_DIR}/include/openssl/*.h" )
+install( FILES ${PUBLIC_HEADERS} DESTINATION include/openssl )
+
+install( DIRECTORY doc DESTINATION share )
+
+configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/Config.cmake.in
+   "${CMAKE_CURRENT_BINARY_DIR}/OpenSSLConfig.cmake"
+   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/openssl
+ )
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/OpenSSLConfig.cmake"
+        DESTINATION lib/cmake/openssl)
+
+install(EXPORT OpenSSLTargets DESTINATION lib/cmake/openssl)
+
+# Generate the package target
+set( CPACK_GENERATOR ZIP TGZ )
+set( CPACK_PACKAGE_NAME "${CMAKE_PROJECT_NAME}" )
+set( CPACK_PACKAGE_VERSION_MAJOR ${VERSION_MAJOR} )
+set( CPACK_PACKAGE_VERSION_MINOR ${VERSION_MINOR} )
+set( CPACK_PACKAGE_VERSION_PATCH ${VERSION_PATCH} )
+set( CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}-${VERSION_STRING}" )
+
+include( CPack )

--- a/external/curl/openssl/cmake/Config.cmake.in
+++ b/external/curl/openssl/cmake/Config.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/OpenSSLTargets.cmake")
+check_required_components(OpenSSL)
+
+set(OPENSSL_FOUND TRUE)
+set(OPENSSL_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include)
+set(OPENSSL_LIBRARIES ssl crypto)
+set(OPENSSL_CRYPTO_LIBRARY crypto)
+set(OPENSSL_SSL_LIBRARY ssl)

--- a/external/curl/openssl/crypto/CMakeLists.txt
+++ b/external/curl/openssl/crypto/CMakeLists.txt
@@ -1,0 +1,286 @@
+# Based on original work by David Manura
+# Copyright (C) 2007-2012 LuaDist.
+# Copyright (C) 2013 Brian Sidebotham
+
+# Redistribution and use of this file is allowed according to the terms of the
+# MIT license.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+include( CMakeParseArguments )
+
+string(TIMESTAMP BUILDINF_DATE "%Y-%m-%d %H:%M:%S UTC" UTC)
+configure_file( buildinf.h.cmake buildinf.h )
+
+file(WRITE ${PROJECT_BINARY_DIR}/bn_conf.h.cmake "${BN_CONF}")
+
+file(WRITE ${PROJECT_BINARY_DIR}/dso_conf.h.cmake
+"#define DSO_EXTENSION \".so\"
+#define DSO_DLFCN
+#define HAVE_DLFCN_H")
+
+configure_file( ${PROJECT_BINARY_DIR}/bn_conf.h.cmake
+  ${PROJECT_BINARY_DIR}/include/crypto/bn_conf.h )
+configure_file( ${PROJECT_BINARY_DIR}/dso_conf.h.cmake
+  ${PROJECT_BINARY_DIR}/include/crypto/dso_conf.h )
+
+set( LIBSRC
+  cpt_err.c cryptlib.c ctype.c cversion.c ebcdic.c ex_data.c init.c mem.c mem_clr.c mem_dbg.c mem_sec.c o_dir.c o_fips.c
+  o_fopen.c o_init.c o_str.c o_time.c uid.c getenv.c )
+
+include_directories( BEFORE SYSTEM
+  modes ec/curve448 ec/curve448/arch_32
+  ${CMAKE_CURRENT_BINARY_DIR}/ # buildinf.h
+  ${PROJECT_BINARY_DIR}/include # public|crypto|internal
+  ${PROJECT_SOURCE_DIR}/ # e_os.h
+)
+
+if( BUILD_SHARED_LIBS )
+  add_definitions( -DOPENSSL_BUILD_SHLIBCRYPTO )
+endif()
+
+macro( add_submodule dir )
+    set( options )
+    set( oneValueArgs )
+    set( multiValueArgs EXHEADERS )
+    cmake_parse_arguments( add_submodule "" "" "${multiValueArgs}" ${ARGN} )
+
+    #message( STATUS "{dir} ${dir}" )
+    #message( STATUS "{add_submodule_UNPARSED_ARGUMENTS} ${add_submodule_UNPARSED_ARGUMENTS}" )
+    foreach( name ${add_submodule_UNPARSED_ARGUMENTS} )
+        set( LIBSRC ${LIBSRC} ${dir}/${name} )
+    endforeach( name )
+
+    #message( STATUS "{add_submodule_EXHEADERS} ${add_submodule_EXHEADERS}" )
+    foreach( name ${add_submodule_EXHEADERS} )
+        set( EXHEADERS ${EXHEADERS} ${name} )
+    endforeach( name )
+
+endmacro( add_submodule )
+
+add_submodule ( aes aes_cbc.c aes_cfb.c aes_core.c aes_ecb.c aes_ige.c aes_misc.c aes_ofb.c
+  aes_wrap.c )
+
+add_submodule ( aria aria.c )
+
+add_submodule ( asn1 a_bitstr.c a_d2i_fp.c a_digest.c a_dup.c a_gentm.c a_i2d_fp.c a_int.c
+  a_mbstr.c a_object.c a_octet.c a_print.c a_sign.c a_strex.c a_strnid.c a_time.c a_type.c
+  a_utctm.c a_utf8.c a_verify.c ameth_lib.c asn1_err.c asn1_gen.c asn1_item_list.c asn1_lib.c asn1_par.c
+  asn_mime.c asn_moid.c asn_mstbl.c asn_pack.c bio_asn1.c bio_ndef.c d2i_pr.c d2i_pu.c
+  evp_asn1.c f_int.c f_string.c i2d_pr.c i2d_pu.c n_pkey.c nsseq.c p5_pbe.c p5_pbev2.c
+  p5_scrypt.c p8_pkey.c t_bitst.c t_pkey.c t_spki.c tasn_dec.c tasn_enc.c tasn_fre.c
+  tasn_new.c tasn_prn.c tasn_scn.c tasn_typ.c tasn_utl.c x_algor.c x_bignum.c x_info.c
+  x_int64.c x_long.c x_pkey.c x_sig.c x_spki.c x_val.c )
+
+add_submodule ( async async.c async_err.c async_wait.c
+  arch/async_null.c arch/async_posix.c arch/async_win.c )
+
+add_submodule ( bf bf_cfb64.c bf_ecb.c bf_enc.c bf_ofb64.c bf_skey.c )
+
+add_submodule ( bio b_addr.c b_dump.c b_print.c b_sock.c b_sock2.c bf_buff.c #bf_lbuf.c
+  bf_nbio.c bf_null.c bio_cb.c bio_err.c bio_lib.c bio_meth.c bss_acpt.c bss_bio.c
+  bss_conn.c bss_dgram.c bss_fd.c bss_file.c bss_log.c bss_mem.c bss_null.c bss_sock.c )
+
+add_submodule ( blake2 blake2b.c blake2s.c m_blake2b.c m_blake2s.c )
+
+add_submodule ( bn bn_add.c bn_asm.c bn_blind.c bn_const.c bn_ctx.c bn_depr.c bn_dh.c
+  bn_div.c bn_err.c bn_exp.c bn_exp2.c bn_gcd.c bn_gf2m.c bn_intern.c bn_kron.c bn_lib.c
+  bn_mod.c bn_mont.c bn_mpi.c bn_mul.c bn_nist.c bn_prime.c bn_print.c bn_rand.c bn_recp.c
+  bn_shift.c bn_sqr.c bn_sqrt.c bn_srp.c bn_word.c bn_x931p.c rsaz_exp.c )
+
+add_submodule ( buffer buf_err.c buffer.c )
+
+add_submodule ( camellia camellia.c cmll_cbc.c cmll_cfb.c cmll_ctr.c cmll_ecb.c
+  cmll_misc.c cmll_ofb.c )
+
+add_submodule ( cast c_cfb64.c c_ecb.c c_enc.c c_ofb64.c c_skey.c )
+
+add_submodule ( chacha chacha_enc.c )
+
+add_submodule ( cmac cm_ameth.c cm_pmeth.c cmac.c )
+
+add_submodule ( cms cms_asn1.c cms_att.c cms_cd.c cms_dd.c cms_enc.c cms_env.c cms_err.c
+  cms_ess.c cms_io.c cms_kari.c cms_lib.c cms_pwri.c cms_sd.c cms_smime.c )
+
+add_submodule ( comp c_zlib.c comp_err.c comp_lib.c )
+
+add_submodule ( conf conf_api.c conf_def.c conf_err.c conf_lib.c conf_mall.c conf_mod.c
+  conf_sap.c conf_ssl.c )
+
+add_submodule ( ct ct_b64.c ct_err.c ct_log.c ct_oct.c ct_policy.c ct_prn.c ct_sct.c
+  ct_sct_ctx.c ct_vfy.c ct_x509v3.c )
+
+add_submodule ( des cbc_cksm.c cbc_enc.c cfb64ede.c cfb64enc.c cfb_enc.c des_enc.c
+  ecb3_enc.c ecb_enc.c fcrypt.c fcrypt_b.c ofb64ede.c ofb64enc.c ofb_enc.c pcbc_enc.c
+  qud_cksm.c rand_key.c set_key.c str2key.c xcbc_enc.c )
+
+add_submodule ( dh dh_ameth.c dh_asn1.c dh_check.c dh_depr.c dh_err.c dh_gen.c dh_kdf.c
+  dh_key.c dh_lib.c dh_meth.c dh_pmeth.c dh_prn.c dh_rfc5114.c dh_rfc7919.c )
+
+add_submodule ( dsa dsa_ameth.c dsa_asn1.c dsa_depr.c dsa_err.c dsa_gen.c dsa_key.c
+  dsa_lib.c dsa_meth.c dsa_ossl.c dsa_pmeth.c dsa_prn.c dsa_sign.c dsa_vrf.c )
+
+add_submodule ( dso dso_dl.c dso_dlfcn.c dso_err.c dso_lib.c dso_openssl.c dso_vms.c
+  dso_win32.c )
+
+add_submodule ( ec curve25519.c ec2_oct.c ec2_smpl.c ec_ameth.c ec_asn1.c
+  ec_check.c ec_curve.c ec_cvt.c ec_err.c ec_key.c ec_kmeth.c ec_lib.c ec_mult.c
+  ec_oct.c ec_pmeth.c ec_print.c ecdh_kdf.c ecdh_ossl.c ecdsa_ossl.c ecdsa_sign.c
+  ecdsa_vrf.c eck_prn.c ecp_mont.c ecp_nist.c ecp_nistp224.c ecp_nistp256.c ecp_nistp521.c
+  ecp_nistputil.c ecp_oct.c ecp_smpl.c ecx_meth.c
+  curve448/curve448.c curve448/curve448_tables.c curve448/eddsa.c curve448/f_generic.c
+  curve448/scalar.c curve448/arch_32/f_impl.c )
+
+add_submodule ( engine eng_all.c eng_cnf.c eng_ctrl.c eng_dyn.c eng_err.c
+  eng_fat.c eng_init.c eng_lib.c eng_list.c eng_openssl.c eng_pkey.c eng_rdrand.c
+  eng_table.c tb_asnmth.c tb_cipher.c tb_dh.c tb_digest.c tb_dsa.c tb_eckey.c tb_pkmeth.c
+  tb_rand.c tb_rsa.c )
+
+add_submodule ( err err.c err_all.c err_prn.c )
+
+add_submodule ( evp bio_b64.c bio_enc.c bio_md.c bio_ok.c c_allc.c c_alld.c cmeth_lib.c
+  digest.c e_aes.c e_aes_cbc_hmac_sha1.c e_aes_cbc_hmac_sha256.c e_aria.c e_bf.c e_camellia.c
+  e_cast.c e_chacha20_poly1305.c e_des.c e_des3.c e_idea.c e_null.c e_old.c e_rc2.c
+  e_rc4.c e_rc4_hmac_md5.c e_rc5.c e_sm4.c e_seed.c e_xcbc_d.c encode.c evp_cnf.c evp_enc.c
+  evp_err.c evp_key.c evp_lib.c evp_pbe.c evp_pkey.c m_md2.c m_md4.c m_md5.c m_md5_sha1.c
+  m_sha3.c m_mdc2.c m_null.c m_ripemd.c m_sha1.c m_sigver.c m_wp.c names.c p5_crpt.c p5_crpt2.c
+  p_dec.c p_enc.c p_lib.c p_open.c p_seal.c p_sign.c p_verify.c pbe_scrypt.c
+  pmeth_fn.c pmeth_gn.c pmeth_lib.c )
+
+add_submodule ( hmac hm_ameth.c hm_pmeth.c hmac.c )
+
+add_submodule ( idea i_cbc.c i_cfb64.c i_ecb.c i_ofb64.c i_skey.c )
+
+add_submodule ( kdf hkdf.c kdf_err.c scrypt.c tls1_prf.c )
+
+add_submodule ( lhash lh_stats.c lhash.c )
+
+add_submodule ( md4 md4_dgst.c md4_one.c )
+
+add_submodule ( md5 md5_dgst.c md5_one.c )
+
+add_submodule ( mdc2 mdc2_one.c mdc2dgst.c )
+
+add_submodule ( modes cbc128.c ccm128.c cfb128.c ctr128.c cts128.c gcm128.c ocb128.c
+  ofb128.c wrap128.c xts128.c )
+
+add_submodule ( objects o_names.c obj_dat.c obj_err.c obj_lib.c obj_xref.c )
+
+add_submodule ( ocsp ocsp_asn.c ocsp_cl.c ocsp_err.c ocsp_ext.c ocsp_ht.c ocsp_lib.c
+  ocsp_prn.c ocsp_srv.c ocsp_vfy.c v3_ocsp.c )
+
+add_submodule ( pem pem_all.c pem_err.c pem_info.c pem_lib.c pem_oth.c pem_pk8.c pem_pkey.c
+  pem_sign.c pem_x509.c pem_xaux.c pvkfmt.c )
+
+add_submodule ( pkcs12 p12_add.c p12_asn.c p12_attr.c p12_crpt.c p12_crt.c p12_decr.c
+  p12_init.c p12_key.c p12_kiss.c p12_mutl.c p12_npas.c p12_p8d.c p12_p8e.c p12_sbag.c
+  p12_utl.c pk12err.c )
+
+add_submodule ( pkcs7 bio_pk7.c pk7_asn1.c pk7_attr.c pk7_doit.c pk7_lib.c pk7_mime.c
+  pk7_smime.c pkcs7err.c )
+
+add_submodule ( poly1305 poly1305.c poly1305_ameth.c poly1305_pmeth.c)
+
+add_submodule ( rand drbg_ctr.c drbg_lib.c rand_egd.c rand_err.c rand_lib.c rand_unix.c rand_vms.c
+ rand_win.c randfile.c )
+
+add_submodule ( rc2 rc2_cbc.c rc2_ecb.c rc2_skey.c rc2cfb64.c rc2ofb64.c )
+
+add_submodule ( rc4 rc4_enc.c rc4_skey.c )
+
+#add_submodule ( rc5 rc5_ecb.c rc5_enc.c rc5_skey.c rc5cfb64.c rc5ofb64.c )
+
+add_submodule ( ripemd rmd_dgst.c rmd_one.c )
+
+add_submodule ( rsa rsa_ameth.c rsa_asn1.c rsa_chk.c rsa_crpt.c rsa_depr.c rsa_err.c
+  rsa_gen.c rsa_lib.c rsa_meth.c rsa_mp.c rsa_none.c rsa_oaep.c rsa_ossl.c rsa_pk1.c
+  rsa_pmeth.c rsa_prn.c rsa_pss.c rsa_saos.c rsa_sign.c rsa_ssl.c rsa_x931.c rsa_x931g.c )
+
+add_submodule ( seed seed.c seed_cbc.c seed_cfb.c seed_ecb.c seed_ofb.c )
+
+add_submodule ( sha keccak1600.c sha1_one.c sha1dgst.c sha256.c sha512.c )
+
+add_submodule ( siphash siphash.c siphash_ameth.c siphash_pmeth.c )
+
+add_submodule ( sm2 sm2_crypt.c sm2_err.c sm2_pmeth.c sm2_sign.c )
+
+add_submodule ( sm3 m_sm3.c sm3.c )
+
+add_submodule ( sm4 sm4.c )
+
+add_submodule ( srp srp_lib.c srp_vfy.c )
+
+add_submodule ( stack stack.c )
+
+add_submodule ( store loader_file.c store_err.c store_init.c store_lib.c store_register.c store_strings.c )
+
+add_submodule ( ts ts_asn1.c ts_conf.c ts_err.c ts_lib.c ts_req_print.c ts_req_utils.c
+  ts_rsp_print.c ts_rsp_sign.c ts_rsp_utils.c ts_rsp_verify.c ts_verify_ctx.c )
+
+add_submodule ( txt_db txt_db.c )
+
+add_submodule ( ui ui_err.c ui_lib.c ui_null.c ui_openssl.c ui_util.c )
+
+add_submodule ( whrlpool wp_block.c wp_dgst.c )
+
+add_submodule ( x509 by_dir.c by_file.c t_crl.c t_req.c t_x509.c x509_att.c x509_cmp.c
+  x509_d2.c x509_def.c x509_err.c x509_ext.c x509_lu.c x509_meth.c x509_obj.c x509_r2x.c
+  x509_req.c x509_set.c x509_trs.c x509_txt.c x509_v3.c x509_vfy.c x509_vpm.c x509cset.c
+  x509name.c x509rset.c x509spki.c x509type.c x_all.c x_attrib.c x_crl.c x_exten.c x_name.c
+  x_pubkey.c x_req.c x_x509.c x_x509a.c )
+
+add_submodule ( x509v3 pcy_cache.c pcy_data.c pcy_lib.c pcy_map.c pcy_node.c pcy_tree.c
+  v3_addr.c v3_admis.c v3_akey.c v3_akeya.c v3_alt.c v3_asid.c v3_bcons.c v3_bitst.c v3_conf.c v3_cpols.c
+  v3_crld.c v3_enum.c v3_extku.c v3_genn.c v3_ia5.c v3_info.c v3_int.c v3_lib.c v3_ncons.c
+  v3_pci.c v3_pcia.c v3_pcons.c v3_pku.c v3_pmaps.c v3_prn.c v3_purp.c v3_skey.c v3_sxnet.c
+  v3_tlsf.c v3_utl.c v3err.c )
+
+set( CMAKE_THREAD_PREFER_PTHREAD TRUE )
+find_package ( Threads )
+if( NOT Threads_FOUND )
+  add_submodule ( . threads_none.c )
+elseif( WIN32 )
+  add_submodule ( . threads_win.c )
+else()
+  add_submodule ( . threads_pthread.c )
+endif()
+
+add_library( crypto ${LIBSRC} ${OBJECTS_SRC} )
+
+target_include_directories( crypto PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include> $<INSTALL_INTERFACE:include/openssl> )
+
+if( WIN32 AND NOT CYGWIN )
+  target_link_libraries( crypto ws2_32 crypt32 )
+else()
+  if( Threads_FOUND )
+    target_link_libraries( crypto ${CMAKE_THREAD_LIBS_INIT} )
+  endif()
+  if( DSO_DLFCN AND HAVE_DLFCN_H )
+    target_link_libraries( crypto dl )
+  endif()
+endif()
+
+set_target_properties( crypto PROPERTIES
+  VERSION "${LIB_VERSION}" SOVERSION "${LIB_SOVERSION}" )
+
+install( TARGETS crypto
+    EXPORT OpenSSLTargets
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib )

--- a/external/curl/openssl/crypto/buildinf.h.cmake
+++ b/external/curl/openssl/crypto/buildinf.h.cmake
@@ -1,0 +1,5 @@
+/* auto-generated for crypto/cversion.c */
+#define CFLAGS "compiler: @CMAKE_C_COMPILER_ID@ @CMAKE_C_FLAGS@"
+#define PLATFORM "platform: @CMAKE_SYSTEM_NAME@"
+#define DATE "built on: @BUILDINF_DATE@"
+static const char *compiler_flags = CFLAGS;

--- a/external/curl/openssl/ssl/CMakeLists.txt
+++ b/external/curl/openssl/ssl/CMakeLists.txt
@@ -1,0 +1,59 @@
+# Based on original work by David Manura
+# Copyright (C) 2007-2012 LuaDist.
+# Copyright (C) 2013 Brian Sidebotham
+
+# Redistribution and use of this file is allowed according to the terms of the
+# MIT license.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+if( BUILD_SHARED_LIBS )
+  add_definitions( -DOPENSSL_BUILD_SHLIBSSL )
+endif()
+
+set( LIBSRC
+  bio_ssl.c d1_lib.c d1_msg.c d1_srtp.c methods.c packet.c pqueue.c s3_cbc.c s3_enc.c s3_lib.c
+  s3_msg.c ssl_asn1.c ssl_cert.c ssl_ciph.c ssl_conf.c ssl_err.c ssl_init.c ssl_lib.c
+  ssl_mcnf.c ssl_rsa.c ssl_sess.c ssl_stat.c ssl_txt.c ssl_utst.c t1_enc.c t1_lib.c
+  t1_trce.c tls13_enc.c tls_srp.c
+  record/dtls1_bitmap.c record/rec_layer_d1.c record/rec_layer_s3.c record/ssl3_buffer.c
+  record/ssl3_record.c record/ssl3_record_tls13.c
+  statem/extensions.c statem/extensions_clnt.c statem/extensions_cust.c
+  statem/extensions_srvr.c statem/statem.c statem/statem_clnt.c statem/statem_dtls.c
+  statem/statem_lib.c statem/statem_srvr.c
+  )
+
+include_directories( BEFORE SYSTEM
+  ${PROJECT_SOURCE_DIR}/ # e_os.h
+)
+
+add_library( ssl ${LIBSRC} )
+
+target_include_directories( ssl PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include> $<INSTALL_INTERFACE:include/openssl> )
+
+target_link_libraries( ssl crypto )
+
+set_target_properties( ssl PROPERTIES
+  VERSION "${LIB_VERSION}" SOVERSION "${LIB_SOVERSION}" )
+
+install( TARGETS ssl
+    EXPORT OpenSSLTargets
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib )

--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -39,18 +39,21 @@ include(cmake/CompileChecks.cmake)
 
 porting_do_checks()
 
-if(ANDROID OR IOS OR (WIN32 AND NOT MINGW))
+if(IOS OR (WIN32 AND NOT MINGW))
     set(NETWORK_NO_CURL ON)
-
-    if(ANDROID)
+elseif(ANDROID)
+    if(OLP_SDK_ENABLE_ANDROID_CURL)
+        set(NETWORK_NO_CURL OFF)
+        find_package(CURL 7.47.0 REQUIRED)
+    else()
         find_package(Java REQUIRED)
+        set(NETWORK_NO_CURL ON)
     endif()
 else()
     set(NETWORK_NO_CURL OFF)
 
-    find_package(CURL REQUIRED)
+    find_package(CURL 7.47.0 REQUIRED)
 endif()
-
 
 set(Network_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
@@ -295,7 +298,7 @@ if (ANDROID)
     set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_HAS_ANDROID)
 endif()
 
-if (UNIX AND NOT ANDROID)
+if (UNIX AND (NOT ANDROID OR OLP_SDK_ENABLE_ANDROID_CURL))
     set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_CURL_SOURCES})
 
     set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_HAS_CURL)
@@ -465,7 +468,7 @@ if(IOS)
     target_link_libraries(${PROJECT_NAME} PRIVATE ${OLP_SDK_CORE_FOUNDATION_FRAMEWORK}
                                                   ${OLP_SDK_SECURITY_FRAMEWORK}
                                                   ${OLP_SDK_CFNETWORK_FRAMEWORK})
-elseif(ANDROID)
+elseif(ANDROID AND NOT OLP_SDK_ENABLE_ANDROID_CURL)
     # Make sure that OlpHttpClient.jar is built before olp-cpp-sdk-core
     add_dependencies(${PROJECT_NAME} ${OLP_SDK_ANDROID_HTTP_CLIENT_JAR})
 endif()

--- a/olp-cpp-sdk-core/cmake/android.cmake
+++ b/olp-cpp-sdk-core/cmake/android.cmake
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
-if(NOT ANDROID)
+if(NOT ANDROID OR OLP_SDK_ENABLE_ANDROID_CURL)
     set(NETWORK_ANDROID_LIBRARIES)
     return()
 endif()

--- a/olp-cpp-sdk-core/cmake/curl.cmake
+++ b/olp-cpp-sdk-core/cmake/curl.cmake
@@ -28,6 +28,10 @@ if(CURL_FOUND AND NOT NETWORK_NO_CURL)
     endif(APPLE)
     include_directories(${CURL_INCLUDE_DIRS})
 
+    if(OLP_SDK_ENABLE_ANDROID_CURL)
+        add_definitions(-DOLP_SDK_ENABLE_ANDROID_CURL)
+    endif()
+
     find_package(OpenSSL)
     if(OPENSSL_FOUND)
         add_definitions(-DOLP_SDK_NETWORK_HAS_OPENSSL)


### PR DESCRIPTION
In some rare cases HttpUrlConnection can cause issue with downloading
bundles. As alternative, we can use libcurl also for Android. The
change provides a way to download and build curl.
OLP_SDK_ENABLE_ANDROID_CURL=ON will enable and use it instead of
android http client.

Resolves: OLPEDGE-2717
Signed-off-by: Kostiantyn Zvieriev <ext-kostiantyn.zvieriev@here.com>