### PR TITLE
Change BadRequest to NotFound error in tests

### DIFF
--- a/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/DataserviceReadVersionedLayerClientTest.cpp
@@ -360,7 +360,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetPartitionsForInvalidLayer) {
       });
 
   ASSERT_FALSE(partitions_response.IsSuccessful());
-  ASSERT_EQ(olp::client::ErrorCode::BadRequest,
+  ASSERT_EQ(olp::client::ErrorCode::NotFound,
             partitions_response.GetError().GetErrorCode());
 }
 
@@ -625,7 +625,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetTileWithInvalidLayerId) {
   });
 
   ASSERT_FALSE(data_response.IsSuccessful());
-  ASSERT_EQ(olp::client::ErrorCode::BadRequest,
+  ASSERT_EQ(olp::client::ErrorCode::NotFound,
             data_response.GetError().GetErrorCode());
 }
 


### PR DESCRIPTION
Platform now reports `(404) Not Found` error instead of expected
`(400) Bad Request` for non-existent layers. Update tests accordingly.

Relates-To: OLPEDGE-2764
Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>