### PR TITLE
Change the order of getting data from cache

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
@@ -95,10 +95,10 @@ client::ApiNoResponse PartitionsCacheRepository::Put(
         cache::KeyGenerator::CreatePartitionsKey(catalog_, layer_id_, version);
     OLP_SDK_LOG_DEBUG_F(kLogTag, "Put -> '%s'", key.c_str());
 
-    const auto put_result =
-        cache_->Put(key, partition_ids,
-                    [&]() { return serializer::serialize(partition_ids); },
-                    expiry.get_value_or(default_expiry_));
+    const auto put_result = cache_->Put(
+        key, partition_ids,
+        [&]() { return serializer::serialize(partition_ids); },
+        expiry.get_value_or(default_expiry_));
 
     if (!put_result) {
       OLP_SDK_LOG_ERROR_F(kLogTag, "Failed to write -> '%s'", key.c_str());
@@ -175,9 +175,9 @@ void PartitionsCacheRepository::Put(
       cache::KeyGenerator::CreateLayerVersionsKey(catalog_, catalog_version);
   OLP_SDK_LOG_DEBUG_F(kLogTag, "Put -> '%s'", key.c_str());
 
-  cache_->Put(key, layer_versions,
-              [&]() { return serializer::serialize(layer_versions); },
-              default_expiry_);
+  cache_->Put(
+      key, layer_versions,
+      [&]() { return serializer::serialize(layer_versions); }, default_expiry_);
 }
 
 boost::optional<model::LayerVersions> PartitionsCacheRepository::Get(
@@ -312,7 +312,7 @@ bool PartitionsCacheRepository::FindQuadTree(geo::TileKey key,
                                              boost::optional<int64_t> version,
                                              read::QuadTreeIndex& tree) {
   auto max_depth = std::min<std::uint32_t>(key.Level(), kMaxQuadTreeIndexDepth);
-  for (auto i = 0u; i <= max_depth; ++i) {
+  for (int32_t i = max_depth; i >= 0; i--) {
     const auto& root_tile_key = key.ChangedLevelBy(-i);
     QuadTreeIndex cached_tree;
     if (Get(root_tile_key, kMaxQuadTreeIndexDepth, version, cached_tree)) {

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -241,8 +241,7 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
   {
     SCOPED_TRACE("Fetch from cache [CacheOnly] negative");
 
-    EXPECT_CALL(*cache, Get(cache_key, _))
-        .WillOnce(Return(boost::any()));
+    EXPECT_CALL(*cache, Get(cache_key, _)).WillOnce(Return(boost::any()));
 
     client::CancellationContext context;
     auto response = repository.GetPartitionById(
@@ -372,8 +371,7 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
         "Network error 403 clears cache and is propagated to the user");
     setup_online_only_mocks();
     setup_positive_metadata_mocks();
-    EXPECT_CALL(*cache, Get(cache_key, _))
-        .WillOnce(Return(boost::any()));
+    EXPECT_CALL(*cache, Get(cache_key, _)).WillOnce(Return(boost::any()));
 
     EXPECT_CALL(*network,
                 Send(IsGetRequest(kOlpSdkUrlPartitionById), _, _, _, _))
@@ -1232,13 +1230,13 @@ TEST_F(PartitionsRepositoryTest, GetTile) {
       [&](const boost::optional<std::string>& root_data = boost::none) {
         testing::InSequence sequence;
 
-        for (auto i = 0; i < depth; ++i) {
+        for (int32_t i = depth; i > 0; --i) {
           EXPECT_CALL(*mock_cache,
                       Get(quad_cache_key(tile_key.ChangedLevelBy(-i))))
               .WillOnce(Return(nullptr));
         }
 
-        EXPECT_CALL(*mock_cache, Get(quad_cache_key(root)))
+        EXPECT_CALL(*mock_cache, Get(quad_cache_key(tile_key)))
             .WillOnce(testing::WithoutArgs(
                 [=]() -> cache::KeyValueCache::ValueTypePtr {
                   if (!root_data) {

--- a/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientImplTest.cpp
@@ -204,11 +204,11 @@ TEST(VersionedLayerClientTest, RemoveFromCacheTileKey) {
 
     EXPECT_CALL(*cache_mock, Get(_))
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
-          EXPECT_EQ(key, quad_cache_key(tile_key));
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-4)));
           return nullptr;
         })
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
-          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-1)));
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-3)));
           return nullptr;
         })
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
@@ -216,12 +216,12 @@ TEST(VersionedLayerClientTest, RemoveFromCacheTileKey) {
           return nullptr;
         })
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
-          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-3)));
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-1)));
           return nullptr;
         })
         .WillOnce(
             [&tile_key, &quad_cache_key, &buffer](const std::string& key) {
-              EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-4)));
+              EXPECT_EQ(key, quad_cache_key(tile_key));
               return buffer;
             });
     EXPECT_CALL(*cache_mock, RemoveKeysWithPrefix(_))
