### PR TITLE
Add API for getting Partition with TileRequest

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -300,6 +300,25 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    */
   client::CancellableFuture<PartitionsResponse> GetPartitions(
       PartitionsRequest partitions_request);
+
+  /**
+   * @brief Fetches a list of partitions including data size, checksum and crc
+   * asynchronously.
+   *
+   * @note CacheWithUpdate fetch option is not supported.
+   * @note If OnlineIfNotFound fetch option is used and the cached data does not
+   * contain data size, checksum or crc, a new network request is triggered to
+   * download required data and update the cache record.
+   *
+   * @param tile_request The `TileRequest` instance that contains
+   * a complete set of request parameters.
+   * @param callback The `PartitionsResponseCallback` object that is invoked if
+   * the list of partitions is available or an error is encountered.
+   *
+   * @return A token that can be used to cancel this request.
+   */
+  client::CancellationToken QuadTreeIndex(TileRequest tile_request,
+                                          PartitionsResponseCallback callback);
 
   /**
    * @brief Prefetches a set of tiles asynchronously.

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,11 @@ client::CancellationToken VersionedLayerClient::GetPartitions(
 client::CancellableFuture<PartitionsResponse>
 VersionedLayerClient::GetPartitions(PartitionsRequest partitions_request) {
   return impl_->GetPartitions(std::move(partitions_request));
+}
+
+client::CancellationToken VersionedLayerClient::QuadTreeIndex(
+    TileRequest tile_request, PartitionsResponseCallback callback) {
+  return impl_->QuadTreeIndex(std::move(tile_request), std::move(callback));
 }
 
 client::CancellationToken VersionedLayerClient::PrefetchTiles(

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include <olp/core/client/ApiLookupClient.h>
 #include <olp/core/client/CancellationContext.h>
@@ -75,6 +76,9 @@ class VersionedLayerClientImpl {
 
   virtual client::CancellableFuture<PartitionsResponse> GetPartitions(
       PartitionsRequest partitions_request);
+
+  virtual client::CancellationToken QuadTreeIndex(
+      TileRequest tile_request, PartitionsResponseCallback callback);
 
   virtual client::CancellationToken PrefetchTiles(
       PrefetchTilesRequest request, PrefetchTilesResponseCallback callback,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,12 +82,16 @@ class PartitionsRepository {
 
   PartitionResponse GetTile(const TileRequest& request,
                             boost::optional<int64_t> version,
-                            client::CancellationContext context);
+                            client::CancellationContext context,
+                            boost::optional<std::vector<std::string>>
+                                additional_fields = boost::none);
 
  private:
   QuadTreeIndexResponse GetQuadTreeIndexForTile(
       const TileRequest& request, boost::optional<int64_t> version,
-      client::CancellationContext context);
+      client::CancellationContext context,
+      boost::optional<std::vector<std::string>> additional_fields =
+          boost::none);
 
   PartitionsResponse GetPartitions(
       const read::PartitionsRequest& request,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <sstream>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -39,6 +40,7 @@ class QuadTreeIndex {
     olp::geo::TileKey tile_key;
     std::string data_handle;
     std::string additional_metadata;
+    std::string crc;
     std::string checksum;
     uint64_t version = -1;
     int64_t data_size = -1;

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,22 +43,23 @@ using olp::client::ErrorCode;
 using olp::client::HRN;
 using olp::client::OlpClientSettings;
 using olp::dataservice::read::DataRequest;
+using olp::geo::TileKey;
 using testing::_;
 
 namespace parser = olp::parser;
 namespace read = olp::dataservice::read;
-namespace model = olp::dataservice::read::model;
+namespace model = read::model;
 namespace client = olp::client;
-namespace repository = olp::dataservice::read::repository;
+namespace repository = read::repository;
 namespace cache = olp::cache;
 
 const std::string kCatalog =
     "hrn:here:data::olp-here-test:hereos-internal-test-v2";
-const std::string kVersionedLayerId = "test_layer";
+const std::string kVersionedLayerId = "testlayer";
 const std::string kVolatileLayerId = "testlayer_volatile";
 const std::string kPartitionId = "1111";
 const std::string kInvalidPartitionId = "2222";
-constexpr int kVersion = 4;
+constexpr int kVersion = 100;
 
 const std::string kOlpSdkUrlLookupQuery =
     R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/)" +
@@ -124,31 +125,41 @@ const std::string kOlpSdkUrlVolatilePartitions =
     kVolatileLayerId + R"(/partitions)";
 
 const std::string kOlpSdkHttpResponsePartitions =
-    R"jsonString({ "partitions": [{"version":4,"partition":"269","layer":"testlayer","dataHandle":"4eed6ed1-0d32-43b9-ae79-043cb4256432"},{"version":4,"partition":"270","layer":"testlayer","dataHandle":"30640762-b429-47b9-9ed6-7a4af6086e8e"},{"version":4,"partition":"3","layer":"testlayer","dataHandle":"data:SomethingBaH!"},{"version":4,"partition":"here_van_wc2018_pool","layer":"testlayer","dataHandle":"bcde4cc0-2678-40e9-b791-c630faee14c3"}]})jsonString";
+    R"jsonString({ "partitions": [{"version":100,"partition":"269","layer":"testlayer","dataHandle":"4eed6ed1-0d32-43b9-ae79-043cb4256432"},{"version":100,"partition":"270","layer":"testlayer","dataHandle":"30640762-b429-47b9-9ed6-7a4af6086e8e"},{"version":100,"partition":"3","layer":"testlayer","dataHandle":"data:SomethingBaH!"},{"version":100,"partition":"here_van_wc2018_pool","layer":"testlayer","dataHandle":"bcde4cc0-2678-40e9-b791-c630faee14c3"}]})jsonString";
 
 const std::string kUrlLookupQuery =
     R"(https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data::olp-here-test:hereos-internal-test-v2/apis)";
 
-const std::string kHttpResponceLookupQuery =
+const std::string kHttpResponseLookupQuery =
     R"jsonString([{"api":"query","version":"v1","baseURL":"https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2","parameters":{}}])jsonString";
 
 const std::string kUrlQueryApi =
     R"(https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2)";
 
 const std::string kQueryTreeIndex =
-    R"(https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/testlayer/versions/4/quadkeys/23064/depths/4)";
+    R"(https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/testlayer/versions/100/quadkeys/23064/depths/4)";
+
+const std::string kQueryTreeIndexWithAdditionalFields =
+    kQueryTreeIndex + R"(?additionalFields=)" +
+    olp::utils::Url::Encode(R"(checksum,crc,dataSize,compressedDataSize)");
 
 const std::string kQueryQuadTreeIndex =
-    R"(https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/testlayer/versions/4/quadkeys/90/depths/4)";
+    R"(https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/testlayer/versions/100/quadkeys/90/depths/4)";
 
 const std::string kSubQuads =
-    R"jsonString({"subQuads": [{"subQuadKey":"115","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"463","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString";
+    R"jsonString({"subQuads": [{"subQuadKey":"115","version":100,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"463","version":100,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString";
 
 const std::string kInvalidJson =
-    R"jsonString({}"subQuads": [{"subQuadKey":"115","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"463","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString";
+    R"jsonString({}"subQuads": [{"subQuadKey":"115","version":100,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"463","version":100,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString";
 
 const std::string kSubQuadsWithParent =
-    R"jsonString({"subQuads": [{"subQuadKey":"115","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"463","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": [{"partition":"5","version":282,"dataHandle":"13E2C624E0136C3357D092EE7F231E87.282","dataSize":99151}]})jsonString";
+    R"jsonString({"subQuads": [{"subQuadKey":"115","version":100,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"463","version":100,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": [{"partition":"5","version":282,"dataHandle":"13E2C624E0136C3357D092EE7F231E87.282","dataSize":99151}]})jsonString";
+
+const std::string kSubQuadsWithParentAndAdditionalFields =
+    R"jsonString({"subQuads": [{"subQuadKey":"115","version":100,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1","checksum":"xxx","compressedDataSize":10,"dataSize":15,"crc":"aaa"},{"subQuadKey":"463","version":100,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1","checksum":"yyy","compressedDataSize":20,"dataSize":25,"crc":"bbb"}],"parentQuads": [{"partition":"5","version":282,"dataHandle":"13E2C624E0136C3357D092EE7F231E87.282","checksum":"zzz","compressedDataSize":30,"dataSize":35,"crc":"ccc"}]})jsonString";
+
+const std::string kSubQuadsWithParentAndAdditionalFieldsWithoutCrc =
+    R"jsonString({"subQuads": [{"subQuadKey":"115","version":100,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1","checksum":"xxx","compressedDataSize":10,"dataSize":15},{"subQuadKey":"463","version":100,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1","checksum":"yyy","compressedDataSize":20,"dataSize":25}],"parentQuads": [{"partition":"5","version":282,"dataHandle":"13E2C624E0136C3357D092EE7F231E87.282","checksum":"zzz","compressedDataSize":30,"dataSize":35}]})jsonString";
 
 const std::string kBlobDataHandle1476147 =
     R"(95c5c703-e00e-4c38-841e-e419367474f1)";
@@ -186,7 +197,7 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
 
   auto setup_online_only_mocks = [&]() {
     ON_CALL(*cache, Get(_, _))
-        .WillByDefault([](const std::string&, const olp::cache::Decoder&) {
+        .WillByDefault([](const std::string&, const cache::Decoder&) {
           ADD_FAILURE() << "Cache should not be used in OnlineOnly request";
           return boost::any{};
         });
@@ -205,10 +216,9 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     SCOPED_TRACE("Fetch from cache [CacheOnly] positive");
 
     const std::string query_cache_response =
-        R"jsonString({"version":4,"partition":"1111","layer":"testlayer","dataHandle":"qwerty"})jsonString";
+        R"jsonString({"version":100,"partition":"1111","layer":"testlayer","dataHandle":"qwerty"})jsonString";
 
     EXPECT_CALL(*cache, Get(cache_key, _))
-        .Times(1)
         .WillOnce(
             Return(parser::parse<model::Partition>(query_cache_response)));
 
@@ -232,7 +242,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     SCOPED_TRACE("Fetch from cache [CacheOnly] negative");
 
     EXPECT_CALL(*cache, Get(cache_key, _))
-        .Times(1)
         .WillOnce(Return(boost::any()));
 
     client::CancellationContext context;
@@ -334,8 +343,7 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         context);
 
     EXPECT_FALSE(response.IsSuccessful());
-    EXPECT_EQ(response.GetError().GetErrorCode(),
-              olp::client::ErrorCode::AccessDenied);
+    EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::AccessDenied);
     Mock::VerifyAndClearExpectations(network.get());
   }
   {
@@ -356,8 +364,7 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         context);
 
     EXPECT_FALSE(response.IsSuccessful());
-    EXPECT_EQ(response.GetError().GetErrorCode(),
-              olp::client::ErrorCode::AccessDenied);
+    EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::AccessDenied);
     Mock::VerifyAndClearExpectations(network.get());
   }
   {
@@ -366,7 +373,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     setup_online_only_mocks();
     setup_positive_metadata_mocks();
     EXPECT_CALL(*cache, Get(cache_key, _))
-        .Times(1)
         .WillOnce(Return(boost::any()));
 
     EXPECT_CALL(*network,
@@ -381,8 +387,7 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         context);
 
     EXPECT_FALSE(response.IsSuccessful());
-    EXPECT_EQ(response.GetError().GetErrorCode(),
-              olp::client::ErrorCode::AccessDenied);
+    EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::AccessDenied);
     Mock::VerifyAndClearExpectations(network.get());
   }
 
@@ -393,7 +398,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
 
     client::CancellationContext context;
     EXPECT_CALL(*network, Send(IsGetRequest(kOlpSdkUrlLookupQuery), _, _, _, _))
-        .Times(1)
         .WillOnce([=](olp::http::NetworkRequest /*request*/,
                       olp::http::Network::Payload /*payload*/,
                       olp::http::Network::Callback /*callback*/,
