### PR TITLE
Add check if an operation was cancelled

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/DownloadItemsJob.h
+++ b/olp-cpp-sdk-dataservice-read/src/DownloadItemsJob.h
@@ -84,6 +84,16 @@ class DownloadItemsJob {
     if (response.IsSuccessful()) {
       requests_succeeded_++;
     } else {
+      if (response.GetError().GetErrorCode() ==
+              olp::client::ErrorCode::Cancelled &&
+          user_callback_) {
+        auto user_callback = std::move(user_callback_);
+        if (user_callback) {
+          user_callback({{client::ErrorCode::Cancelled, "Cancelled"}});
+        }
+        return;
+      }
+
       requests_failed_++;
     }
 

--- a/olp-cpp-sdk-dataservice-read/src/QueryMetadataJob.h
+++ b/olp-cpp-sdk-dataservice-read/src/QueryMetadataJob.h
@@ -112,15 +112,15 @@ class QueryMetadataJob {
       }
     }
 
+    if (canceled_) {
+      download_job_->OnPrefetchCompleted(
+          {{client::ErrorCode::Cancelled, "Cancelled"}});
+      return;
+    }
+
     if (!--query_count_) {
       if (CheckIfFail()) {
         download_job_->OnPrefetchCompleted(query_errors_.front());
-        return;
-      }
-
-      if (canceled_) {
-        download_job_->OnPrefetchCompleted(
-            {{client::ErrorCode::Cancelled, "Cancelled"}});
         return;
       }
 


### PR DESCRIPTION
Add checking if the download operation was cancelled
after getting a result and not wait for all operations
to be done.

Relates-To: OLPEDGE-2746

Signed-off-by: Yevhenii Dudnyk <ext-yevhenii.dudnyk@here.com>