### PR TITLE
Add cache optimizations

### DIFF
--- a/olp-cpp-sdk-core/src/cache/InMemoryCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/InMemoryCache.cpp
@@ -25,6 +25,10 @@ namespace {
 inline bool HasExpiry(time_t expiry_seconds) {
   return (expiry_seconds != InMemoryCache::kExpiryMax);
 }
+bool IsPrefix(const std::string& key, const std::string& prefix) {
+  return (key.size() >= prefix.size()) &&
+         (memcmp(key.data(), prefix.data(), prefix.size()) == 0);
+}
 }  // namespace
 
 InMemoryCache::InMemoryCache(size_t max_size, ModelCacheCostFunc cache_cost,
@@ -98,7 +102,7 @@ void InMemoryCache::RemoveKeysWithPrefix(const std::string& key_prefix,
   std::lock_guard<std::mutex> lock{mutex_};
 
   for (auto it = item_tuples_.begin(); it != item_tuples_.end();) {
-    if (it->key().substr(0, key_prefix.length()) == key_prefix) {
+    if (IsPrefix(it.key(), key_prefix)) {
       // Check if this key is not protected, and if it is do not remove
       if (filter && filter(it->key())) {
         ++it;

--- a/olp-cpp-sdk-core/src/cache/ProtectedKeyList.cpp
+++ b/olp-cpp-sdk-core/src/cache/ProtectedKeyList.cpp
@@ -147,6 +147,10 @@ bool ProtectedKeyList::Release(const KeyValueCache::KeyListType& keys) {
 }
 
 bool ProtectedKeyList::IsProtected(const std::string& key) const {
+  if (protected_data_.empty()) {
+    return false;
+  }
+
   auto it = protected_data_.lower_bound(key);
   if (it == protected_data_.end()) {
     return false;

--- a/olp-cpp-sdk-core/tests/cache/DefaultCacheImplTest.cpp
+++ b/olp-cpp-sdk-core/tests/cache/DefaultCacheImplTest.cpp
@@ -232,8 +232,9 @@ TEST_F(DefaultCacheImplTest, LruCachePut) {
 
     cache.Open();
     cache.Clear();
-    cache.Put(key, data_string, [=]() { return data_string; },
-              (std::numeric_limits<time_t>::max)());
+    cache.Put(
+        key, data_string, [=]() { return data_string; },
+        (std::numeric_limits<time_t>::max)());
 
     EXPECT_TRUE(cache.ContainsLru(key));
   }
@@ -266,8 +267,9 @@ TEST_F(DefaultCacheImplTest, LruCacheGetPromote) {
 
   cache.Open();
   cache.Clear();
-  cache.Put(key1, data_string, [=]() { return data_string; },
-            (std::numeric_limits<time_t>::max)());
+  cache.Put(
+      key1, data_string, [=]() { return data_string; },
+      (std::numeric_limits<time_t>::max)());
   cache.Put(key2, std::make_shared<std::vector<unsigned char>>(binary_data),
             (std::numeric_limits<time_t>::max)());
 
@@ -334,8 +336,9 @@ TEST_F(DefaultCacheImplTest, LruCacheRemove) {
               (std::numeric_limits<time_t>::max)());
     cache.Put(key2, std::make_shared<std::vector<unsigned char>>(binary_data),
               (std::numeric_limits<time_t>::max)());
-    cache.Put(key3, data_string, [=]() { return data_string; },
-              (std::numeric_limits<time_t>::max)());
+    cache.Put(
+        key3, data_string, [=]() { return data_string; },
+        (std::numeric_limits<time_t>::max)());
 
     EXPECT_TRUE(cache.ContainsLru(key1));
     EXPECT_TRUE(cache.ContainsLru(key2));
@@ -379,7 +382,8 @@ TEST_F(DefaultCacheImplTest, MutableCacheExpired) {
   cache1.Clear();
 
   cache1.Put(key1, data_ptr, expiry);
-  cache1.Put(key2, data_string, [=]() { return data_string; }, expiry);
+  cache1.Put(
+      key2, data_string, [=]() { return data_string; }, expiry);
   cache1.Close();
 
   cache::CacheSettings settings2;
@@ -421,7 +425,8 @@ TEST_F(DefaultCacheImplTest, ProtectedCacheExpired) {
   cache1.Clear();
 
   cache1.Put(key1, data_ptr, expiry);
-  cache1.Put(key2, data_string, [=]() { return data_string; }, expiry);
+  cache1.Put(
+      key2, data_string, [=]() { return data_string; }, expiry);
   cache1.Close();
 
   cache::CacheSettings settings2;
@@ -468,13 +473,15 @@ TEST_F(DefaultCacheImplTest, MutableCacheSize) {
     cache.Open();
     cache.Clear();
 
-    cache.Put(key1, data_string, [=]() { return data_string; },
-              (std::numeric_limits<time_t>::max)());
+    cache.Put(
+        key1, data_string, [=]() { return data_string; },
+        (std::numeric_limits<time_t>::max)());
     auto data_size = key1.size() + data_string.size();
 
     EXPECT_EQ(data_size, cache.Size(CacheType::kMutable));
 
-    cache.Put(key2, data_string, [=]() { return data_string; }, expiry);
+    cache.Put(
+        key2, data_string, [=]() { return data_string; }, expiry);
     data_size +=
         key2.size() + data_string.size() + cache.CalculateExpirySize(key2);
 
@@ -509,8 +516,9 @@ TEST_F(DefaultCacheImplTest, MutableCacheSize) {
     cache.Clear();
 
     cache.Put(key1, data_ptr, (std::numeric_limits<time_t>::max)());
-    cache.Put(key2, data_string, [=]() { return data_string; },
-              (std::numeric_limits<time_t>::max)());
+    cache.Put(
+        key2, data_string, [=]() { return data_string; },
+        (std::numeric_limits<time_t>::max)());
 
     cache.Remove(key1);
     cache.Remove(key2);
@@ -527,7 +535,8 @@ TEST_F(DefaultCacheImplTest, MutableCacheSize) {
     cache.Clear();
 
     cache.Put(key1, data_ptr, expiry);
-    cache.Put(key2, data_string, [=]() { return data_string; }, expiry);
+    cache.Put(
+        key2, data_string, [=]() { return data_string; }, expiry);
 
     cache.Remove(key1);
     cache.Remove(key2);
@@ -545,7 +554,8 @@ TEST_F(DefaultCacheImplTest, MutableCacheSize) {
 
     cache.Put(key1, data_ptr, (std::numeric_limits<time_t>::max)());
     cache.Put(key2, data_ptr, expiry);
-    cache.Put(key3, data_string, [=]() { return data_string; }, expiry);
+    cache.Put(
+        key3, data_string, [=]() { return data_string; }, expiry);
     const auto data_size =
         key3.size() + data_string.size() + cache.CalculateExpirySize(key3);
 
@@ -563,7 +573,8 @@ TEST_F(DefaultCacheImplTest, MutableCacheSize) {
     cache.Clear();
 
     cache.Put(key1, data_ptr, -1);
-    cache.Put(key2, data_string, [=]() { return data_string; }, -1);
+    cache.Put(
+        key2, data_string, [=]() { return data_string; }, -1);
 
     cache.Get(key1);
     cache.Get(key2, [](const std::string& value) { return value; });
@@ -582,8 +593,9 @@ TEST_F(DefaultCacheImplTest, MutableCacheSize) {
     cache.Open();
     cache.Clear();
 
-    cache.Put(key, data_string, [=]() { return data_string; },
-              (std::numeric_limits<time_t>::max)());
+    cache.Put(
+        key, data_string, [=]() { return data_string; },
+        (std::numeric_limits<time_t>::max)());
     cache.Close();
     EXPECT_EQ(0u, cache.Size(CacheType::kMutable));
 
@@ -825,21 +837,24 @@ TEST_F(DefaultCacheImplTest, ProtectTest) {
     DefaultCacheImplHelper cache(settings);
     ASSERT_EQ(olp::cache::DefaultCache::Success, cache.Open());
     ASSERT_TRUE(cache.Clear());
-    cache.Put(key1, key1_data_string, [=]() { return key1_data_string; }, 2);
-    cache.Put(other_key1, key1_data_string, [=]() { return key1_data_string; },
-              2);
+    cache.Put(
+        key1, key1_data_string, [=]() { return key1_data_string; }, 2);
+    cache.Put(
+        other_key1, key1_data_string, [=]() { return key1_data_string; }, 2);
     ASSERT_TRUE(cache.Contains(key1));
     // protect single keys, and prefix
     ASSERT_TRUE(cache.Protect({key1, key2, "other"}));
     // Try to protect key already protected by prefix
     ASSERT_FALSE(cache.Protect({other_key1}));
     ASSERT_FALSE(cache.Contains(key2));
-    cache.Put(key2, key2_data_string, [=]() { return key2_data_string; }, 2);
-    cache.Put(key3, key3_data_string, [=]() { return key3_data_string; }, 2);
-    cache.Put(other_key2, key2_data_string, [=]() { return key2_data_string; },
-              2);
-    cache.Put(other_key3, key3_data_string, [=]() { return key3_data_string; },
-              2);
+    cache.Put(
+        key2, key2_data_string, [=]() { return key2_data_string; }, 2);
+    cache.Put(
+        key3, key3_data_string, [=]() { return key3_data_string; }, 2);
+    cache.Put(
+        other_key2, key2_data_string, [=]() { return key2_data_string; }, 2);
+    cache.Put(
+        other_key3, key3_data_string, [=]() { return key3_data_string; }, 2);
     ASSERT_TRUE(cache.Protect({key3}));
     ASSERT_TRUE(cache.Release({key1}));
     std::this_thread::sleep_for(std::chrono::seconds(3));
@@ -969,8 +984,9 @@ TEST_F(DefaultCacheImplTest, ReadOnlyPartitionForProtectedCache) {
             cache1.Open());
   cache1.Clear();
 
-  cache1.Put(key, data_string, [=]() { return data_string; },
-             std::numeric_limits<time_t>::max());
+  cache1.Put(
+      key, data_string, [=]() { return data_string; },
+      std::numeric_limits<time_t>::max());
   cache1.Close();
 
   // Make readonly
@@ -997,8 +1013,9 @@ TEST_F(DefaultCacheImplTest, ProtectTestWithoutMutableCache) {
     DefaultCacheImplHelper cache({});
     ASSERT_EQ(olp::cache::DefaultCache::Success, cache.Open());
     ASSERT_TRUE(cache.Clear());
-    cache.Put(key1, key1_data_string, [=]() { return key1_data_string; },
-              std::numeric_limits<time_t>::max());
+    cache.Put(
+        key1, key1_data_string, [=]() { return key1_data_string; },
+        std::numeric_limits<time_t>::max());
     ASSERT_TRUE(cache.Contains(key1));
     ASSERT_FALSE(cache.Protect({key1}));
 
@@ -1012,9 +1029,9 @@ TEST_F(DefaultCacheImplTest, ProtectTestWithoutMutableCache) {
     DefaultCacheImplHelper cache(settings);
     ASSERT_EQ(olp::cache::DefaultCache::Success, cache.Open());
     ASSERT_TRUE(cache.Clear());
-    ASSERT_TRUE(cache.Put(key1, key1_data_string,
-                          [=]() { return key1_data_string; },
-                          std::numeric_limits<time_t>::max()));
+    ASSERT_TRUE(cache.Put(
+        key1, key1_data_string, [=]() { return key1_data_string; },
+        std::numeric_limits<time_t>::max()));
     ASSERT_TRUE(cache.Protect({key1}));
     cache.Close();
   }

--- a/olp-cpp-sdk-core/tests/cache/ProtectedKeyListTest.cpp
+++ b/olp-cpp-sdk-core/tests/cache/ProtectedKeyListTest.cpp
@@ -53,7 +53,9 @@ TEST(ProtectedKeyList, Protect) {
       EXPECT_FALSE(protected_keys.IsDirty());
 
       // protect key
+      EXPECT_FALSE(protected_keys.IsProtected({"key:1"}));
       EXPECT_TRUE(protected_keys.Protect({"key:1"}, cb));
+      EXPECT_TRUE(protected_keys.IsProtected({"key:1"}));
       EXPECT_TRUE(protected_keys.IsDirty());
       auto raw_data = protected_keys.Serialize();
       EXPECT_TRUE(raw_data.get());


### PR DESCRIPTION
Add cache optimizations
    
Replace substr to memcmp to avoid additional allocations
and put it to the IsPrefix function.
Put checking memory cache from the first cache in the order
for checking Contains to the last one as it usually small
in size and and not sufficient to store the entire cache.
    
Add checks expiry validity in case of LRU cache as there is no
need for additional checks if the expiry is not valid
Check protected_data size in IsProtected if there are elements
in ProtectedKeyList.
    
Relates-To: OLPSUP-18424
    
Signed-off-by: Yevhenii Dudnyk <ext-yevhenii.dudnyk@here.com>