### PR TITLE
Enable the APIs to return network statistics

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/ApiError.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiError.h
@@ -67,6 +67,37 @@ class CORE_API ApiError {
     return ApiError(ErrorCode::PreconditionFailed, description);
   }
 
+  /**
+   * @brief Creates the `ApiError` instance with the not found error code and
+   * description.
+   * @param description The optional description.
+   * @return The `ApiError` instance.
+   */
+  static ApiError NotFound(const char* description = "Resource not found") {
+    return ApiError(ErrorCode::NotFound, description);
+  }
+
+  /**
+   * @brief Creates the `ApiError` instance with the unknown error code and
+   * description.
+   * @param description The optional description.
+   * @return The `ApiError` instance.
+   */
+  static ApiError Unknown(const char* description = "Unknown") {
+    return ApiError(ErrorCode::Unknown, description);
+  }
+
+  /**
+   * @brief Creates the `ApiError` instance with the unknown error code and
+   * description.
+   * @param description The optional description.
+   * @return The `ApiError` instance.
+   */
+  static ApiError InvalidArgument(
+      const char* description = "Invalid argument") {
+    return ApiError(ErrorCode::InvalidArgument, description);
+  }
+
   ApiError() = default;
 
   /**

--- a/olp-cpp-sdk-core/include/olp/core/client/BackdownStrategy.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/BackdownStrategy.h
@@ -105,7 +105,7 @@ struct CORE_API EqualJitterBackdownStrategy {
     constexpr size_t max_retry_count = 30u;
     retry_count = std::min<size_t>(retry_count, max_retry_count);
     const int64_t exponential_wait_time =
-        initial_backdown_period.count() * (1 << retry_count);
+        initial_backdown_period.count() * (1ll << retry_count);
     static thread_local std::mt19937 kGenerator(std::random_device{}());
     const auto temp = std::min<int64_t>(cap_.count(), exponential_wait_time);
     std::uniform_int_distribution<int64_t> dist(0, temp / 2);

--- a/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
@@ -70,6 +70,13 @@ class NetworkStatistics {
     return *this;
   }
 
+  /// An overloaded addition operator for accumulating statistics.
+  NetworkStatistics operator+(const NetworkStatistics& other) const {
+    NetworkStatistics statistics(*this);
+    statistics += other;
+    return statistics;
+  }
+
  private:
   uint64_t bytes_uploaded_{0};
   uint64_t bytes_downloaded_{0};

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/ExtendedApiResponse.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/ExtendedApiResponse.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <utility>
+
 #include <olp/core/client/ApiResponse.h>
 
 namespace olp {
@@ -31,12 +33,16 @@ class ExtendedApiResponse : public client::ApiResponse<Result, Error> {
   ExtendedApiResponse() = default;
 
   // Implicit constructor by desing, same as in ApiResponse
-  ExtendedApiResponse(Result result)
+  ExtendedApiResponse(Result result)  // NOLINT
       : client::ApiResponse<Result, Error>(std::move(result)), payload_{} {}
 
   // Implicit constructor by desing, same as in ApiResponse
-  ExtendedApiResponse(const Error& error)
+  ExtendedApiResponse(const Error& error)  // NOLINT
       : client::ApiResponse<Result, Error>(error), payload_{} {}
+
+  ExtendedApiResponse(
+      const client::ApiResponse<Result, Error>& other)  // NOLINT
+      : client::ApiResponse<Result, Error>(other), payload_{} {}
 
   ExtendedApiResponse(Result result, Payload payload)
       : client::ApiResponse<Result, Error>(std::move(result)),

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
@@ -26,8 +26,10 @@
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiNoResult.h>
 #include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/HttpResponse.h>
 
 #include <olp/dataservice/read/AggregatedDataResult.h>
+#include <olp/dataservice/read/ExtendedApiResponse.h>
 #include <olp/dataservice/read/PrefetchPartitionsResult.h>
 #include <olp/dataservice/read/PrefetchStatus.h>
 #include <olp/dataservice/read/model/Catalog.h>
@@ -48,9 +50,18 @@ class PrefetchTileResult;
 template <typename ResultType>
 using Response = client::ApiResponse<ResultType, client::ApiError>;
 
+/// The union response type that contains the network statistics for the API.
+template <typename ResultType>
+using ExtendedResponse = ExtendedApiResponse<ResultType, client::ApiError,
+                                             client::NetworkStatistics>;
+
 /// The callback template type.
 template <typename ResultType>
 using Callback = std::function<void(Response<ResultType>)>;
+
+/// The callback template type for the extended response.
+template <typename ResultType>
+using ExtendedCallback = std::function<void(ExtendedResponse<ResultType>)>;
 
 /// An alias for the catalog configuration.
 using CatalogResult = model::Catalog;
@@ -69,9 +80,9 @@ using CatalogVersionCallback = Callback<CatalogVersionResult>;
 /// An alias for the partition metadata result.
 using PartitionsResult = model::Partitions;
 /// The partition metadata response type.
-using PartitionsResponse = Response<PartitionsResult>;
+using PartitionsResponse = ExtendedResponse<PartitionsResult>;
 /// The callback type of the partition metadata response.
-using PartitionsResponseCallback = Callback<PartitionsResult>;
+using PartitionsResponseCallback = ExtendedCallback<PartitionsResult>;
 
 /// The `Data` alias type.
 using DataResult = model::Data;
@@ -81,9 +92,9 @@ using DataResponse = Response<DataResult>;
 using DataResponseCallback = Callback<DataResult>;
 
 /// The aggregated data response alias.
-using AggregatedDataResponse = Response<AggregatedDataResult>;
+using AggregatedDataResponse = ExtendedResponse<AggregatedDataResult>;
 /// The callback type of the aggregated data response.
-using AggregatedDataResponseCallback = Callback<AggregatedDataResult>;
+using AggregatedDataResponseCallback = ExtendedCallback<AggregatedDataResult>;
 
 /// An alias for the prefetch tiles result.
 using PrefetchTilesResult = std::vector<std::shared_ptr<PrefetchTileResult>>;

--- a/olp-cpp-sdk-dataservice-read/src/DownloadItemsJob.h
+++ b/olp-cpp-sdk-dataservice-read/src/DownloadItemsJob.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 #include <olp/core/logging/Log.h>
 #include <olp/dataservice/read/Types.h>
 #include "Common.h"
-#include "ExtendedApiResponse.h"
+#include <olp/dataservice/read/ExtendedApiResponse.h>
 #include "ExtendedApiResponseHelpers.h"
 
 namespace olp {

--- a/olp-cpp-sdk-dataservice-read/src/ExtendedApiResponseHelpers.h
+++ b/olp-cpp-sdk-dataservice-read/src/ExtendedApiResponseHelpers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,8 @@
 
 #pragma once
 
-#include "ExtendedApiResponse.h"
-
 #include <olp/core/client/HttpResponse.h>
+#include <olp/dataservice/read/ExtendedApiResponse.h>
 
 namespace olp {
 namespace dataservice {

--- a/olp-cpp-sdk-dataservice-read/src/PrefetchPartitionsHelper.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/PrefetchPartitionsHelper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 HERE Europe B.V.
+ * Copyright (C) 2021-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@
 #include <olp/dataservice/read/Types.h>
 #include "Common.h"
 #include "DownloadItemsJob.h"
-#include "ExtendedApiResponse.h"
 #include "ExtendedApiResponseHelpers.h"
 #include "QueryPartitionsJob.h"
 #include "TaskSink.h"

--- a/olp-cpp-sdk-dataservice-read/src/PrefetchTilesHelper.h
+++ b/olp-cpp-sdk-dataservice-read/src/PrefetchTilesHelper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@
 #include <olp/dataservice/read/Types.h>
 #include "Common.h"
 #include "DownloadItemsJob.h"
-#include "ExtendedApiResponse.h"
 #include "ExtendedApiResponseHelpers.h"
 #include "QueryMetadataJob.h"
 #include "TaskSink.h"

--- a/olp-cpp-sdk-dataservice-read/src/QueryMetadataJob.h
+++ b/olp-cpp-sdk-dataservice-read/src/QueryMetadataJob.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@
 #include <olp/core/logging/Log.h>
 #include <olp/dataservice/read/Types.h>
 #include "Common.h"
-#include "ExtendedApiResponse.h"
 #include "TaskSink.h"
 
 namespace olp {

--- a/olp-cpp-sdk-dataservice-read/src/QueryPartitionsJob.h
+++ b/olp-cpp-sdk-dataservice-read/src/QueryPartitionsJob.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,9 @@
 
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/logging/Log.h>
+#include <olp/dataservice/read/ExtendedApiResponse.h>
 #include <olp/dataservice/read/Types.h>
 #include "Common.h"
-#include "ExtendedApiResponse.h"
 #include "QueryMetadataJob.h"
 #include "TaskSink.h"
 

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/BlobApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/BlobApi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/HttpResponse.h>
+#include <olp/dataservice/read/ExtendedApiResponse.h>
 #include <boost/optional.hpp>
-#include "ExtendedApiResponse.h"
 #include "olp/dataservice/read/model/Data.h"
 
 namespace olp {

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/MetadataApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/MetadataApi.h
@@ -24,8 +24,8 @@
 
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
+#include <olp/dataservice/read/ExtendedApiResponse.h>
 #include <boost/optional.hpp>
-#include "ExtendedApiResponse.h"
 #include "generated/model/LayerVersions.h"
 #include "olp/dataservice/read/model/Partitions.h"
 #include "olp/dataservice/read/model/VersionInfos.h"

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/HttpResponse.h>
+#include <olp/dataservice/read/ExtendedApiResponse.h>
 #include <boost/optional.hpp>
-#include "ExtendedApiResponse.h"
 #include "generated/model/Index.h"
 #include "olp/dataservice/read/model/Partitions.h"
 

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/VolatileBlobApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/VolatileBlobApi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,9 @@
 
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
+#include <olp/dataservice/read/ExtendedApiResponse.h>
 #include <boost/optional.hpp>
 #include "olp/dataservice/read/model/Data.h"
-
-#include "ExtendedApiResponse.h"
 
 namespace olp {
 namespace client {

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -27,7 +27,7 @@
 #include <olp/core/client/CancellationToken.h>
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettings.h>
-#include "ExtendedApiResponse.h"
+#include <olp/dataservice/read/ExtendedApiResponse.h>
 #include "QuadTreeIndex.h"
 #include "generated/api/QueryApi.h"
 #include "generated/model/Index.h"
@@ -47,8 +47,12 @@ class TileRequest;
 namespace repository {
 
 /// The partition metadata response type.
-using PartitionResponse = Response<model::Partition>;
-using QuadTreeIndexResponse = Response<QuadTreeIndex>;
+using PartitionResponse =
+    ExtendedApiResponse<model::Partition, client::ApiError,
+                        client::NetworkStatistics>;
+using QuadTreeIndexResponse =
+    ExtendedApiResponse<QuadTreeIndex, client::ApiError,
+                        client::NetworkStatistics>;
 
 class PartitionsRepository {
  public:

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,13 +29,12 @@
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/core/geo/tiling/TileKey.h>
+#include <olp/dataservice/read/ExtendedApiResponse.h>
 #include <olp/dataservice/read/PrefetchTilesRequest.h>
 #include <olp/dataservice/read/model/Partitions.h>
 #include "NamedMutex.h"
 #include "PartitionsCacheRepository.h"
 #include "generated/model/Index.h"
-
-#include "ExtendedApiResponse.h"
 
 namespace olp {
 namespace dataservice {

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     CatalogRepositoryTest.cpp
     DataCacheRepositoryTest.cpp
     DataRepositoryTest.cpp
+    ExtendedApiResponseTest.cpp
     JsonResultParserTest.cpp
     MetadataApiTest.cpp
     ParserTest.cpp

--- a/olp-cpp-sdk-dataservice-read/tests/ExtendedApiResponseTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/ExtendedApiResponseTest.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gtest/gtest.h>
+
+#include <olp/dataservice/read/Types.h>
+
+namespace {
+
+namespace read = olp::dataservice::read;
+using olp::client::NetworkStatistics;
+
+bool IsEqual(const NetworkStatistics& lhs, const NetworkStatistics& rhs) {
+  return lhs.GetBytesDownloaded() == rhs.GetBytesDownloaded() &&
+         lhs.GetBytesUploaded() == rhs.GetBytesUploaded();
+}
+
+TEST(ExtendedApiResponseTest, TypesAreBackwardsCompatible) {
+  using StringResponse = read::Response<std::string>;
+  using ExtendedStringResponse = read::ExtendedResponse<std::string>;
+
+  // Response copy preserves the payload
+  ExtendedStringResponse response_copy =
+      ExtendedStringResponse("test", NetworkStatistics(1, 2));
+  EXPECT_EQ(response_copy.GetResult(), "test");
+  EXPECT_TRUE(IsEqual(response_copy.GetPayload(), NetworkStatistics(1, 2)));
+
+  // Extended response could be slices to normal
+  StringResponse sliced_response = ExtendedStringResponse("test");
+  EXPECT_EQ(sliced_response.GetResult(), "test");
+
+  // Normal response is implicitly converted to extended
+  ExtendedStringResponse extended_response = StringResponse("test");
+  EXPECT_EQ(extended_response.GetResult(), "test");
+
+  // Normal callback type works for both normal and extended response
+  read::Callback<std::string> normal_callback =
+      [](read::Response<std::string> response) {
+        EXPECT_EQ(response.GetResult(), "test");
+      };
+
+  normal_callback(ExtendedStringResponse("test", NetworkStatistics(2, 3)));
+  normal_callback(StringResponse("test"));
+
+  // Extended callback type works for both response types
+  read::ExtendedCallback<std::string> extended_callback_1 =
+      [](read::ExtendedResponse<std::string> response) {
+        EXPECT_EQ(response.GetResult(), "test");
+        EXPECT_TRUE(IsEqual(response.GetPayload(), NetworkStatistics(2, 3)));
+      };
+
+  extended_callback_1(ExtendedStringResponse("test", NetworkStatistics(2, 3)));
+
+  read::ExtendedCallback<std::string> extended_callback_2 =
+      [](read::ExtendedResponse<std::string> response) {
+        EXPECT_EQ(response.GetResult(), "test");
+        EXPECT_TRUE(IsEqual(response.GetPayload(), NetworkStatistics()));
+      };
+
+  extended_callback_2(StringResponse("test"));
+
+  // Normal callback type could be casted to extended and consume both response
+  // types.
+  read::ExtendedCallback<std::string> callback_cast =
+      [](read::Response<std::string> response) {
+        EXPECT_EQ(response.GetResult(), "test");
+      };
+
+  callback_cast(ExtendedStringResponse("test", NetworkStatistics(2, 3)));
+  callback_cast(StringResponse("test"));
+
+  // Extended callback could be casted to normal callback, but the payload is
+  // sliced away.
+  read::Callback<std::string> callback_cast2 =
+      [](read::ExtendedResponse<std::string> response) {
+        EXPECT_EQ(response.GetResult(), "test");
+        EXPECT_TRUE(IsEqual(response.GetPayload(), NetworkStatistics()));
+      };
+
+  callback_cast2(ExtendedStringResponse("test", NetworkStatistics(2, 3)));
+  callback_cast2(StringResponse("test"));
+}
+
+}  // namespace

--- a/olp-cpp-sdk-dataservice-read/tests/JsonResultParserTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/JsonResultParserTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@
 #include "generated/serializer/PartitionsSerializer.h"
 #include "generated/serializer/JsonSerializer.h"
 #include "ReadDefaultResponses.h"
-#include "ExtendedApiResponse.h"
+#include <olp/dataservice/read/ExtendedApiResponse.h>
 // clang-format on
 
 namespace dr = olp::dataservice::read;

--- a/tests/common/mocks/NetworkMock.h
+++ b/tests/common/mocks/NetworkMock.h
@@ -108,6 +108,11 @@ NetworkCallback ReturnHttpResponse(
     std::chrono::nanoseconds delay = std::chrono::milliseconds(50),
     olp::http::RequestId request_id = 5);
 
-inline olp::http::NetworkResponse GetResponse(int status) {
-  return olp::http::NetworkResponse().WithStatus(status);
+inline olp::http::NetworkResponse GetResponse(int status,
+                                              int bytes_downloaded = 0,
+                                              int bytes_uploaded = 0) {
+  return olp::http::NetworkResponse()
+      .WithStatus(status)
+      .WithBytesDownloaded(bytes_downloaded)
+      .WithBytesUploaded(bytes_uploaded);
 }


### PR DESCRIPTION
Moved the ExtendedApiResponse to the public includes.
Added `ExtendedResponse` and `ExtendedCallback` types.
Enable the GetAggregatedData and QuadTreeIndex APIs to return the
network statistics along with the result or error.

Relates-To: OLPEDGE-2753

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>