@@ -408,8 +412,7 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         context);
 
     EXPECT_FALSE(response.IsSuccessful());
-    EXPECT_EQ(response.GetError().GetErrorCode(),
-              olp::client::ErrorCode::Cancelled);
+    EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::Cancelled);
     Mock::VerifyAndClearExpectations(network.get());
   }
   {
@@ -421,7 +424,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     client::CancellationContext context;
     EXPECT_CALL(*network,
                 Send(IsGetRequest(kOlpSdkUrlPartitionById), _, _, _, _))
-        .Times(1)
         .WillOnce([=](olp::http::NetworkRequest /*request*/,
                       olp::http::Network::Payload /*payload*/,
                       olp::http::Network::Callback /*callback*/,
@@ -436,8 +438,7 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         context);
 
     EXPECT_FALSE(response.IsSuccessful());
-    EXPECT_EQ(response.GetError().GetErrorCode(),
-              olp::client::ErrorCode::Cancelled);
+    EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::Cancelled);
     Mock::VerifyAndClearExpectations(network.get());
   }
 
@@ -447,7 +448,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
 
     client::CancellationContext context;
     EXPECT_CALL(*network, Send(IsGetRequest(kOlpSdkUrlLookupQuery), _, _, _, _))
-        .Times(1)
         .WillOnce([=](olp::http::NetworkRequest /*request*/,
                       olp::http::Network::Payload /*payload*/,
                       olp::http::Network::Callback /*callback*/,
@@ -458,15 +458,14 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
           constexpr auto unused_request_id = 12;
           return olp::http::SendOutcome(unused_request_id);
         });
-    EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
+    EXPECT_CALL(*network, Cancel(_)).WillOnce(Return());
 
     auto response = repository.GetPartitionById(
         DataRequest(request).WithFetchOption(read::OnlineOnly), kVersion,
         context);
 
     EXPECT_FALSE(response.IsSuccessful());
-    EXPECT_EQ(response.GetError().GetErrorCode(),
-              olp::client::ErrorCode::RequestTimeout);
+    EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::RequestTimeout);
     Mock::VerifyAndClearExpectations(network.get());
   }
 
@@ -478,7 +477,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     client::CancellationContext context;
     EXPECT_CALL(*network,
                 Send(IsGetRequest(kOlpSdkUrlPartitionById), _, _, _, _))
-        .Times(1)
         .WillOnce([=](olp::http::NetworkRequest /*request*/,
                       olp::http::Network::Payload /*payload*/,
                       olp::http::Network::Callback /*callback*/,
@@ -489,15 +487,14 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
           constexpr auto unused_request_id = 12;
           return olp::http::SendOutcome(unused_request_id);
         });
