### PR TITLE
Extend the ApiResponse type with optional payload

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/ApiError.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiError.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,6 +83,30 @@ class CORE_API ApiError {
    */
   static ApiError InvalidArgument(const char* message = "Invalid argument") {
     return {ErrorCode::InvalidArgument, message};
+  }
+
+  /**
+   * @brief Creates the `ApiError` instance with the not found error code and
+   * description.
+   *
+   * @param description The optional description.
+   *
+   * @return The `ApiError` instance.
+   */
+  static ApiError NotFound(const char* message = "Resource not found") {
+    return {ErrorCode::NotFound, message};
+  }
+
+  /**
+   * @brief Creates the `ApiError` instance with the unknown error code and
+   * description.
+   *
+   * @param description The optional description.
+   *
+   * @return The `ApiError` instance.
+   */
+  static ApiError Unknown(const char* message = "Unknown") {
+    return {ErrorCode::Unknown, message};
   }
 
   ApiError() = default;

--- a/olp-cpp-sdk-core/include/olp/core/client/ApiResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiResponse.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,12 +22,35 @@
 #include <future>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 #include "CancellationToken.h"
 
 namespace olp {
 namespace client {
+
+/// The `ApiResponse` extension class, used to carry the payload with the
+/// response.
+template <typename Payload>
+class ResponseExtension {
+ public:
+  ResponseExtension() = default;
+
+  explicit ResponseExtension(Payload payload) : payload_(std::move(payload)) {}
+
+  const Payload& GetPayload() const { return payload_; }
+
+ protected:
+  Payload payload_{};
+};
+
+/// The `ApiResponse` extension class specialization without any payload.
+template <>
+class ResponseExtension<void> {
+ public:
+  ResponseExtension() = default;
+};
 
 /**
  * @brief Represents a request outcome.
@@ -38,19 +61,78 @@ namespace client {
  * @tparam Result The result type.
  * @tparam Error The error type.
  */
-template <typename Result, typename Error>
-class ApiResponse {
+template <typename Result, typename Error, typename Payload = void>
+class ApiResponse : public ResponseExtension<Payload> {
  public:
-  /**
-   * @brief The type of result.
-   */
+  /// The type of result.
   using ResultType = Result;
-  /**
-   * @brief The type of error.
-   */
+
+  /// The type of error.
   using ErrorType = Error;
 
+  /// The type of additional payload.
+  using PayloadType = Payload;
+
   ApiResponse() = default;
+
+  /**
+   * @brief Creates the `ApiResponse` instance from a similar response type
+   * without payload. The payload is default initialized.
+   *
+   * @note Enabled only for the use cases when the input response type has no
+   * payload.
+   *
+   * Used for moving the successfully executed request.
+   *
+   * @param other The `ApiResponse` instance.
+   */
+  template <typename P = Payload, typename = typename std::enable_if<
+                                      !std::is_same<P, void>::value>::type>
+  ApiResponse(const ApiResponse<Result, Error, void>& other)  // NOLINT
+      : ResponseExtension<P>(),
+        result_(other.GetResult()),
+        error_(other.GetError()),
+        success_(other.IsSuccessful()) {}
+
+  /**
+   * @brief Creates the `ApiResponse` instance from a similar response type
+   * without payload, and a separate payload.
+   *
+   * @note Enabled only for the use cases when the input response type has no
+   * payload.
+   *
+   * Used for moving the successfully executed request.
+   *
+   * @param other The `ApiResponse` instance.
+   * @param payload The `Payload` value.
+   */
+  template <typename P = Payload, typename = typename std::enable_if<
+                                      !std::is_same<P, void>::value>::type>
+  ApiResponse(const ApiResponse<Result, Error, void>& other, P payload)
+      : ResponseExtension<P>(std::move(payload)),
+        result_(other.GetResult()),
+        error_(other.GetError()),
+        success_(other.IsSuccessful()) {}
+
+  /**
+   * @brief Creates the `ApiResponse` instance from a similar request with a
+   * payload.
+   *
+   * @note Enabled only for the use cases when the input with a payload is
+   * sliced to the response without payload.
+   *
+   * Used for moving the successfully executed request.
+   *
+   * @param other The `ApiResponse` instance.
+   */
+  template <
+      typename U, typename P = Payload,
+      typename = typename std::enable_if<std::is_same<P, void>::value>::type>
+  ApiResponse(const ApiResponse<Result, Error, U>& other)
+      : ResponseExtension<P>(),
+        result_(other.GetResult()),
+        error_(other.GetError()),
+        success_(other.IsSuccessful()) {}
 
   /**
    * @brief Creates the `ApiResponse` instance.
@@ -60,7 +142,24 @@ class ApiResponse {
    * @param result The `ResultType` instance.
    */
   ApiResponse(ResultType result)  // NOLINT
-      : result_(std::move(result)), success_(true) {}
+      : ResponseExtension<Payload>(),
+        result_(std::move(result)),
+        success_(true) {}
+
+  /**
+   * @brief Creates the `ApiResponse` instance with payload.
+   *
+   * Used for moving the successfully executed request.
+   *
+   * @param result The `ResultType` instance.
+   * @param payload The payload.
+   */
+  template <typename P = Payload, typename = typename std::enable_if<
+                                      !std::is_same<P, void>::value>::type>
+  ApiResponse(ResultType result, P payload)
+      : ResponseExtension<Payload>(std::move(payload)),
+        result_(std::move(result)),
+        success_(true) {}
 
   /**
    * @brief Creates the `ApiResponse` instance if the request is not successful.
@@ -69,6 +168,18 @@ class ApiResponse {
    */
   ApiResponse(const ErrorType& error)  // NOLINT
       : error_(error), success_(false) {}
+
+  /**
+   * @brief Creates the `ApiResponse` instance if the request is not successful.
+   *
+   * @param error The `ErrorType` instance.
+   */
+  template <typename P = Payload, typename = typename std::enable_if<
+                                      !std::is_same<P, void>::value>::type>
+  ApiResponse(const ErrorType& error, P payload)
+      : ResponseExtension<Payload>(std::move(payload)),
+        error_(error),
+        success_(false) {}
 
   /**
    * @brief Checks the status of the request attempt.

--- a/olp-cpp-sdk-core/include/olp/core/client/BackdownStrategy.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/BackdownStrategy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,7 +105,7 @@ struct CORE_API EqualJitterBackdownStrategy {
     constexpr size_t max_retry_count = 30u;
     retry_count = std::min<size_t>(retry_count, max_retry_count);
     const int64_t exponential_wait_time =
-        initial_backdown_period.count() * (1 << retry_count);
+        initial_backdown_period.count() * (1ull << retry_count);
     static thread_local std::mt19937 kGenerator(std::random_device{}());
     const auto temp = std::min<int64_t>(cap_.count(), exponential_wait_time);
     std::uniform_int_distribution<int64_t> dist(0, temp / 2);

--- a/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/HttpResponse.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,13 @@ class NetworkStatistics {
     bytes_uploaded_ += other.bytes_uploaded_;
     bytes_downloaded_ += other.bytes_downloaded_;
     return *this;
+  }
+
+  /// An overloaded addition operator for accumulating statistics.
+  NetworkStatistics operator+(const NetworkStatistics& other) const {
+    NetworkStatistics statistics(*this);
+    statistics += other;
+    return statistics;
   }
 
  private:

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 HERE Europe B.V.
+# Copyright (C) 2019-2022 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ set(OLP_CPP_SDK_CORE_TESTS_SOURCES
     ./cache/ProtectedKeyListTest.cpp
 
     ./client/ApiLookupClientImplTest.cpp
+    ./client/ApiResponseTest.cpp
     ./client/BackdownStrategyTest.cpp
     ./client/CancellationContextTest.cpp
     ./client/ConditionTest.cpp

--- a/olp-cpp-sdk-core/tests/client/ApiResponseTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/ApiResponseTest.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/core/client/ApiResponse.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+struct PayloadT {
+  int v;
+};
+
+struct PrivateClass {
+  explicit PrivateClass(int v) : v_(v) {}
+  PrivateClass(const PrivateClass&) = delete;
+  PrivateClass(PrivateClass&&) = default;
+
+  int v_;
+};
+
+using ResultType = int;
+using ErrorType = std::string;
+
+using olp::client::ApiResponse;
+
+using IntResponse = ApiResponse<ResultType, ErrorType>;
+using ExtendedIntResponse = ApiResponse<ResultType, ErrorType, PayloadT>;
+
+inline bool operator==(const PayloadT& l, const PayloadT& r) {
+  return l.v == r.v;
+}
+
+TEST(ApiResponseTest, Payload) {
+  ExtendedIntResponse extended_response_1(1, PayloadT{2});
+  ExtendedIntResponse extended_response_2 = extended_response_1;
+  EXPECT_EQ(extended_response_1.GetPayload(), extended_response_2.GetPayload());
+  ExtendedIntResponse extended_response_3(IntResponse(2),
+                                          extended_response_2.GetPayload());
+  EXPECT_EQ(extended_response_1.GetPayload(), extended_response_3.GetPayload());
+}
+
+TEST(ApiResponseTest, ResponseSlicing) {
+  ExtendedIntResponse extended_response_1(1, PayloadT{2});
+
+  IntResponse sliced_response_1(extended_response_1);
+  EXPECT_EQ(sliced_response_1.GetResult(), 1);
+  EXPECT_EQ(sliced_response_1.IsSuccessful(),
+            extended_response_1.IsSuccessful());
+
+  IntResponse sliced_response_2 = extended_response_1;
+  EXPECT_EQ(sliced_response_2.GetResult(), 1);
+  EXPECT_EQ(sliced_response_2.IsSuccessful(),
+            extended_response_1.IsSuccessful());
+
+  ExtendedIntResponse extended_response_2("error", PayloadT{2});
+
+  IntResponse sliced_response_3(extended_response_2);
+  EXPECT_EQ(sliced_response_3.GetError(), "error");
+  EXPECT_EQ(sliced_response_3.IsSuccessful(),
+            extended_response_2.IsSuccessful());
+
+  IntResponse sliced_response_4 = extended_response_2;
+  EXPECT_EQ(sliced_response_4.GetError(), "error");
+  EXPECT_EQ(sliced_response_4.IsSuccessful(),
+            extended_response_2.IsSuccessful());
+}
+
+TEST(ApiResponseTest, ResponseExtention) {
+  IntResponse normal_response_1(123);
+
+  ExtendedIntResponse extended_response_1(normal_response_1);
+  EXPECT_EQ(extended_response_1.GetResult(), 123);
+  EXPECT_EQ(extended_response_1.IsSuccessful(),
+            normal_response_1.IsSuccessful());
+
+  ExtendedIntResponse extended_response_2 = normal_response_1;
+  EXPECT_EQ(extended_response_2.GetResult(), 123);
+  EXPECT_EQ(extended_response_2.IsSuccessful(),
+            normal_response_1.IsSuccessful());
+
+  ExtendedIntResponse extended_response_3(normal_response_1, PayloadT{234});
+  EXPECT_EQ(extended_response_3.GetResult(), 123);
+  EXPECT_EQ(extended_response_3.GetPayload(), PayloadT{234});
+
+  IntResponse normal_response_2("error");
+
+  ExtendedIntResponse extended_response_4(normal_response_2);
+  EXPECT_EQ(extended_response_4.GetError(), "error");
+  EXPECT_EQ(extended_response_4.IsSuccessful(),
+            normal_response_2.IsSuccessful());
+
+  ExtendedIntResponse extended_response_5 = normal_response_2;
+  EXPECT_EQ(extended_response_5.GetError(), "error");
+  EXPECT_EQ(extended_response_5.IsSuccessful(),
+            normal_response_2.IsSuccessful());
+
+  ExtendedIntResponse extended_response_6(normal_response_2, PayloadT{234});
+  EXPECT_EQ(extended_response_6.GetError(), "error");
+  EXPECT_EQ(extended_response_6.GetPayload(), PayloadT{234});
+}
+
+TEST(ApiResponseTest, ResultWithoutCopyCtor) {
+  using ProvateResponse = ApiResponse<PrivateClass, ErrorType, PayloadT>;
+  // move constructed
+  ProvateResponse response_1(PrivateClass(1));
+  // move asigned
+  ProvateResponse response_2 = PrivateClass(1);
+  // response can be moved
+  ProvateResponse response_3 = std::move(response_2);
+}
+}  // namespace

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
@@ -26,6 +26,7 @@
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiNoResult.h>
 #include <olp/core/client/ApiResponse.h>
+#include <olp/core/client/HttpResponse.h>
 
 #include <olp/dataservice/read/AggregatedDataResult.h>
 #include <olp/dataservice/read/PrefetchPartitionsResult.h>
@@ -45,12 +46,12 @@ namespace read {
 class PrefetchTileResult;
 
 /// The response template type.
-template <typename ResultType>
-using Response = client::ApiResponse<ResultType, client::ApiError>;
+template <typename ResultType, typename PayloadType = void>
+using Response = client::ApiResponse<ResultType, client::ApiError, PayloadType>;
 
 /// The callback template type.
-template <typename ResultType>
-using Callback = std::function<void(Response<ResultType>)>;
+template <typename ResultType, typename PayloadType = void>
+using Callback = std::function<void(Response<ResultType, PayloadType>)>;
 
 /// An alias for the catalog configuration.
 using CatalogResult = model::Catalog;
@@ -69,9 +70,11 @@ using CatalogVersionCallback = Callback<CatalogVersionResult>;
 /// An alias for the partition metadata result.
 using PartitionsResult = model::Partitions;
 /// The partition metadata response type.
-using PartitionsResponse = Response<PartitionsResult>;
+using PartitionsResponse =
+    Response<PartitionsResult, client::NetworkStatistics>;
 /// The callback type of the partition metadata response.
-using PartitionsResponseCallback = Callback<PartitionsResult>;
+using PartitionsResponseCallback =
+    Callback<PartitionsResult, client::NetworkStatistics>;
 
 /// The `Data` alias type.
 using DataResult = model::Data;
@@ -81,9 +84,11 @@ using DataResponse = Response<DataResult>;
 using DataResponseCallback = Callback<DataResult>;
 
 /// The aggregated data response alias.
-using AggregatedDataResponse = Response<AggregatedDataResult>;
+using AggregatedDataResponse =
+    Response<AggregatedDataResult, client::NetworkStatistics>;
 /// The callback type of the aggregated data response.
-using AggregatedDataResponseCallback = Callback<AggregatedDataResult>;
+using AggregatedDataResponseCallback =
+    Callback<AggregatedDataResult, client::NetworkStatistics>;
 
 /// An alias for the prefetch tiles result.
 using PrefetchTilesResult = std::vector<std::shared_ptr<PrefetchTileResult>>;

--- a/olp-cpp-sdk-dataservice-read/src/ExtendedApiResponse.h
+++ b/olp-cpp-sdk-dataservice-read/src/ExtendedApiResponse.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,31 +26,7 @@ namespace dataservice {
 namespace read {
 
 template <typename Result, typename Error, typename Payload>
-class ExtendedApiResponse : public client::ApiResponse<Result, Error> {
- public:
-  ExtendedApiResponse() = default;
-
-  // Implicit constructor by desing, same as in ApiResponse
-  ExtendedApiResponse(Result result)
-      : client::ApiResponse<Result, Error>(std::move(result)), payload_{} {}
-
-  // Implicit constructor by desing, same as in ApiResponse
-  ExtendedApiResponse(const Error& error)
-      : client::ApiResponse<Result, Error>(error), payload_{} {}
-
-  ExtendedApiResponse(Result result, Payload payload)
-      : client::ApiResponse<Result, Error>(std::move(result)),
-        payload_(std::move(payload)) {}
-
-  ExtendedApiResponse(const Error& error, Payload payload)
-      : client::ApiResponse<Result, Error>(error),
-        payload_(std::move(payload)) {}
-
-  const Payload& GetPayload() const { return payload_; }
-
- private:
-  Payload payload_;
-};
+using ExtendedApiResponse = client::ApiResponse<Result, Error, Payload>;
 
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -87,8 +87,7 @@ client::CancellationToken VersionedLayerClientImpl::GetPartitions(
              client::CancellationContext context) -> PartitionsResponse {
     const auto fetch_option = partitions_request.GetFetchOption();
     if (fetch_option == CacheWithUpdate) {
-      return client::ApiError(
-          client::ErrorCode::InvalidArgument,
+      return client::ApiError::InvalidArgument(
           "CacheWithUpdate option can not be used for versioned layer");
     }
 
@@ -127,9 +126,8 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
   auto data_task =
       [=](client::CancellationContext context) mutable -> DataResponse {
     if (request.GetFetchOption() == CacheWithUpdate) {
-      return {{client::ErrorCode::InvalidArgument,
-               "CacheWithUpdate option can not be used for versioned "
-               "layer"}};
+      return client::ApiError::InvalidArgument(
+          "CacheWithUpdate option can not be used for versioned layer");
     }
 
     int64_t version = -1;
@@ -156,13 +154,13 @@ client::CancellationToken VersionedLayerClientImpl::QuadTreeIndex(
   auto data_task =
       [=](client::CancellationContext context) mutable -> PartitionsResponse {
     if (!tile_request.GetTileKey().IsValid()) {
-      return {{client::ErrorCode::InvalidArgument, "Tile key is invalid"}};
+      return client::ApiError::InvalidArgument("Tile key is invalid");
     }
 
     const auto& fetch_option = tile_request.GetFetchOption();
     if (fetch_option == CacheWithUpdate) {
-      return {{client::ErrorCode::InvalidArgument,
-               "CacheWithUpdate option can not be used for versioned layer"}};
+      return client::ApiError::InvalidArgument(
+          "CacheWithUpdate option can not be used for versioned layer");
     }
 
     auto version_response =
@@ -182,12 +180,14 @@ client::CancellationToken VersionedLayerClientImpl::QuadTreeIndex(
     auto partition_response = repository.GetTile(tile_request, version, context,
                                                  std::move(additional_fields));
     if (!partition_response) {
-      return partition_response.GetError();
+      return PartitionsResponse(partition_response.GetError(),
+                                partition_response.GetPayload());
     }
 
     model::Partitions result;
     result.GetMutablePartitions().emplace_back(partition_response.MoveResult());
-    return result;
+    return PartitionsResponse(std::move(result),
+                              partition_response.GetPayload());
   };
 
   return task_sink_.AddTask(std::move(data_task), std::move(callback),
@@ -237,7 +237,7 @@ client::CancellationToken VersionedLayerClientImpl::PrefetchPartitions(
       OLP_SDK_LOG_WARNING_F(
           kLogTag, "PrefetchPartitions: invalid request, catalog=%s, key=%s",
           catalog_.ToCatalogHRNString().c_str(), key.c_str());
-      callback(ApiError(ErrorCode::InvalidArgument, "Empty partitions list"));
+      callback(ApiError::InvalidArgument("Empty partitions list"));
       return;
     }
 
@@ -588,12 +588,12 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
     TileRequest request, DataResponseCallback callback) {
   auto data_task = [=](client::CancellationContext context) -> DataResponse {
     if (request.GetFetchOption() == CacheWithUpdate) {
-      return {{client::ErrorCode::InvalidArgument,
-               "CacheWithUpdate option can not be used for versioned layer"}};
+      return client::ApiError::InvalidArgument(
+          "CacheWithUpdate option can not be used for versioned layer");
     }
 
     if (!request.GetTileKey().IsValid()) {
-      return {{client::ErrorCode::InvalidArgument, "Tile key is invalid"}};
+      return client::ApiError::InvalidArgument("Tile key is invalid");
     }
 
     auto version_response =
@@ -741,13 +741,12 @@ client::CancellationToken VersionedLayerClientImpl::GetAggregatedData(
     const auto billing_tag = request.GetBillingTag();
 
     if (fetch_option == CacheWithUpdate) {
-      return {{client::ErrorCode::InvalidArgument,
-               "CacheWithUpdate option can not be used for versioned "
-               "layer"}};
+      return client::ApiError::InvalidArgument(
+          "CacheWithUpdate option can not be used for versioned layer");
     }
 
     if (!request.GetTileKey().IsValid()) {
-      return {{client::ErrorCode::InvalidArgument, "Tile key is invalid"}};
+      return client::ApiError::InvalidArgument("Tile key is invalid");
     }
 
     auto version_response = GetVersion(billing_tag, fetch_option, context);
@@ -759,9 +758,10 @@ client::CancellationToken VersionedLayerClientImpl::GetAggregatedData(
     repository::PartitionsRepository repository(catalog_, layer_id_, settings_,
                                                 lookup_client_, mutex_storage_);
     auto partition_response =
-        repository.GetAggregatedTile(std::move(request), version, context);
+        repository.GetAggregatedTile(request, version, context);
     if (!partition_response.IsSuccessful()) {
-      return partition_response.GetError();
+      return AggregatedDataResponse(partition_response.GetError(),
+                                    partition_response.GetPayload());
     }
 
     const auto& fetch_partition = partition_response.GetResult();
@@ -778,20 +778,25 @@ client::CancellationToken VersionedLayerClientImpl::GetAggregatedData(
     auto data_response = data_repository.GetVersionedData(
         layer_id_, data_request, version, context);
 
-    if (!data_response.IsSuccessful()) {
+    const auto aggregated_network_statistics =
+        partition_response.GetPayload() + data_response.GetPayload();
+
+    if (!data_response) {
       OLP_SDK_LOG_WARNING_F(
           kLogTag,
           "GetAggregatedData: failed to load data, key=%s, data_handle=%s",
           fetch_tile_key.ToHereTile().c_str(),
           fetch_partition.GetDataHandle().c_str());
-      return data_response.GetError();
+      return AggregatedDataResponse(data_response.GetError(),
+                                    aggregated_network_statistics);
     }
 
     AggregatedDataResult result;
     result.SetTile(fetch_tile_key);
     result.SetData(data_response.MoveResult());
 
-    return std::move(result);
+    return AggregatedDataResponse(std::move(result),
+                                  aggregated_network_statistics);
   };
 
   return task_sink_.AddTask(std::move(data_task), std::move(callback),

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/BlobApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/BlobApi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,6 @@ namespace olp {
 namespace dataservice {
 namespace read {
 
-namespace client = olp::client;
-
 BlobApi::DataResponse BlobApi::GetBlob(
     const client::OlpClient& client, const std::string& layer_id,
     const std::string& data_handle, boost::optional<std::string> billing_tag,
@@ -53,13 +51,14 @@ BlobApi::DataResponse BlobApi::GetBlob(
                                      header_params, {}, nullptr, "", context);
 
   if (api_response.status != http::HttpStatusCode::OK) {
-    return {{api_response.status, api_response.response.str()},
-            api_response.GetNetworkStatistics()};
+    return DataResponse(
+        client::ApiError(api_response.status, api_response.response.str()),
+        api_response.GetNetworkStatistics());
   }
 
   auto result = std::make_shared<std::vector<unsigned char>>();
   api_response.GetResponse(*result);
-  return {result, api_response.GetNetworkStatistics()};
+  return DataResponse(result, api_response.GetNetworkStatistics());
 }
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/MetadataApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/MetadataApi.cpp
@@ -114,8 +114,9 @@ MetadataApi::PartitionsExtendedResponse MetadataApi::GetPartitions(
                                       header_params, {}, nullptr, "", context);
 
   if (http_response.status != olp::http::HttpStatusCode::OK) {
-    return {{http_response.status, http_response.response.str()},
-            http_response.GetNetworkStatistics()};
+    return PartitionsExtendedResponse(
+        client::ApiError(http_response.status, http_response.response.str()),
+        http_response.GetNetworkStatistics());
   }
 
   using PartitionsResponse =
@@ -125,12 +126,12 @@ MetadataApi::PartitionsExtendedResponse MetadataApi::GetPartitions(
       parser::parse_result<PartitionsResponse>(http_response.response);
 
   if (!partitions_response.IsSuccessful()) {
-    return {{partitions_response.GetError()},
-            http_response.GetNetworkStatistics()};
+    return PartitionsExtendedResponse(partitions_response.GetError(),
+                                      http_response.GetNetworkStatistics());
   }
 
-  return {partitions_response.MoveResult(),
-          http_response.GetNetworkStatistics()};
+  return PartitionsExtendedResponse(partitions_response.MoveResult(),
+                                    http_response.GetNetworkStatistics());
 }
 
 MetadataApi::CatalogVersionResponse MetadataApi::GetLatestCatalogVersion(

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,8 +94,9 @@ QueryApi::PartitionsExtendedResponse QueryApi::GetPartitionsbyId(
                       layer_id.c_str(), http_response.status);
 
   if (http_response.status != olp::http::HttpStatusCode::OK) {
-    return {{http_response.status, http_response.response.str()},
-            http_response.GetNetworkStatistics()};
+    return PartitionsExtendedResponse(
+        client::ApiError(http_response.status, http_response.response.str()),
+        http_response.GetNetworkStatistics());
   }
   using PartitionsResponse =
       client::ApiResponse<model::Partitions, client::ApiError>;
@@ -104,12 +105,12 @@ QueryApi::PartitionsExtendedResponse QueryApi::GetPartitionsbyId(
       parser::parse_result<PartitionsResponse>(http_response.response);
 
   if (!partitions_response.IsSuccessful()) {
-    return {{partitions_response.GetError()},
-            http_response.GetNetworkStatistics()};
+    return PartitionsExtendedResponse(partitions_response.GetError(),
+                                      http_response.GetNetworkStatistics());
   }
 
-  return {partitions_response.MoveResult(),
-          http_response.GetNetworkStatistics()};
+  return PartitionsExtendedResponse(partitions_response.MoveResult(),
+                                    http_response.GetNetworkStatistics());
 }
 
 olp::client::HttpResponse QueryApi::QuadTreeIndex(

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/VolatileBlobApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/VolatileBlobApi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@
 namespace olp {
 namespace dataservice {
 namespace read {
-namespace client = olp::client;
 
 VolatileBlobApi::DataResponse VolatileBlobApi::GetVolatileBlob(
     const client::OlpClient& client, const std::string& layer_id,
@@ -49,13 +48,14 @@ VolatileBlobApi::DataResponse VolatileBlobApi::GetVolatileBlob(
                      form_params, nullptr, "", context);
 
   if (api_response.status != http::HttpStatusCode::OK) {
-    return {{api_response.status, api_response.response.str()},
-            api_response.GetNetworkStatistics()};
+    return DataResponse(
+        client::ApiError(api_response.status, api_response.response.str()),
+        api_response.GetNetworkStatistics());
   }
 
   auto result = std::make_shared<std::vector<unsigned char>>();
   api_response.GetResponse(*result);
-  return {result, api_response.GetNetworkStatistics()};
+  return DataResponse(result, api_response.GetNetworkStatistics());
 }
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -47,8 +47,8 @@ class TileRequest;
 namespace repository {
 
 /// The partition metadata response type.
-using PartitionResponse = Response<model::Partition>;
-using QuadTreeIndexResponse = Response<QuadTreeIndex>;
+using PartitionResponse = Response<model::Partition, client::NetworkStatistics>;
+using QuadTreeIndexResponse = Response<QuadTreeIndex, client::NetworkStatistics>;
 
 class PartitionsRepository {
  public:

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -419,8 +419,9 @@ PrefetchTilesRepository::DownloadVersionedQuadTree(
     OLP_SDK_LOG_WARNING_F(kLogTag,
                           "GetSubQuads failed(%s, %" PRId64 ", %" PRId32 ")",
                           tile_key.c_str(), version, depth);
-    return {{quad_tree.status, quad_tree.response.str()},
-            quad_tree.GetNetworkStatistics()};
+    return QuadTreeResponse(
+        client::ApiError(quad_tree.status, quad_tree.response.str()),
+        quad_tree.GetNetworkStatistics());
   }
 
   QuadTreeIndex tree(tile, depth, quad_tree.response);
@@ -432,8 +433,9 @@ PrefetchTilesRepository::DownloadVersionedQuadTree(
                           "', depth='%" PRId32 "'",
                           catalog_.ToString().c_str(), layer_id_.c_str(),
                           tile_key.c_str(), version, depth);
-    return {{client::ErrorCode::Unknown, "Failed to parse quad tree response"},
-            quad_tree.GetNetworkStatistics()};
+    return QuadTreeResponse(
+        client::ApiError::Unknown("Failed to parse quad tree response"),
+        quad_tree.GetNetworkStatistics());
   }
 
   // add to cache
@@ -442,7 +444,7 @@ PrefetchTilesRepository::DownloadVersionedQuadTree(
     return {put_result.GetError(), quad_tree.GetNetworkStatistics()};
   }
 
-  return {std::move(tree), quad_tree.GetNetworkStatistics()};
+  return QuadTreeResponse(std::move(tree), quad_tree.GetNetworkStatistics());
 }
 
 }  // namespace repository

--- a/tests/common/mocks/NetworkMock.h
+++ b/tests/common/mocks/NetworkMock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,6 +108,11 @@ NetworkCallback ReturnHttpResponse(
     std::chrono::nanoseconds delay = std::chrono::milliseconds(50),
     olp::http::RequestId request_id = 5);
 
-inline olp::http::NetworkResponse GetResponse(int status) {
-  return olp::http::NetworkResponse().WithStatus(status);
+inline olp::http::NetworkResponse GetResponse(int status,
+                                              int bytes_downloaded = 0,
+                                              int bytes_uploaded = 0) {
+  return olp::http::NetworkResponse()
+      .WithStatus(status)
+      .WithBytesDownloaded(bytes_downloaded)
+      .WithBytesUploaded(bytes_uploaded);
 }


### PR DESCRIPTION
Added `ExtendedResponse` and `ExtendedCallback` types that uses
`olp::client::NetworkStatistics` as a payload.
Enable the GetAggregatedData and QuadTreeIndex APIs to return the
extended responses.
Added NotFound, Unknown helper methods to `ApiError` class.
Fixed a warning in `BackdownStrategy` class.

Relates-To: OLPEDGE-2753

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>