### PR TITLE
Separate thread for cancellation tasks

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/thread/TaskScheduler.h
+++ b/olp-cpp-sdk-core/include/olp/core/thread/TaskScheduler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +72,18 @@ class CORE_API TaskScheduler {
   }
 
   /**
+   * @brief Schedules the asynchronous cancellation task.
+   *
+   * @note Tasks added with this method has Priority::NORMAL priority.
+   *
+   * @param[in] func The callable target that should be added to the scheduling
+   * pipeline.
+   */
+  void ScheduleCancelTask(CallFuncType&& func) {
+    EnqueueCancelTask(std::move(func));
+  }
+
+  /**
    * @brief Schedules the asynchronous cancellable task.
    *
    * @param[in] func The callable target that should be added to the scheduling
@@ -134,6 +146,21 @@ class CORE_API TaskScheduler {
    */
   virtual void EnqueueTask(CallFuncType&& func, uint32_t priority) {
     OLP_SDK_CORE_UNUSED(priority);
+    EnqueueTask(std::forward<CallFuncType>(func));
+  }
+
+  /**
+   * @brief The enqueue cancellation task interface that is implemented by
+   * the subclass.
+   *
+   * Implement this method in the subclass that takes `TaskScheduler`
+   * as a base and provides a custom algorithm for scheduling tasks
+   * enqueued by the SDK.
+   *
+   * @note Tasks added trough this method should be scheduled with
+   * Priority::NORMAL priority.
+   */
+  virtual void EnqueueCancelTask(CallFuncType&& func) {
     EnqueueTask(std::forward<CallFuncType>(func));
   }
 };

--- a/olp-cpp-sdk-core/include/olp/core/thread/ThreadPoolTaskScheduler.h
+++ b/olp-cpp-sdk-core/include/olp/core/thread/ThreadPoolTaskScheduler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,6 +81,18 @@ class CORE_API ThreadPoolTaskScheduler final : public TaskScheduler {
   void EnqueueTask(TaskScheduler::CallFuncType&& func,
                    uint32_t priority) override;
 
+  /**
+   * @brief Overrides the base class method to enqueue cancellation tasks and
+   * execute them on the next free thread from the thread pool.
+   *
+   * @note Tasks added with this method has Priority::NORMAL priority.
+   *
+   * @param func The rvalue reference of the task that should be enqueued.
+   * Move this task into your queue. No internal references are
+   * kept. Once this method is called, you own the task.
+   */
+  void EnqueueCancelTask(TaskScheduler::CallFuncType&& func) override;
+
  private:
   class QueueImpl;
 
@@ -88,6 +100,8 @@ class CORE_API ThreadPoolTaskScheduler final : public TaskScheduler {
   std::vector<std::thread> thread_pool_;
   /// SyncQueue used to manage tasks.
   std::unique_ptr<QueueImpl> queue_;
+  /// SyncQueue used to manage cancel tasks.
+  std::unique_ptr<QueueImpl> cancel_queue_;
 };
 
 }  // namespace thread

--- a/olp-cpp-sdk-core/src/thread/ThreadPoolTaskScheduler.cpp
+++ b/olp-cpp-sdk-core/src/thread/ThreadPoolTaskScheduler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,8 +74,9 @@ struct ComparePrioritizedTask {
   }
 };
 
-void SetExecutorName(size_t idx) {
-  std::string thread_name = "OLPSDKPOOL_" + std::to_string(idx);
+void SetExecutorName(std::string name) {
+  std::string thread_name = "OLPSDKPOOL_" + std::move(name);
+
   SetCurrentThreadName(thread_name);
   OLP_SDK_LOG_INFO_F(kLogTag, "Starting thread '%s'", thread_name.c_str());
 }
@@ -97,13 +98,15 @@ class ThreadPoolTaskScheduler::QueueImpl {
 };
 
 ThreadPoolTaskScheduler::ThreadPoolTaskScheduler(size_t thread_count)
-    : queue_{std::make_unique<QueueImpl>()} {
-  thread_pool_.reserve(thread_count);
+    : queue_{std::make_unique<QueueImpl>()},
+      cancel_queue_{std::make_unique<QueueImpl>()} {
+  constexpr auto kCancelThreadsCount = 1;
+
+  thread_pool_.reserve(thread_count + kCancelThreadsCount);
 
   for (size_t idx = 0; idx < thread_count; ++idx) {
     std::thread executor([this, idx]() {
-      // Set thread name for easy profiling and debugging
-      SetExecutorName(idx);
+      SetExecutorName(std::to_string(idx));
 
       for (;;) {
         PrioritizedTask task;
@@ -116,10 +119,25 @@ ThreadPoolTaskScheduler::ThreadPoolTaskScheduler(size_t thread_count)
 
     thread_pool_.push_back(std::move(executor));
   }
+
+  for (size_t idx = 0; idx < kCancelThreadsCount; ++idx) {
+    thread_pool_.emplace_back([this, idx] {
+      SetExecutorName("CANCEL_" + std::to_string(idx));
+
+      for (;;) {
+        PrioritizedTask task;
+        if (!cancel_queue_->Pull(task)) {
+          return;
+        }
+        task.function();
+      }
+    });
+  }
 }
 
 ThreadPoolTaskScheduler::~ThreadPoolTaskScheduler() {
   queue_->Close();
+  cancel_queue_->Close();
   for (auto& thread : thread_pool_) {
     thread.join();
   }
@@ -128,6 +146,11 @@ ThreadPoolTaskScheduler::~ThreadPoolTaskScheduler() {
 
 void ThreadPoolTaskScheduler::EnqueueTask(TaskScheduler::CallFuncType&& func) {
   queue_->Push({std::move(func), thread::NORMAL});
+}
+
+void ThreadPoolTaskScheduler::EnqueueCancelTask(
+    TaskScheduler::CallFuncType&& func) {
+  cancel_queue_->Push({std::move(func), thread::NORMAL});
 }
 
 void ThreadPoolTaskScheduler::EnqueueTask(TaskScheduler::CallFuncType&& func,

--- a/olp-cpp-sdk-dataservice-read/src/TaskSink.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/TaskSink.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ client::CancellationToken TaskSink::AddTask(
       [=](client::ApiResponse<bool, client::ApiError>) { func(context); },
       context);
   AddTaskImpl(task, priority);
-  return task.CancelToken();
+  return task.CancelToken(task_scheduler_);
 }
 
 bool TaskSink::AddTaskImpl(client::TaskContext task, uint32_t priority) {

--- a/olp-cpp-sdk-dataservice-read/src/TaskSink.h
+++ b/olp-cpp-sdk-dataservice-read/src/TaskSink.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ class TaskSink {
     auto context = client::TaskContext::Create(
         std::move(task), std::move(callback), std::forward<Args>(args)...);
     AddTaskImpl(context, priority);
-    return context.CancelToken();
+    return context.CancelToken(task_scheduler_);
   }
 
   template <typename Function, typename Callback, typename... Args>
@@ -64,7 +64,7 @@ class TaskSink {
     if (!AddTaskImpl(context, priority)) {
       return boost::none;
     }
-    return context.CancelToken();
+    return context.CancelToken(task_scheduler_);
   }
 
  protected:


### PR DESCRIPTION
This commit introduces separate thread specifically for the cancellation
tasks. By doing so we may speed up final callback execution as task
won't wait for its turn in the main busy queue and instead will be
executed on the separate usually free thread.
This is a quite bold move as we always allocate one additional thread
regardless of user-specified total threads number.

Relates-To: OLPSUP-17825
Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>