-    EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
+    EXPECT_CALL(*network, Cancel(_)).WillOnce(Return());
 
     auto response = repository.GetPartitionById(
         DataRequest(request).WithFetchOption(read::OnlineOnly), kVersion,
         context);
 
     EXPECT_FALSE(response.IsSuccessful());
-    EXPECT_EQ(response.GetError().GetErrorCode(),
-              olp::client::ErrorCode::RequestTimeout);
+    EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::RequestTimeout);
     Mock::VerifyAndClearExpectations(network.get());
   }
 
@@ -507,7 +504,6 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
 
     client::CancellationContext context;
     EXPECT_CALL(*network, Send(IsGetRequest(kOlpSdkUrlLookupQuery), _, _, _, _))
-        .Times(1)
         .WillOnce([=, &context](
                       olp::http::NetworkRequest /*request*/,
                       olp::http::Network::Payload /*payload*/,
@@ -523,15 +519,14 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
           constexpr auto unused_request_id = 12;
           return olp::http::SendOutcome(unused_request_id);
         });
-    EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
+    EXPECT_CALL(*network, Cancel(_)).WillOnce(Return());
 
     auto response = repository.GetPartitionById(
         DataRequest(request).WithFetchOption(read::OnlineOnly), kVersion,
         context);
 
     EXPECT_FALSE(response.IsSuccessful());
-    EXPECT_EQ(response.GetError().GetErrorCode(),
-              olp::client::ErrorCode::Cancelled);
+    EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::Cancelled);
     Mock::VerifyAndClearExpectations(network.get());
   }
   {
@@ -542,7 +537,7 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     client::CancellationContext context;
     EXPECT_CALL(*network,
                 Send(IsGetRequest(kOlpSdkUrlPartitionById), _, _, _, _))
-        .Times(1)
+
         .WillOnce([=, &context](
                       olp::http::NetworkRequest /*request*/,
                       olp::http::Network::Payload /*payload*/,
@@ -558,15 +553,14 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
           constexpr auto unused_request_id = 12;
           return olp::http::SendOutcome(unused_request_id);
         });
-    EXPECT_CALL(*network, Cancel(_)).Times(1).WillOnce(Return());
+    EXPECT_CALL(*network, Cancel(_)).WillOnce(Return());
 
     auto response = repository.GetPartitionById(
         DataRequest(request).WithFetchOption(read::OnlineOnly), kVersion,
         context);
 
     EXPECT_FALSE(response.IsSuccessful());
-    EXPECT_EQ(response.GetError().GetErrorCode(),
-              olp::client::ErrorCode::Cancelled);
+    EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::Cancelled);
     Mock::VerifyAndClearExpectations(network.get());
   }
 
@@ -581,8 +575,7 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         context);
 
     EXPECT_FALSE(response.IsSuccessful());
-    EXPECT_EQ(response.GetError().GetErrorCode(),
-              olp::client::ErrorCode::Cancelled);
+    EXPECT_EQ(response.GetError().GetErrorCode(), ErrorCode::Cancelled);
     Mock::VerifyAndClearExpectations(network.get());
   }
 }
@@ -591,7 +584,7 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
   using testing::Return;
 
   std::shared_ptr<cache::KeyValueCache> default_cache =
-      olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+      client::OlpClientSettingsFactory::CreateDefaultCache({});
 
   auto mock_network = std::make_shared<NetworkMock>();
   auto cache = std::make_shared<testing::StrictMock<CacheMock>>();
@@ -614,19 +607,19 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
         "::" + std::to_string(kVersion) + "::partition";
 
     const std::string query_cache_response =
-        R"jsonString({"version":4,"partition":"1111","layer":"testlayer","dataHandle":"qwerty"})jsonString";
+        R"jsonString({"version":100,"partition":"1111","layer":"testlayer","dataHandle":"qwerty"})jsonString";
 
     EXPECT_CALL(*cache, Get(cache_key_1, _))
-        .Times(1)
+
         .WillOnce(
             Return(parser::parse<model::Partition>(query_cache_response)));
 
     EXPECT_CALL(*cache, Get(cache_key_2, _))
-        .Times(1)
+
         .WillOnce(Return(boost::any()));
 
     client::CancellationContext context;
-    olp::client::ApiLookupClient lookup_client(catalog, settings);
+    ApiLookupClient lookup_client(catalog, settings);
     repository::PartitionsRepository repository(catalog, kVersionedLayerId,
                                                 settings, lookup_client);
 
@@ -641,7 +634,7 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
     EXPECT_TRUE(response.GetResult().GetPartitions().empty());
   }
   {
-    SCOPED_TRACE("Successfull fetch from network with a list of partitions");
+    SCOPED_TRACE("Successful fetch from network with a list of partitions");
 
     OlpClientSettings settings;
     settings.cache = default_cache;
@@ -661,7 +654,7 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
                                      kOlpSdkHttpResponsePartitionById));
 
     client::CancellationContext context;
-    olp::client::ApiLookupClient lookup_client(catalog, settings);
+    ApiLookupClient lookup_client(catalog, settings);
     repository::PartitionsRepository repository(catalog, kVersionedLayerId,
                                                 settings, lookup_client);
     read::PartitionsRequest request;
@@ -674,7 +667,7 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
     EXPECT_EQ(response.GetResult().GetPartitions().size(), 1);
   }
   {
-    SCOPED_TRACE("Successfull fetch from network, empty layer");
+    SCOPED_TRACE("Successful fetch from network, empty layer");
 
     OlpClientSettings settings;
     settings.cache = default_cache;
@@ -694,7 +687,7 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
                                      kOlpSdkHttpResponseEmptyPartitionList));
 
     client::CancellationContext context;
-    olp::client::ApiLookupClient lookup_client(catalog, settings);
+    ApiLookupClient lookup_client(catalog, settings);
     repository::PartitionsRepository repository(catalog, kVersionedLayerId,
                                                 settings, lookup_client);
     read::PartitionsRequest request;
