### PR TITLE
Fix path duplication with catalog endpoint provider

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/generated/api/ConfigApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/ConfigApi.cpp
@@ -43,7 +43,8 @@ ConfigApi::CatalogResponse ConfigApi::GetCatalog(
   if (billing_tag) {
     query_params.insert(std::make_pair("billingTag", *billing_tag));
   }
-  std::string catalog_uri = "/catalogs/" + catalog_hrn;
+  auto catalog_uri =
+      catalog_hrn.empty() ? std::string() : "/catalogs/" + catalog_hrn;
 
   client::HttpResponse response = client.CallApi(
       std::move(catalog_uri), "GET", std::move(query_params),

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
@@ -54,7 +54,10 @@ CatalogResponse CatalogRepository::GetCatalog(
     const CatalogRequest& request, client::CancellationContext context) {
   const auto request_key = request.CreateKey();
   const auto fetch_options = request.GetFetchOption();
-  const auto catalog_str = catalog_.ToCatalogHRNString();
+  const auto catalog_str =
+      settings_.api_lookup_settings.catalog_endpoint_provider
+          ? std::string()
+          : catalog_.ToCatalogHRNString();
 
   repository::CatalogCacheRepository repository(
       catalog_, settings_.cache, settings_.default_cache_expiration);


### PR DESCRIPTION
Fix path duplication when using catalog endpoint provider:
as it's base url being set in GetStaticUrl method of OlpClient
there is no need to add path later in GetCatalog.

Relates-To: OLPEDGE-2730

Signed-off-by: Yevhenii Dudnyk <ext-yevhenii.dudnyk@here.com>