### PR TITLE
Add TaskContinuation unit tests/change cancellation

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/thread/Continuation.h
+++ b/olp-cpp-sdk-core/include/olp/core/thread/Continuation.h
@@ -100,13 +100,6 @@ class CORE_API ContinuationImpl final {
   const ExecutionContext& GetExecutionContext() const;
 
   /**
-   * @brief Gets the `CancellationContext` object.
-   *
-   * @return The `CancellationContext` instance.
-   */
-  const client::CancellationContext& GetContext() const;
-
-  /**
    * @brief Checks whether the `CancellationContext` instance is cancelled.
    *
    * @return True if the `CancellationContext` instance is cancelled; false

--- a/olp-cpp-sdk-core/src/thread/Continuation.cpp
+++ b/olp-cpp-sdk-core/src/thread/Continuation.cpp
@@ -114,7 +114,7 @@ class Processor {
 
   // creates a task for execution by TaskContinuation
   Task CreateFollowingTask(const std::shared_ptr<ProcessorInternal>& context) {
-    return [this, context] { ProcessNextTask(context); };
+    return [=] { ProcessNextTask(context); };
   }
 
   // starts the first task in a chain
@@ -147,10 +147,6 @@ class Processor {
 
     // checks whether the Continuation is cancelled
     bool IsCancelled() const { return public_execution_context_.Cancelled(); }
-
-    const ExecutionContext& GetExecutionContext() {
-      return public_execution_context_;
-    }
 
     // An input argument used by the current task in the queue, it's the result
     // of the previous task
@@ -191,10 +187,6 @@ void ContinuationImpl::Run(FinalCallbackType callback) {
 
 const ExecutionContext& ContinuationImpl::GetExecutionContext() const {
   return execution_context_;
-}
-
-const client::CancellationContext& ContinuationImpl::GetContext() const {
-  return execution_context_.GetContext();
 }
 
 bool ContinuationImpl::Cancelled() const {

--- a/olp-cpp-sdk-core/tests/thread/ExecutionContextTest.cpp
+++ b/olp-cpp-sdk-core/tests/thread/ExecutionContextTest.cpp
@@ -41,11 +41,11 @@ TEST(ExecutionContextTest, ExecuteOrCancelled) {
     bool executed = false;
     bool cancelled = false;
     execution_context.ExecuteOrCancelled(
-        [&executed]() {
+        [&]() {
           executed = true;
           return olp::client::CancellationToken();
         },
-        [&cancelled]() { cancelled = true; });
+        [&]() { cancelled = true; });
 
     EXPECT_TRUE(executed);
     EXPECT_FALSE(cancelled);
@@ -62,7 +62,7 @@ TEST(ExecutionContextTest, ExecuteOrCancelled) {
           executed = true;
           return olp::client::CancellationToken();
         },
-        [&cancelled]() { cancelled = true; });
+        [&]() { cancelled = true; });
 
     EXPECT_FALSE(executed);
     EXPECT_TRUE(cancelled);


### PR DESCRIPTION
Add TaskContinuation unit tests/change cancellation

Add unit tests that check asynchronous behaviour of
TaskContinuation.
Add clearing a callback and tasks on cancellation.
Fix calling SetError in case a continuation is cancelled.
Change the mechanism to cover cancellation cases(cancel before/
after run) in case of calling SetError.
Simplify usage of promise/future.

Relates-To: OLPEDGE-2721

Signed-off-by: Yevhenii Dudnyk <ext-yevhenii.dudnyk@here.com>