@@ -718,7 +711,7 @@ TEST_F(PartitionsRepositoryTest, GetVolatilePartitions) {
   using testing::Return;
 
   std::shared_ptr<cache::KeyValueCache> default_cache =
-      olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+      client::OlpClientSettingsFactory::CreateDefaultCache({});
 
   auto mock_network = std::make_shared<NetworkMock>();
   const auto catalog = HRN::FromString(kCatalog);
@@ -747,7 +740,7 @@ TEST_F(PartitionsRepositoryTest, GetVolatilePartitions) {
                                    kOlpSdkHttpResponsePartitions));
 
   {
-    SCOPED_TRACE("Successfull fetch from network");
+    SCOPED_TRACE("Successful fetch from network");
 
     OlpClientSettings settings;
     settings.cache = default_cache;
@@ -755,7 +748,7 @@ TEST_F(PartitionsRepositoryTest, GetVolatilePartitions) {
     settings.retry_settings.timeout = 1;
 
     client::CancellationContext context;
-    olp::client::ApiLookupClient lookup_client(catalog, settings);
+    ApiLookupClient lookup_client(catalog, settings);
     repository::PartitionsRepository repository(catalog, kVolatileLayerId,
                                                 settings, lookup_client);
     read::PartitionsRequest request;
@@ -767,13 +760,13 @@ TEST_F(PartitionsRepositoryTest, GetVolatilePartitions) {
   }
 
   {
-    SCOPED_TRACE("Successfull fetch from only cache");
+    SCOPED_TRACE("Successful fetch from only cache");
 
     OlpClientSettings settings;
     settings.cache = default_cache;
     settings.retry_settings.timeout = 0;
 
-    olp::client::ApiLookupClient lookup_client(catalog, settings);
+    ApiLookupClient lookup_client(catalog, settings);
     repository::PartitionsRepository repository(catalog, kVolatileLayerId,
                                                 settings, lookup_client);
     client::CancellationContext context;
@@ -791,7 +784,7 @@ TEST_F(PartitionsRepositoryTest, GetVolatilePartitions) {
 
 TEST_F(PartitionsRepositoryTest, AdditionalFields) {
   std::shared_ptr<cache::KeyValueCache> default_cache =
-      olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+      client::OlpClientSettingsFactory::CreateDefaultCache({});
 
   auto mock_network = std::make_shared<NetworkMock>();
   const auto catalog = HRN::FromString(kCatalog);
@@ -814,7 +807,7 @@ TEST_F(PartitionsRepositoryTest, AdditionalFields) {
   settings.cache = default_cache;
   settings.network_request_handler = mock_network;
 
-  olp::client::ApiLookupClient lookup_client(catalog, settings);
+  ApiLookupClient lookup_client(catalog, settings);
   repository::PartitionsRepository repository(catalog, kVersionedLayerId,
                                               settings, lookup_client);
   client::CancellationContext context;
@@ -857,7 +850,7 @@ TEST_F(PartitionsRepositoryTest, AdditionalFields) {
 
 TEST_F(PartitionsRepositoryTest, CheckCashedPartitions) {
   std::shared_ptr<cache::KeyValueCache> default_cache =
-      olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
+      client::OlpClientSettingsFactory::CreateDefaultCache({});
   auto mock_network = std::make_shared<NetworkMock>();
   OlpClientSettings settings;
   settings.cache = default_cache;
@@ -867,7 +860,7 @@ TEST_F(PartitionsRepositoryTest, CheckCashedPartitions) {
   EXPECT_CALL(*mock_network, Send(IsGetRequest(kUrlLookupQuery), _, _, _, _))
       .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                        olp::http::HttpStatusCode::OK),
-                                   kHttpResponceLookupQuery));
+                                   kHttpResponseLookupQuery));
 
   EXPECT_CALL(*mock_network, Send(IsGetRequest(kQueryTreeIndex), _, _, _, _))
       .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
@@ -875,20 +868,18 @@ TEST_F(PartitionsRepositoryTest, CheckCashedPartitions) {
                                    kSubQuads));
 
   const auto hrn = HRN::FromString(kCatalog);
-  int64_t version = 4;
-  auto layer = "testlayer";
 
-  olp::client::ApiLookupClient lookup_client(hrn, settings);
-  repository::PartitionsRepository repository(hrn, layer, settings,
+  ApiLookupClient lookup_client(hrn, settings);
+  repository::PartitionsRepository repository(hrn, kVersionedLayerId, settings,
                                               lookup_client);
 
   {
     SCOPED_TRACE("query partitions and store to cache");
-    auto request = olp::dataservice::read::TileRequest().WithTileKey(
-        olp::geo::TileKey::FromHereTile("5904591"));
+    auto request =
+        read::TileRequest().WithTileKey(TileKey::FromHereTile("5904591"));
     olp::client::CancellationContext context;
 
-    auto response = repository.GetTile(request, version, context);
+    auto response = repository.GetTile(request, kVersion, context);
 
     ASSERT_TRUE(response.IsSuccessful());
     ASSERT_EQ(response.GetResult().GetDataHandle(),
@@ -899,11 +890,11 @@ TEST_F(PartitionsRepositoryTest, CheckCashedPartitions) {
     SCOPED_TRACE(
         "Check if all partitions stored in cache, request another tile");
     olp::client::CancellationContext context;
-    auto request = olp::dataservice::read::TileRequest()
-                       .WithTileKey(olp::geo::TileKey::FromHereTile("1476147"))
+    auto request = read::TileRequest()
+                       .WithTileKey(TileKey::FromHereTile("1476147"))
                        .WithFetchOption(read::CacheOnly);
 
-    auto response = repository.GetTile(request, version, context);
+    auto response = repository.GetTile(request, kVersion, context);
 
     // check if partition was stored to cache
     ASSERT_TRUE(response.IsSuccessful());
@@ -912,21 +903,16 @@ TEST_F(PartitionsRepositoryTest, CheckCashedPartitions) {
 }
 
 TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
-  using olp::cache::KeyValueCache;
-  using testing::_;
+  using cache::KeyValueCache;
   using testing::Return;
-
-  constexpr auto version = 4u;
-  constexpr auto layer = "testlayer";
 
   const auto hrn = HRN::FromString(kCatalog);
 
   {
     SCOPED_TRACE("Same tile");
 
-    const auto tile_key = olp::geo::TileKey::FromHereTile("23247");
-    const auto request =
-        olp::dataservice::read::TileRequest().WithTileKey(tile_key);
+    const auto tile_key = TileKey::FromHereTile("23247");
+    const auto request = read::TileRequest().WithTileKey(tile_key);
     olp::client::CancellationContext context;
 
     auto mock_network = std::make_shared<NetworkMock>();
@@ -939,7 +925,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_network, Send(IsGetRequest(kUrlLookupQuery), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     kHttpResponceLookupQuery));
+                                     kHttpResponseLookupQuery));
     EXPECT_CALL(*mock_network,
                 Send(IsGetRequest(kQueryQuadTreeIndex), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
@@ -951,10 +937,10 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
 
-    olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, layer, settings,
-                                                lookup_client);
-    auto response = repository.GetAggregatedTile(request, version, context);
+    ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, kVersionedLayerId,
+                                                settings, lookup_client);
+    auto response = repository.GetAggregatedTile(request, kVersion, context);
     const auto& result = response.GetResult();
 
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
@@ -964,9 +950,8 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     SCOPED_TRACE("QuadTree is cached");
 
     const auto depth = 4;
-    const auto tile_key = olp::geo::TileKey::FromHereTile("23247");
-    const auto request =
-        olp::dataservice::read::TileRequest().WithTileKey(tile_key);
+    const auto tile_key = TileKey::FromHereTile("23247");
+    const auto request = read::TileRequest().WithTileKey(tile_key);
     olp::client::CancellationContext context;
 
     auto mock_network = std::make_shared<NetworkMock>();
@@ -981,10 +966,10 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
 
     EXPECT_CALL(*mock_cache, Get(_)).WillOnce(Return(quad_tree.GetRawData()));
 
-    olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, layer, settings,
-                                                lookup_client);
-    auto response = repository.GetAggregatedTile(request, version, context);
+    ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, kVersionedLayerId,
+                                                settings, lookup_client);
+    auto response = repository.GetAggregatedTile(request, kVersion, context);
 
     const auto& result = response.GetResult();
 
@@ -995,9 +980,8 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
   {
     SCOPED_TRACE("QueryApi is cached");
 
-    const auto tile_key = olp::geo::TileKey::FromHereTile("23247");
-    const auto request =
-        olp::dataservice::read::TileRequest().WithTileKey(tile_key);
+    const auto tile_key = TileKey::FromHereTile("23247");
+    const auto request = read::TileRequest().WithTileKey(tile_key);
     olp::client::CancellationContext context;
 
     auto mock_network = std::make_shared<NetworkMock>();
@@ -1018,10 +1002,10 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
 
-    olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, layer, settings,
-                                                lookup_client);
-    auto response = repository.GetAggregatedTile(request, version, context);
+    ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, kVersionedLayerId,
+                                                settings, lookup_client);
+    auto response = repository.GetAggregatedTile(request, kVersion, context);
 
     const auto& result = response.GetResult();
 
@@ -1032,9 +1016,8 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
   {
     SCOPED_TRACE("No tiles found");
 
-    const auto tile_key = olp::geo::TileKey::FromHereTile("23064");
-    const auto request =
-        olp::dataservice::read::TileRequest().WithTileKey(tile_key);
+    const auto tile_key = TileKey::FromHereTile("23064");
+    const auto request = read::TileRequest().WithTileKey(tile_key);
     olp::client::CancellationContext context;
 
     auto mock_network = std::make_shared<NetworkMock>();
@@ -1047,7 +1030,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_network, Send(IsGetRequest(kUrlLookupQuery), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     kHttpResponceLookupQuery));
+                                     kHttpResponseLookupQuery));
     EXPECT_CALL(*mock_network,
                 Send(IsGetRequest(kQueryQuadTreeIndex), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
@@ -1059,10 +1042,10 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
 
-    olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, layer, settings,
-                                                lookup_client);
-    auto response = repository.GetAggregatedTile(request, version, context);
+    ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, kVersionedLayerId,
+                                                settings, lookup_client);
+    auto response = repository.GetAggregatedTile(request, kVersion, context);
 
     const auto& error = response.GetError();
 
