### PR TITLE
Change readonly result in case of absent target

### DIFF
--- a/olp-cpp-sdk-core/src/utils/Dir.cpp
+++ b/olp-cpp-sdk-core/src/utils/Dir.cpp
@@ -514,7 +514,7 @@ bool Dir::IsReadOnly(const std::string& path) {
   CloseHandle(handle);
   return false;
 #else
-  return access(path.c_str(), W_OK) != 0;
+  return !(access(path.c_str(), W_OK) == 0 || errno == ENOENT);
 #endif
 }
 


### PR DESCRIPTION
- Add error handling to detect if dir checked for access rights is
  absent. Thus in case when access() method returns error, and
  errno variable is set to ENOENT (no such entry), false returned
  to indicate that directory with proper access rights could be
  created

Relates-To: OAM-1168

Signed-off-by: Viacheslav Marusyk <ext-viacheslav.marusyk@here.com>