### PR TITLE
Change access permissions for newly created dirs

### DIFF
--- a/olp-cpp-sdk-core/src/utils/Dir.cpp
+++ b/olp-cpp-sdk-core/src/utils/Dir.cpp
@@ -282,7 +282,7 @@ bool Dir::Create(const std::string& path) {
 #if !defined(_WIN32) || defined(__MINGW32__)
   struct stat sbuf;
   if (stat(path.c_str(), &sbuf) != 0) {
-    if (!mkdir_all(path.c_str(), 0777)) {
+    if (!mkdir_all(path.c_str(), 0774)) {
       ret = false;
     }
   }


### PR DESCRIPTION
- Create a new directories with r/o permission for other users

Relates-To: OAM-1535

Signed-off-by: Viacheslav Marusyk <ext-viacheslav.marusyk@here.com>