@@ -1073,10 +1056,10 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
   {
     SCOPED_TRACE("CacheOnly");
 
-    const auto tile_key = olp::geo::TileKey::FromHereTile("23064");
-    const auto request = olp::dataservice::read::TileRequest()
-                             .WithTileKey(tile_key)
-                             .WithFetchOption(read::CacheOnly);
+    const auto tile_key = TileKey::FromHereTile("23064");
+    const auto request =
+        read::TileRequest().WithTileKey(tile_key).WithFetchOption(
+            read::CacheOnly);
     olp::client::CancellationContext context;
 
     auto mock_network = std::make_shared<NetworkMock>();
@@ -1089,10 +1072,10 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
-    olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, layer, settings,
-                                                lookup_client);
-    auto response = repository.GetAggregatedTile(request, version, context);
+    ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, kVersionedLayerId,
+                                                settings, lookup_client);
+    auto response = repository.GetAggregatedTile(request, kVersion, context);
     const auto& error = response.GetError();
 
     ASSERT_FALSE(response.IsSuccessful());
@@ -1102,9 +1085,8 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
   {
     SCOPED_TRACE("QueryApi request failed");
 
-    const auto tile_key = olp::geo::TileKey::FromHereTile("23247");
-    const auto request =
-        olp::dataservice::read::TileRequest().WithTileKey(tile_key);
+    const auto tile_key = TileKey::FromHereTile("23247");
+    const auto request = read::TileRequest().WithTileKey(tile_key);
     olp::client::CancellationContext context;
 
     auto mock_network = std::make_shared<NetworkMock>();
@@ -1123,10 +1105,10 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
-    olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, layer, settings,
-                                                lookup_client);
-    auto response = repository.GetAggregatedTile(request, version, context);
+    ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, kVersionedLayerId,
+                                                settings, lookup_client);
+    auto response = repository.GetAggregatedTile(request, kVersion, context);
 
     const auto& error = response.GetError();
 
@@ -1139,9 +1121,8 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
   {
     SCOPED_TRACE("QuadTreeIndex request failed");
 
-    const auto tile_key = olp::geo::TileKey::FromHereTile("23247");
-    const auto request =
-        olp::dataservice::read::TileRequest().WithTileKey(tile_key);
+    const auto tile_key = TileKey::FromHereTile("23247");
+    const auto request = read::TileRequest().WithTileKey(tile_key);
     olp::client::CancellationContext context;
 
     auto mock_network = std::make_shared<NetworkMock>();
@@ -1154,7 +1135,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_network, Send(IsGetRequest(kUrlLookupQuery), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     kHttpResponceLookupQuery));
+                                     kHttpResponseLookupQuery));
     EXPECT_CALL(*mock_network,
                 Send(IsGetRequest(kQueryQuadTreeIndex), _, _, _, _))
         .WillOnce(
@@ -1166,10 +1147,10 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
-    olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, layer, settings,
-                                                lookup_client);
-    auto response = repository.GetAggregatedTile(request, version, context);
+    ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, kVersionedLayerId,
+                                                settings, lookup_client);
+    auto response = repository.GetAggregatedTile(request, kVersion, context);
 
     const auto& error = response.GetError();
 
@@ -1182,9 +1163,8 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
   {
     SCOPED_TRACE("Failed to parse json");
 
-    const auto tile_key = olp::geo::TileKey::FromHereTile("23247");
-    const auto request =
-        olp::dataservice::read::TileRequest().WithTileKey(tile_key);
+    const auto tile_key = TileKey::FromHereTile("23247");
+    const auto request = read::TileRequest().WithTileKey(tile_key);
     olp::client::CancellationContext context;
 
     auto mock_network = std::make_shared<NetworkMock>();
@@ -1197,7 +1177,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_network, Send(IsGetRequest(kUrlLookupQuery), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
-                                     kHttpResponceLookupQuery));
+                                     kHttpResponseLookupQuery));
     EXPECT_CALL(*mock_network,
                 Send(IsGetRequest(kQueryQuadTreeIndex), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
@@ -1208,10 +1188,10 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
-    olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, layer, settings,
-                                                lookup_client);
-    auto response = repository.GetAggregatedTile(request, version, context);
+    ApiLookupClient lookup_client(hrn, settings);
+    repository::PartitionsRepository repository(hrn, kVersionedLayerId,
+                                                settings, lookup_client);
+    auto response = repository.GetAggregatedTile(request, kVersion, context);
     const auto& error = response.GetError();
 
     ASSERT_FALSE(response.IsSuccessful());
@@ -1220,53 +1200,306 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
 }
 
 TEST_F(PartitionsRepositoryTest, GetTile) {
-  using olp::cache::KeyValueCache;
-  using testing::_;
+  using testing::Mock;
   using testing::Return;
 
-  constexpr auto version = 4u;
-  constexpr auto layer = "testlayer";
-
   const auto hrn = HRN::FromString(kCatalog);
+  olp::client::CancellationContext context;
+
+  auto mock_network = std::make_shared<NetworkMock>();
+  auto mock_cache = std::make_shared<CacheMock>();
+
+  OlpClientSettings settings;
+  settings.cache = mock_cache;
+  settings.network_request_handler = mock_network;
+
+  const auto depth = 4;
+  auto quad_cache_key = [&](const TileKey& key) {
+    return kCatalog + "::" + kVersionedLayerId + "::" + key.ToHereTile() +
+           "::" + std::to_string(kVersion) + "::" + std::to_string(depth) +
+           "::quadtree";
+  };
+
+  std::string expected_api = kCatalog + "::query::v1::api";
+  ApiLookupClient lookup_client(hrn, settings);
+  EXPECT_CALL(*mock_cache, Get(expected_api, _)).WillOnce(Return(kUrlQueryApi));
+
+  auto tile_key = TileKey::FromHereTile("23064");
+  auto root = tile_key.ChangedLevelBy(-depth);
+  auto request = read::TileRequest().WithTileKey(tile_key);
+
+  const auto setup_get_cached_quad_expectations =
+      [&](const boost::optional<std::string>& root_data = boost::none) {
+        testing::InSequence sequence;
+
+        for (auto i = 0; i < depth; ++i) {
+          EXPECT_CALL(*mock_cache,
+                      Get(quad_cache_key(tile_key.ChangedLevelBy(-i))))
+              .WillOnce(Return(nullptr));
+        }
+
+        EXPECT_CALL(*mock_cache, Get(quad_cache_key(root)))
+            .WillOnce(testing::WithoutArgs(
+                [=]() -> cache::KeyValueCache::ValueTypePtr {
+                  if (!root_data) {
+                    return nullptr;
+                  }
+
+                  auto stream = std::stringstream(*root_data);
+                  read::QuadTreeIndex quad_tree(root, depth, stream);
+                  return quad_tree.GetRawData();
+                }));
+      };
 
   {
-    SCOPED_TRACE("Get tile not aggregated, if parent exist");
+    SCOPED_TRACE("Get tile not aggregated, partition not found");
 
-    const auto tile_key = olp::geo::TileKey::FromHereTile("23064");
-    const auto parent_tile_key = tile_key.ChangedLevelBy(-6).ToHereTile();
-    const auto request =
-        olp::dataservice::read::TileRequest().WithTileKey(tile_key);
-    olp::client::CancellationContext context;
-
-    auto mock_network = std::make_shared<NetworkMock>();
-    auto mock_cache = std::make_shared<CacheMock>();
-
-    OlpClientSettings settings;
-    settings.cache = mock_cache;
-    settings.network_request_handler = mock_network;
-
-    EXPECT_CALL(*mock_network, Send(IsGetRequest(kUrlLookupQuery), _, _, _, _))
-        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
-                                         olp::http::HttpStatusCode::OK),
-                                     kHttpResponceLookupQuery));
+    setup_get_cached_quad_expectations();
     EXPECT_CALL(*mock_network,
                 Send(IsGetRequest(kQueryQuadTreeIndex), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
                                      kSubQuadsWithParent));