@@ -230,20 +230,11 @@ TEST(VersionedLayerClientTest, RemoveFromCacheTileKey) {
         .WillRepeatedly([&](const std::string&) { return true; });
     ASSERT_TRUE(client.RemoveFromCache(tile_key));
   }
-
   {
     SCOPED_TRACE("Remove not existing tile from cache");
     EXPECT_CALL(*cache_mock, Get(_))
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
-          EXPECT_EQ(key, quad_cache_key(tile_key));
-          return nullptr;
-        })
-        .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
-          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-1)));
-          return nullptr;
-        })
-        .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
-          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-2)));
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-4)));
           return nullptr;
         })
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
@@ -251,7 +242,15 @@ TEST(VersionedLayerClientTest, RemoveFromCacheTileKey) {
           return nullptr;
         })
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
-          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-4)));
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-2)));
+          return nullptr;
+        })
+        .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-1)));
+          return nullptr;
+        })
+        .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
+          EXPECT_EQ(key, quad_cache_key(tile_key));
           return nullptr;
         });
     ASSERT_TRUE(client.RemoveFromCache(tile_key));
@@ -260,11 +259,11 @@ TEST(VersionedLayerClientTest, RemoveFromCacheTileKey) {
     SCOPED_TRACE("Data cache failure");
     EXPECT_CALL(*cache_mock, Get(_))
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
-          EXPECT_EQ(key, quad_cache_key(tile_key));
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-4)));
           return nullptr;
         })
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
-          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-1)));
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-3)));
           return nullptr;
         })
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
@@ -272,12 +271,12 @@ TEST(VersionedLayerClientTest, RemoveFromCacheTileKey) {
           return nullptr;
         })
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
-          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-3)));
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-1)));
           return nullptr;
         })
         .WillOnce(
             [&tile_key, &quad_cache_key, &buffer](const std::string& key) {
-              EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-4)));
+              EXPECT_EQ(key, quad_cache_key(tile_key));
               return buffer;
             });
     EXPECT_CALL(*cache_mock, RemoveKeysWithPrefix(_))
@@ -288,11 +287,11 @@ TEST(VersionedLayerClientTest, RemoveFromCacheTileKey) {
     SCOPED_TRACE("Successful remove tile and quad tree from cache");
     EXPECT_CALL(*cache_mock, Get(_))
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
-          EXPECT_EQ(key, quad_cache_key(tile_key));
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-4)));
           return nullptr;
         })
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
-          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-1)));
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-3)));
           return nullptr;
         })
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
@@ -300,12 +299,12 @@ TEST(VersionedLayerClientTest, RemoveFromCacheTileKey) {
           return nullptr;
         })
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
-          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-3)));
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-1)));
           return nullptr;
         })
         .WillOnce(
             [&tile_key, &quad_cache_key, &buffer](const std::string& key) {
-              EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-4)));
+              EXPECT_EQ(key, quad_cache_key(tile_key));
               return buffer;
             });
     EXPECT_CALL(*cache_mock, RemoveKeysWithPrefix(_))
@@ -319,11 +318,11 @@ TEST(VersionedLayerClientTest, RemoveFromCacheTileKey) {
     SCOPED_TRACE("Successful remove tile but removing quad tree fails");
     EXPECT_CALL(*cache_mock, Get(_))
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
-          EXPECT_EQ(key, quad_cache_key(tile_key));
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-4)));
           return nullptr;
         })
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
-          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-1)));
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-3)));
           return nullptr;
         })
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
@@ -331,12 +330,12 @@ TEST(VersionedLayerClientTest, RemoveFromCacheTileKey) {
           return nullptr;
         })
         .WillOnce([&tile_key, &quad_cache_key](const std::string& key) {
-          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-3)));
+          EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-1)));
           return nullptr;
         })
         .WillOnce(
             [&tile_key, &quad_cache_key, &buffer](const std::string& key) {
-              EXPECT_EQ(key, quad_cache_key(tile_key.ChangedLevelBy(-4)));
+              EXPECT_EQ(key, quad_cache_key(tile_key));
               return buffer;
             });
     EXPECT_CALL(*cache_mock, RemoveKeysWithPrefix(_))
@@ -1207,12 +1206,12 @@ TEST(VersionedLayerClientTest, CacheErrorsDuringPrefetch) {
 
     std::promise<read::PrefetchTilesResponse> promise;
 
-    auto token =
-        client.PrefetchTiles(request,
-                             [&promise](read::PrefetchTilesResponse response) {
-                               promise.set_value(std::move(response));
-                             },
-                             nullptr);
+    auto token = client.PrefetchTiles(
+        request,
+        [&promise](read::PrefetchTilesResponse response) {
+          promise.set_value(std::move(response));
+        },
+        nullptr);
 
     auto future = promise.get_future();
     ASSERT_NE(future.wait_for(std::chrono::seconds(kTimeout)),


### PR DESCRIPTION
Change the order of getting data from cache based on
level: previously the first check started from the highest
value, currently	from the lowest.

Relates-To: OLPSUP-18351

Signed-off-by: Yevhenii Dudnyk <ext-yevhenii.dudnyk@here.com>