### PR TITLE
Replace win-2016 to 2019

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
       displayName: 'Commit checker script'
 - job: Windows_build
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   steps:
   - bash: scripts/windows/build.sh
     displayName: 'Windows Build'

--- a/scripts/windows/build.sh
+++ b/scripts/windows/build.sh
@@ -20,6 +20,6 @@
 
 [[ -d "build" ]] && rm -rf build
 mkdir build && cd build
-cmake .. -G "Visual Studio 15 2017 Win64" \
+cmake .. -G "Visual Studio 16 2019" -A x64 \
         -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 cmake --build . --config $BUILD_TYPE


### PR DESCRIPTION
Due to Microsoft deprecation notice.

Relates-To: OLPEDGE-2728

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>