-    EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(boost::any()));
-    EXPECT_CALL(*mock_cache, Put(_, _, _, _)).WillOnce(Return(true));
-    EXPECT_CALL(*mock_cache, Get(_))
-        .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
-    EXPECT_CALL(*mock_cache, Put(_, _, _)).WillOnce(Return(true));
+    EXPECT_CALL(*mock_cache, Put(quad_cache_key(root), _, _))
+        .WillOnce(Return(true));
 
-    olp::client::ApiLookupClient lookup_client(hrn, settings);
-    repository::PartitionsRepository repository(hrn, layer, settings,
-                                                lookup_client);
-    auto response = repository.GetTile(request, version, context);
+    repository::PartitionsRepository repository(hrn, kVersionedLayerId,
+                                                settings, lookup_client);
+    const auto response = repository.GetTile(request, kVersion, context);
 
-    ASSERT_FALSE(response.IsSuccessful()) << response.GetError().GetMessage();
+    ASSERT_FALSE(response);
+
+    testing::Mock::VerifyAndClearExpectations(mock_network.get());
+    testing::Mock::VerifyAndClearExpectations(mock_cache.get());
+  }
+
+  const auto kHereTile = "5904591";
+  tile_key = TileKey::FromHereTile(kHereTile);
+  root = tile_key.ChangedLevelBy(-depth);
+  request = read::TileRequest().WithTileKey(tile_key);
+
+  {
+    SCOPED_TRACE("Get tile not aggregated");
+
+    setup_get_cached_quad_expectations();
+    EXPECT_CALL(*mock_network, Send(IsGetRequest(kQueryTreeIndex), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     kSubQuadsWithParent));
+    EXPECT_CALL(*mock_cache, Put(quad_cache_key(root), _, _))
+        .WillOnce(Return(true));
+
+    repository::PartitionsRepository repository(hrn, kVersionedLayerId,
+                                                settings, lookup_client);
+    const auto response = repository.GetTile(request, kVersion, context);
+
+    ASSERT_TRUE(response);
+    EXPECT_EQ(response.GetResult().GetPartition(), kHereTile);
+
+    testing::Mock::VerifyAndClearExpectations(mock_network.get());
+    testing::Mock::VerifyAndClearExpectations(mock_cache.get());
+  }
+
+  std::vector<std::string> all_additional_fields = {
+      read::PartitionsRequest::kChecksum, read::PartitionsRequest::kCrc,
+      read::PartitionsRequest::kDataSize,
+      read::PartitionsRequest::kCompressedDataSize};
+
+  // Expected values
+  int64_t data_size = 25;
+  int64_t compressed_data_size = 20;
+  std::string checksum = "yyy";
+  std::string crc = "bbb";
+
+  {
+    SCOPED_TRACE("Get tile not aggregated with additional fields");
+
+    setup_get_cached_quad_expectations();
+    EXPECT_CALL(
+        *mock_network,
+        Send(IsGetRequest(kQueryTreeIndexWithAdditionalFields), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     kSubQuadsWithParentAndAdditionalFields));
+    EXPECT_CALL(*mock_cache, Put(quad_cache_key(root), _, _))
+        .WillOnce(Return(true));
+
+    repository::PartitionsRepository repository(hrn, kVersionedLayerId,
+                                                settings, lookup_client);
+    const auto response =
+        repository.GetTile(request, kVersion, context, all_additional_fields);
+
+    ASSERT_TRUE(response);
+    const auto& result = response.GetResult();
+    EXPECT_EQ(result.GetPartition(), kHereTile);
+    EXPECT_TRUE(result.GetDataSize());
+    EXPECT_EQ(*result.GetDataSize(), data_size);
+    EXPECT_TRUE(result.GetCompressedDataSize());
+    EXPECT_EQ(*result.GetCompressedDataSize(), compressed_data_size);
+    EXPECT_TRUE(result.GetChecksum());
+    EXPECT_EQ(*result.GetChecksum(), checksum);
+    EXPECT_TRUE(result.GetCrc());
+    EXPECT_EQ(*result.GetCrc(), crc);
+
+    testing::Mock::VerifyAndClearExpectations(mock_network.get());
+    testing::Mock::VerifyAndClearExpectations(mock_cache.get());
+  }
+
+  {
+    SCOPED_TRACE(
+        "Cached partition without additional fields, request without "
+        "additional fields");
+
+    setup_get_cached_quad_expectations(kSubQuadsWithParent);
+    EXPECT_CALL(*mock_network, Send(_, _, _, _, _)).Times(0);
+    EXPECT_CALL(*mock_cache, Put(_, _, _)).Times(0);
+
+    repository::PartitionsRepository repository(hrn, kVersionedLayerId,
+                                                settings, lookup_client);
+    const auto response = repository.GetTile(request, kVersion, context);
+
+    ASSERT_TRUE(response);
+    const auto& result = response.GetResult();
+    EXPECT_EQ(result.GetPartition(), kHereTile);
+    EXPECT_FALSE(result.GetDataSize());
+    EXPECT_FALSE(result.GetCompressedDataSize());
+    EXPECT_FALSE(result.GetChecksum());
+    EXPECT_FALSE(result.GetCrc());
+
+    testing::Mock::VerifyAndClearExpectations(mock_network.get());
+    testing::Mock::VerifyAndClearExpectations(mock_cache.get());
+  }
+
+  {
+    SCOPED_TRACE(
+        "Cached partition with additional fields, request without additional "
+        "fields");
+
+    setup_get_cached_quad_expectations(kSubQuadsWithParentAndAdditionalFields);
+    EXPECT_CALL(*mock_network, Send(_, _, _, _, _)).Times(0);
+    EXPECT_CALL(*mock_cache, Put(_, _, _)).Times(0);
+
+    repository::PartitionsRepository repository(hrn, kVersionedLayerId,
+                                                settings, lookup_client);
+    const auto response = repository.GetTile(request, kVersion, context);
+
+    ASSERT_TRUE(response);
+    const auto& result = response.GetResult();
+    EXPECT_EQ(result.GetPartition(), kHereTile);
+    EXPECT_TRUE(result.GetDataSize());
+    EXPECT_EQ(*result.GetDataSize(), data_size);
+    EXPECT_TRUE(result.GetCompressedDataSize());
+    EXPECT_EQ(*result.GetCompressedDataSize(), compressed_data_size);
+    EXPECT_TRUE(result.GetChecksum());
+    EXPECT_EQ(*result.GetChecksum(), checksum);
+    EXPECT_TRUE(result.GetCrc());
+    EXPECT_EQ(*result.GetCrc(), crc);
+
+    testing::Mock::VerifyAndClearExpectations(mock_network.get());
+    testing::Mock::VerifyAndClearExpectations(mock_cache.get());
+  }
+
+  {
+    SCOPED_TRACE(
+        "Cached partition without additional fields, request with additional "
+        "fields");
+
+    setup_get_cached_quad_expectations(kSubQuadsWithParent);
+    EXPECT_CALL(
+        *mock_network,
+        Send(IsGetRequest(kQueryTreeIndexWithAdditionalFields), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     kSubQuadsWithParentAndAdditionalFields));
+    EXPECT_CALL(*mock_cache, Put(quad_cache_key(root), _, _))
+        .WillOnce(Return(true));
+
+    repository::PartitionsRepository repository(hrn, kVersionedLayerId,
+                                                settings, lookup_client);
+    const auto response =
+        repository.GetTile(request, kVersion, context, all_additional_fields);
+
+    ASSERT_TRUE(response);
+    const auto& result = response.GetResult();
+    EXPECT_EQ(result.GetPartition(), kHereTile);
+    EXPECT_TRUE(result.GetDataSize());
+    EXPECT_EQ(*result.GetDataSize(), data_size);
+    EXPECT_TRUE(result.GetCompressedDataSize());
+    EXPECT_EQ(*result.GetCompressedDataSize(), compressed_data_size);
+    EXPECT_TRUE(result.GetChecksum());
+    EXPECT_EQ(*result.GetChecksum(), checksum);
+    EXPECT_TRUE(result.GetCrc());
+    EXPECT_EQ(*result.GetCrc(), crc);
+
+    testing::Mock::VerifyAndClearExpectations(mock_network.get());
+    testing::Mock::VerifyAndClearExpectations(mock_cache.get());
+  }
+
+  {
+    SCOPED_TRACE(
+        "Cached partition with not all additional fields, request with all "
+        "additional fields");
+
+    setup_get_cached_quad_expectations(
+        kSubQuadsWithParentAndAdditionalFieldsWithoutCrc);
+    EXPECT_CALL(
+        *mock_network,
+        Send(IsGetRequest(kQueryTreeIndexWithAdditionalFields), _, _, _, _))
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     kSubQuadsWithParentAndAdditionalFields));
+    EXPECT_CALL(*mock_cache, Put(quad_cache_key(root), _, _))
+        .WillOnce(Return(true));
+
+    repository::PartitionsRepository repository(hrn, kVersionedLayerId,
+                                                settings, lookup_client);
+    const auto response =
+        repository.GetTile(request, kVersion, context, all_additional_fields);
+
+    ASSERT_TRUE(response);
+    const auto& result = response.GetResult();
+    EXPECT_EQ(result.GetPartition(), kHereTile);
+    EXPECT_TRUE(result.GetDataSize());
+    EXPECT_EQ(*result.GetDataSize(), data_size);
+    EXPECT_TRUE(result.GetCompressedDataSize());
+    EXPECT_EQ(*result.GetCompressedDataSize(), compressed_data_size);
+    EXPECT_TRUE(result.GetChecksum());
+    EXPECT_EQ(*result.GetChecksum(), checksum);
+    EXPECT_TRUE(result.GetCrc());
+    EXPECT_EQ(*result.GetCrc(), crc);
+
+    testing::Mock::VerifyAndClearExpectations(mock_network.get());
+    testing::Mock::VerifyAndClearExpectations(mock_cache.get());
+  }
+
+  {
+    SCOPED_TRACE(
+        "Cached partition with additional fields, request with additional "
+        "fields");
+
+    setup_get_cached_quad_expectations(kSubQuadsWithParentAndAdditionalFields);
+    EXPECT_CALL(*mock_network, Send(_, _, _, _, _)).Times(0);
+    EXPECT_CALL(*mock_cache, Put(_, _, _)).Times(0);
+
+    repository::PartitionsRepository repository(hrn, kVersionedLayerId,
+                                                settings, lookup_client);
+    const auto response =
+        repository.GetTile(request, kVersion, context, all_additional_fields);
+
+    ASSERT_TRUE(response);
+    const auto& result = response.GetResult();
+    EXPECT_EQ(result.GetPartition(), kHereTile);
+    EXPECT_TRUE(result.GetDataSize());
+    EXPECT_EQ(*result.GetDataSize(), data_size);
+    EXPECT_TRUE(result.GetCompressedDataSize());
+    EXPECT_EQ(*result.GetCompressedDataSize(), compressed_data_size);
+    EXPECT_TRUE(result.GetChecksum());
+    EXPECT_EQ(*result.GetChecksum(), checksum);
+    EXPECT_TRUE(result.GetCrc());
+    EXPECT_EQ(*result.GetCrc(), crc);
+
+    testing::Mock::VerifyAndClearExpectations(mock_network.get());
+    testing::Mock::VerifyAndClearExpectations(mock_cache.get());
   }
 }
