### PR TITLE
Extend olp::utils::Base64Encode() for URIs.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/utils/Base64.h
+++ b/olp-cpp-sdk-core/include/olp/core/utils/Base64.h
@@ -33,37 +33,45 @@ namespace utils {
  * @brief Encodes a binary stream into a Base64 text.
  *
  * @param bytes The data to be encoded.
+ * @param url If set to true, the "=" padding will be omitted. The default value
+ * is false.
  *
  * @return The Base64 encoded string.
  */
-CORE_API std::string Base64Encode(const std::vector<std::uint8_t>& bytes);
+CORE_API std::string Base64Encode(const std::vector<uint8_t>& bytes,
+                                  bool url = false);
 
 /**
  * @brief Encodes a string into a Base64 text.
  *
  * @param bytes The data to be encoded.
+ * @param url If set to true, the "=" padding will be omitted. The default value
+ * is false.
  *
  * @return The Base64 encoded string.
  */
-CORE_API std::string Base64Encode(const std::string& bytes);
+CORE_API std::string Base64Encode(const std::string& bytes, bool url = false);
 
 /**
  * @brief Encodes a binary stream into a Base64 text.
  *
  * @param bytes The data to be encoded.
  * @param size The length of the byte array.
+ * @param url If set to true, the "=" padding will be omitted. The default value
+ * is false.
  *
  * @return The Base64 encoded string.
  */
-CORE_API std::string Base64Encode(const void* bytes, size_t size);
+CORE_API std::string Base64Encode(const void* bytes, size_t size,
+                                  bool url = false);
 
 /**
  * @brief Decodes a Base64 string into a binary stream.
  *
  * @param[in] string The Base64 string to be decoded.
  * @param[out] bytes The vector containing the decoded bytes.
- * @param[in] write_null_bytes True if the decoded NULL bytes should be written to
- * the output; false otherwise. The default value is true.
+ * @param[in] write_null_bytes True if the decoded NULL bytes should be written
+ * to the output; false otherwise. The default value is true.
  *
  * @return True if the decoding was successful; false otherwise.
  */

--- a/olp-cpp-sdk-core/src/utils/Base64.cpp
+++ b/olp-cpp-sdk-core/src/utils/Base64.cpp
@@ -64,7 +64,7 @@ bool IsValidBase64(const std::string& string) {
 }
 }  // anonymous namespace
 
-std::string Base64Encode(const void* bytes, size_t size) {
+std::string Base64Encode(const void* bytes, size_t size, bool url) {
   namespace iterators = boost::archive::iterators;
   using It = iterators::base64_from_binary<
       iterators::transform_width<const uint8_t*, 6, 8> >;
@@ -75,19 +75,21 @@ std::string Base64Encode(const void* bytes, size_t size) {
 
   const uint8_t* data = reinterpret_cast<const uint8_t*>(bytes);
   auto return_string = std::string(It(data), It(data + size));
-  return_string.append((3 - size % 3) % 3, '=');
+
+  // See https://datatracker.ietf.org/doc/html/rfc4648#section-5
+  if (!url) {
+    return_string.append((3 - size % 3) % 3, '=');
+  }
 
   return return_string;
 }
 
-std::string Base64Encode(const std::vector<uint8_t>& bytes) {
-  return Base64Encode(reinterpret_cast<const void*>(bytes.data()),
-                      bytes.size());
+std::string Base64Encode(const std::vector<uint8_t>& bytes, bool url) {
+  return Base64Encode(bytes.data(), bytes.size(), url);
 }
 
-std::string Base64Encode(const std::string& bytes) {
-  return Base64Encode(reinterpret_cast<const void*>(bytes.c_str()),
-                      bytes.size());
+std::string Base64Encode(const std::string& bytes, bool url) {
+  return Base64Encode(bytes.c_str(), bytes.size(), url);
 }
 
 bool Base64Decode(const std::string& string, std::vector<std::uint8_t>& bytes,


### PR DESCRIPTION
As described in https://datatracker.ietf.org/doc/html/rfc4648#section-5
the padding at the end for URIs can be omitted, therefore the three
available Base64Encode() methods are now extended with an extra
bool parameter which indicates that this is a URI encoding and thus
will omit to pad the output with "=" characters.

Relates-To: OLPEDGE-2680

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>