### PR TITLE
Add device_id field to SignInProperties

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,8 @@ namespace authentication {
 class AuthenticationClientImpl;
 
 /**
- * @brief Provides programmatic access to the HERE Account Authentication Service.
+ * @brief Provides programmatic access to the HERE Account Authentication
+ * Service.
  *
  * The supported APIs mirror the REST APIs currently available for the HERE
  * Account Authentication Service.
@@ -66,6 +67,14 @@ class AUTHENTICATION_API AuthenticationClient {
      * @brief (Optional) The scope assigned to the access token.
      */
     boost::optional<std::string> scope{boost::none};
+
+    /**
+     * @brief (Optional) The device ID assigned to the access token.
+     *
+     * @note This field is only necessary if you want to apply a oauth rate
+     * limit on a particular device.
+     */
+    boost::optional<std::string> device_id{boost::none};
 
     /**
      * @brief (Optional) The number of seconds left before the access

--- a/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,7 @@ constexpr auto kEmail = "email";
 constexpr auto kFirstName = "firstname";
 constexpr auto kGrantType = "grantType";
 constexpr auto kScope = "scope";
+constexpr auto kDeviceId = "deviceId";
 constexpr auto kInviteToken = "inviteToken";
 constexpr auto kLanguage = "language";
 constexpr auto kLastName = "lastname";
@@ -792,6 +793,12 @@ client::OlpClient::RequestBodyType AuthenticationClientImpl::GenerateClientBody(
     writer.Key(kScope);
     writer.String(properties.scope.get().c_str());
   }
+
+  if (properties.device_id) {
+    writer.Key(kDeviceId);
+    writer.String(properties.device_id.get().c_str());
+  }
+
   writer.EndObject();
   auto content = data.GetString();
   return std::make_shared<RequestBodyData>(content, content + data.GetSize());


### PR DESCRIPTION
Add device_id property to the SignInProperties for implementing
rate limiting by device functionality.

Relates-To: OLPEDGE-2745

Signed-off-by: Yevhenii Dudnyk <ext-yevhenii.dudnyk@here.com>