-
 }  // namespace

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@
 #include <olp/core/client/OlpClientSettingsFactory.h>
 #include <olp/core/porting/warning_disable.h>
 #include <olp/core/utils/Dir.h>
+#include <olp/core/utils/Url.h>
 #include <olp/dataservice/read/VersionedLayerClient.h>
 #include <olp/dataservice/read/model/Partitions.h>
 
@@ -93,8 +94,15 @@ constexpr char kHttpResponseBlobData_5904591[] =
 constexpr char kHttpQueryTreeIndex_23064[] =
     R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/testlayer/versions/4/quadkeys/23064/depths/4)";
 
+const auto kHttpQueryTreeIndexWithAdditionalFields_23064 =
+    std::string(kHttpQueryTreeIndex_23064) +
+    "?additionalFields=" + olp::utils::Url::Encode("checksum,crc,dataSize");
+
 constexpr char kHttpSubQuads_23064[] =
     R"jsonString({"subQuads": [{"subQuadKey":"115","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"463","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString";
+
+constexpr char kHttpSubQuadsWithAdditionalFields_23064[] =
+    R"jsonString({"subQuads": [{"subQuadKey":"115","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1","checksum":"xxx","dataSize":10,"crc":"aaa"},{"subQuadKey":"463","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1","checksum":"yyy","dataSize":20,"crc":"bbb"}],"parentQuads": []})jsonString";
 
 constexpr char kUrlBlobData_1476147[] =
     R"(https://blob-ireland.data.api.platform.here.com/blobstore/v1/catalogs/hereos-internal-test-v2/layers/testlayer/data/95c5c703-e00e-4c38-841e-e419367474f1)";
