### PR TITLE
Speed-up DefaultCache::Release

### DIFF
--- a/olp-cpp-sdk-authentication/tests/AuthenticationClientTest.cpp
+++ b/olp-cpp-sdk-authentication/tests/AuthenticationClientTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
  * License-Filename: LICENSE
  */
 
-#include <cstdio>
 #include <memory>
 #include <string>
+#include <thread>
 
 #include <gmock/gmock.h>
 

--- a/olp-cpp-sdk-core/tests/thread/ContinuationTest.cpp
+++ b/olp-cpp-sdk-core/tests/thread/ContinuationTest.cpp
@@ -19,6 +19,7 @@
 
 #include <chrono>
 #include <future>
+#include <thread>
 
 #include <gtest/gtest.h>
 

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+#include <thread>
+
 #include <gmock/gmock.h>
 #include <matchers/NetworkUrlMatchers.h>
 #include <mocks/NetworkMock.h>

--- a/tests/integration/olp-cpp-sdk-authentication/TokenEndpointTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/TokenEndpointTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 HERE Europe B.V.
+ * Copyright (C) 2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 
 #include <future>
 #include <memory>
+#include <thread>
 
 #include <gmock/gmock.h>
 #include <matchers/NetworkUrlMatchers.h>


### PR DESCRIPTION
Introduce a fast-path for 'mutable-cache-only' scenarios and go to the
microseconds' territory: for the applicable cases release time become
<1ms (original time depends on the `keys` size, e.g. 200 keys ~ 60ms).

This commit switches milliseconds to microseconds for the elapsed timer

Relates-To: OAM-1629, OAM-1563
Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>