### PR TITLE
Add HTTPS proxy support for Curl

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkProxySettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkProxySettings.h
@@ -37,6 +37,7 @@ class CORE_API NetworkProxySettings final {
   enum class Type {
     NONE,             ///< Don't use the proxy.
     HTTP,             ///< HTTP proxy as in https://www.ietf.org/rfc/rfc2068.txt
+    HTTPS,            ///< HTTPS proxy as in https://www.ietf.org/rfc/rfc2818.txt
     SOCKS4,           ///< SOCKS4 proxy.
     SOCKS4A,          ///< SOCKS4a proxy. Proxy resolves the URL hostname.
     SOCKS5,           ///< SOCKS5 proxy.

--- a/olp-cpp-sdk-core/src/http/android/HttpClient.java
+++ b/olp-cpp-sdk-core/src/http/android/HttpClient.java
@@ -123,16 +123,20 @@ public class HttpClient {
           this.proxyType = Proxy.Type.HTTP;
           break;
         case 2:
-          this.proxyType = Proxy.Type.SOCKS;
+          Log.w(LOGTAG, "HttpClient::Request(): Unsupported proxy version (" + proxyType + "). Falling back to HTTP(1)");
+          this.proxyType = Proxy.Type.HTTP;
           break;
         case 3:
+          this.proxyType = Proxy.Type.SOCKS;
+          break;
         case 4:
         case 5:
+        case 6:
+          Log.w(LOGTAG, "HttpClient::Request(): Unsupported proxy version (" + proxyType + "). Falling back to SOCKS4(3)");
           this.proxyType = Proxy.Type.SOCKS;
-          Log.w(LOGTAG, "HttpClient::Request(): Unsupported proxy version (" + proxyType + "). Falling back to SOCKS4(4)");
           break;
         default:
-          Log.w(LOGTAG, "HttpClient::Request(): Unsupported proxy version (" + proxyType + "). Falling back to HTTP(0)");
+          Log.w(LOGTAG, "HttpClient::Request(): Unsupported proxy version (" + proxyType + "). Falling back to HTTP(1)");
           this.proxyType = Proxy.Type.HTTP;
           break;
       }

--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
@@ -279,7 +279,7 @@ bool NetworkCurl::Initialize() {
     return false;
   }
   // Set read and write pipes non blocking
-  for (size_t i = 0; i < 2u; ++i) {
+  for (size_t i = 0u; i < 2u; ++i) {
     int flags = fcntl(pipe_[i], F_GETFL);
     if (flags == -1) {
       flags = 0;
@@ -338,7 +338,7 @@ void NetworkCurl::Deinitialize() {
     event_condition_.notify_all();
 #if defined(OLP_SDK_NETWORK_HAS_PIPE) || defined(OLP_SDK_NETWORK_HAS_PIPE2)
     char tmp = 1;
-    if (write(pipe_[1u], &tmp, 1u) < 0u) {
+    if (write(pipe_[1], &tmp, 1) < 0) {
       OLP_SDK_LOG_INFO(kLogTag, __PRETTY_FUNCTION__
                                     << ". Failed to write pipe. Error "
                                     << errno);
@@ -378,8 +378,8 @@ void NetworkCurl::Teardown() {
     curl_ = nullptr;
 
 #if (defined OLP_SDK_NETWORK_HAS_PIPE) || (defined OLP_SDK_NETWORK_HAS_PIPE2)
-    close(pipe_[0u]);
-    close(pipe_[1u]);
+    close(pipe_[0]);
+    close(pipe_[1]);
 #endif
   }
 
@@ -638,7 +638,7 @@ void NetworkCurl::AddEvent(EventInfo::Type type, RequestHandle* handle) {
   // Notify also trough the pipe so that we can unlock curl_multi_wait() if
   // the network thread is currently blocked there.
   char tmp = 1;
-  if (write(pipe_[1u], &tmp, 1u) < 0u) {
+  if (write(pipe_[1], &tmp, 1) < 0) {
     OLP_SDK_LOG_WARNING(kLogTag, "AddEvent - failed for id="
                                      << handle->id << ", err=" << errno);
   }
@@ -683,7 +683,7 @@ NetworkCurl::RequestHandle* NetworkCurl::GetHandle(
       handle.payload = std::move(payload);
       handle.body = std::move(body);
       handle.send_time = std::chrono::steady_clock::now();
-      handle.error_text[0u] = 0;
+      handle.error_text[0] = 0;
       handle.skip_content = false;
 
       return &handle;
@@ -1055,7 +1055,7 @@ void NetworkCurl::Run() {
       if (mc == CURLM_OK && numfds != 0 && waitfd[0].revents != 0) {
         // Empty pipe data to make sure we are clear for the next wait
         char tmp;
-        while (read(waitfd[0u].fd, &tmp, 1u) > 0u) {
+        while (read(waitfd[0].fd, &tmp, 1) > 0) {
         }
       }
 #else

--- a/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
+++ b/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
@@ -469,9 +469,16 @@ SendOutcome NetworkWinHttp::Send(NetworkRequest request,
                      network_settings.GetTransferTimeout() * 1000);
 
   const auto& proxy = network_settings.GetProxySettings();
+  const auto proxy_type = proxy.GetType();
 
-  if (proxy.GetType() != NetworkProxySettings::Type::NONE) {
+  if (proxy_type != NetworkProxySettings::Type::NONE) {
     const std::wstring proxy_string = ProxyString(proxy);
+
+    if (proxy_type == NetworkProxySettings::Type::HTTPS) {
+      OLP_SDK_LOG_ERROR(kLogTag, "Unsupported proxy type, proxy_type="
+                                     << proxy_string.c_str());
+      return SendOutcome(ErrorCode::UNKNOWN_ERROR);
+    }
 
     WINHTTP_PROXY_INFO proxy_info;
     proxy_info.dwAccessType = WINHTTP_ACCESS_TYPE_NAMED_PROXY;

--- a/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
+++ b/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
@@ -174,7 +174,11 @@ std::wstring ProxyString(const olp::http::NetworkProxySettings& proxy) {
 
   switch (proxy.GetType()) {
     case olp::http::NetworkProxySettings::Type::NONE:
+    case olp::http::NetworkProxySettings::Type::HTTP:
       proxy_string_stream << "http://";
+      break;
+    case olp::http::NetworkProxySettings::Type::HTTPS:
+      proxy_string_stream << "https://";
       break;
     case olp::http::NetworkProxySettings::Type::SOCKS4:
       proxy_string_stream << "socks4://";
@@ -224,7 +228,7 @@ std::string QueryHeaders(HINTERNET handle) {
     headers.resize(len);
     const int convertResult =
         WideCharToMultiByte(CP_ACP, 0, wide_buffer.get(), len, &headers.front(),
-                            headers.size(), 0, nullptr);
+                            static_cast<int>(headers.size()), 0, nullptr);
     assert(convertResult == static_cast<int>(len));
   }
 
@@ -265,6 +269,11 @@ NetworkWinHttp::NetworkWinHttp(size_t max_request_count)
   // Store the memory tracking state during initialization so that it can be
   // used by the thread.
   thread_ = CreateThread(NULL, 0, NetworkWinHttp::Run, this, 0, NULL);
+  if (thread_ == NULL) {
+    OLP_SDK_LOG_ERROR(kLogTag, "CreateThread failed " << GetLastError());
+    return;
+  }
+
   SetThreadPriority(thread_, THREAD_PRIORITY_ABOVE_NORMAL);
 
   OLP_SDK_LOG_TRACE(kLogTag, "Created NetworkWinHttp with address="
@@ -462,7 +471,7 @@ SendOutcome NetworkWinHttp::Send(NetworkRequest request,
   const auto& proxy = network_settings.GetProxySettings();
 
   if (proxy.GetType() != NetworkProxySettings::Type::NONE) {
-    std::wstring proxy_string = ProxyString(proxy);
+    const std::wstring proxy_string = ProxyString(proxy);
 
     WINHTTP_PROXY_INFO proxy_info;
     proxy_info.dwAccessType = WINHTTP_ACCESS_TYPE_NAMED_PROXY;
@@ -662,7 +671,7 @@ void NetworkWinHttp::RequestCallback(HINTERNET, DWORD_PTR context, DWORD status,
             index++;
           }
         }
-        headers_size += headers.size();
+        headers_size += static_cast<DWORD>(headers.size());
       } else {
         headers_size += QueryHeadersSize(handle->http_request);
       }


### PR DESCRIPTION
Added new HTTPS value for proxy settings, added support in Curl.
Added log messages for Android and Windows, that feature is not
supported for that platforms. Curl implementation was tested on
Ubuntu using mock-server.

Resolves: OLPEDGE-1099
Signed-off-by: Yevhen Krasilnyk <ext-yevhen.krasilnyk@here.com>