@@ -4502,6 +4510,160 @@ TEST_F(DataserviceReadVersionedLayerClientTest, OverlappingQuads) {
 
   // remove cache folder
   olp::utils::Dir::remove(cache_path);
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest, QuadTreeIndex) {
+  auto client = std::make_shared<read::VersionedLayerClient>(
+      kCatalog, kTestLayer, 4, settings_);
+
+  EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_API), _, _, _, _));
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(kHttpQueryTreeIndexWithAdditionalFields_23064),
+                   _, _, _, _))
+      .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
+                                   kHttpSubQuadsWithAdditionalFields_23064));
+
+  std::promise<PartitionsResponse> promise;
+  auto request =
+      read::TileRequest().WithTileKey(geo::TileKey::FromHereTile("5904591"));
+  auto cancellation_context =
+      client->QuadTreeIndex(request, [&](PartitionsResponse response) {
+        promise.set_value(std::move(response));
+      });
+
+  const auto response = promise.get_future().get();
+  ASSERT_TRUE(response);
+
+  const auto& partitions = response.GetResult().GetPartitions();
+  ASSERT_EQ(partitions.size(), 1u);
+
+  const auto& partition = partitions.front();
+  ASSERT_TRUE(partition.GetChecksum());
+  EXPECT_EQ(*partition.GetChecksum(), "yyy");
+  ASSERT_TRUE(partition.GetCrc());
+  EXPECT_EQ(*partition.GetCrc(), "bbb");
+  ASSERT_TRUE(partition.GetDataSize());
+  EXPECT_EQ(*partition.GetDataSize(), 20);
+}
+
+TEST_F(DataserviceReadVersionedLayerClientTest, QuadTreeIndexFallback) {
+  auto client = std::make_shared<read::VersionedLayerClient>(
+      kCatalog, kTestLayer, 4, settings_);
+  {
+    SCOPED_TRACE("Load the data without additional fields to the cache");
+
+    EXPECT_CALL(*network_mock_, Send(IsGetRequest(URL_LOOKUP_API), _, _, _, _));
+    EXPECT_CALL(
+        *network_mock_,
+        Send(IsGetRequest(kHttpQueryTreeIndexWithAdditionalFields_23064), _, _,
+             _, _))
+        .Times(2)
+        .WillRepeatedly(ReturnHttpResponse(
+            GetResponse(http::HttpStatusCode::OK), kHttpSubQuads_23064));
+
+    std::promise<PartitionsResponse> promise;
+    auto request =
+        read::TileRequest().WithTileKey(geo::TileKey::FromHereTile("5904591"));
+    auto cancellation_context =
+        client->QuadTreeIndex(request, [&](PartitionsResponse response) {
+          promise.set_value(std::move(response));
+        });
+
+    auto response = promise.get_future().get();
+    ASSERT_TRUE(response);
+
+    const auto& partitions = response.GetResult().GetPartitions();
+    ASSERT_EQ(partitions.size(), 1u);
+
+    const auto& partition = partitions.front();
+    EXPECT_FALSE(partition.GetChecksum());
+    EXPECT_FALSE(partition.GetCrc());
+    EXPECT_FALSE(partition.GetDataSize());
+  }
+  {
+    SCOPED_TRACE("Load the data with CacheOnly fetch option");
+
+    std::promise<PartitionsResponse> promise;
+    auto request = read::TileRequest()
+                       .WithTileKey(geo::TileKey::FromHereTile("5904591"))
+                       .WithFetchOption(FetchOptions::CacheOnly);
+    auto cancellation_context =
+        client->QuadTreeIndex(request, [&](PartitionsResponse response) {
+          promise.set_value(std::move(response));
+        });
+
+    auto response = promise.get_future().get();
+    ASSERT_TRUE(response);
+
+    const auto& partitions = response.GetResult().GetPartitions();
+    ASSERT_EQ(partitions.size(), 1u);
+
+    const auto& partition = partitions.front();
+    EXPECT_FALSE(partition.GetChecksum());
+    EXPECT_FALSE(partition.GetCrc());
+    EXPECT_FALSE(partition.GetDataSize());
+  }
+  {
+    SCOPED_TRACE("Load the data when it is cached without additional fields");
+
+    EXPECT_CALL(
+        *network_mock_,
+        Send(IsGetRequest(kHttpQueryTreeIndexWithAdditionalFields_23064), _, _,
+             _, _))
+        .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
+                                     kHttpSubQuadsWithAdditionalFields_23064));
+
+    std::promise<PartitionsResponse> promise;
+    auto request =
+        read::TileRequest().WithTileKey(geo::TileKey::FromHereTile("5904591"));
+    auto cancellation_context =
+        client->QuadTreeIndex(request, [&](PartitionsResponse response) {
+          promise.set_value(std::move(response));
+        });
+
+    auto response = promise.get_future().get();
+    ASSERT_TRUE(response);
+
+    const auto& partitions = response.GetResult().GetPartitions();
+    ASSERT_EQ(partitions.size(), 1u);
+
+    const auto& partition = partitions.front();
+    ASSERT_TRUE(partition.GetChecksum());
+    EXPECT_EQ(*partition.GetChecksum(), "yyy");
+    ASSERT_TRUE(partition.GetCrc());
+    EXPECT_EQ(*partition.GetCrc(), "bbb");
+    ASSERT_TRUE(partition.GetDataSize());
+    EXPECT_EQ(*partition.GetDataSize(), 20);
+  }
+  {
+    SCOPED_TRACE("Load the data with CacheOnly fetch option again");
+
+    std::promise<PartitionsResponse> promise;
+    auto request = read::TileRequest()
+                       .WithTileKey(geo::TileKey::FromHereTile("5904591"))
+                       .WithFetchOption(FetchOptions::CacheOnly);
+    auto cancellation_context =
+        client->QuadTreeIndex(request, [&](PartitionsResponse response) {
+          promise.set_value(std::move(response));
+        });
+
+    auto future = promise.get_future();
+    ASSERT_EQ(future.wait_for(kWaitTimeout), std::future_status::ready);
+
+    const auto response = future.get();
+    ASSERT_TRUE(response);
+
+    const auto& partitions = response.GetResult().GetPartitions();
+    ASSERT_EQ(partitions.size(), 1u);
+
+    const auto& partition = partitions.front();
+    ASSERT_TRUE(partition.GetChecksum());
+    EXPECT_EQ(*partition.GetChecksum(), "yyy");
+    ASSERT_TRUE(partition.GetCrc());
+    EXPECT_EQ(*partition.GetCrc(), "bbb");
+    ASSERT_TRUE(partition.GetDataSize());
+    EXPECT_EQ(*partition.GetDataSize(), 20);
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
A new API VersionedLayerClient::QuadTreeIndex has been introduced
to get partitions including additional fields.

PartitionsRepository::GetTile and
PartitionsRepository::GetQuadTreeIndexForTile APIs have been extended
with additional_fields argument.

QuadTreeIndex class has been extended with crc.

New tests have been added to cover source code changes.
Touched test files have been slightly refactored.

Relates-To: OAM-1496

Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>
Signed-off-by: Mykola Malik <ext-mykola.malik@here.com>