### PR TITLE
Remove std::ostringstream from TileKey::ToHereTile

### DIFF
--- a/olp-cpp-sdk-core/src/geo/tiling/TileKey.cpp
+++ b/olp-cpp-sdk-core/src/geo/tiling/TileKey.cpp
@@ -76,9 +76,7 @@ TileKey TileKey::FromQuadKey(const std::string& quad_key) {
 }
 
 std::string TileKey::ToHereTile() const {
-  std::ostringstream os;
-  os << std::dec << ToQuadKey64();
-  return os.str();
+  return std::to_string(ToQuadKey64());
 }
 
 TileKey TileKey::FromHereTile(const std::string& key) {


### PR DESCRIPTION
Not the most efficient way of converting number to string. Replace
with dedicated std::to_string.
`ToHereTile` is being used a lot in the logs so any performance gains
are welcomed.

Relates-To: OAM-1686
Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>