### PR TITLE
Add check for IsCancelled in NamedMutex

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,8 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApi(
     std::string service_version, FetchOptions options,
     client::OlpClientSettings settings, repository::NamedMutexStorage storage) {
   // This mutex is required to avoid concurrent requests to online.
-  repository::NamedMutex mutex(storage, catalog.ToString());
+  repository::NamedMutex mutex(storage, catalog.ToString(),
+                               cancellation_context);
   std::unique_lock<repository::NamedMutex> lock(mutex, std::defer_lock);
 
   // If we are not planning to go online or access the cache, do not lock.

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,7 +158,8 @@ BlobApi::DataResponse DataRepository::GetBlobData(
     return client::ApiError::PreconditionFailed("Data handle is missing");
   }
 
-  NamedMutex mutex(storage_, catalog_.ToString() + layer + *data_handle);
+  NamedMutex mutex(storage_, catalog_.ToString() + layer + *data_handle,
+                   context);
   std::unique_lock<NamedMutex> lock(mutex, std::defer_lock);
 
   // If we are not planning to go online or access the cache, do not lock.

--- a/olp-cpp-sdk-dataservice-read/src/repositories/NamedMutex.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/NamedMutex.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 #include <unordered_map>
 
 #include <olp/core/client/ApiError.h>
+#include <olp/core/client/CancellationContext.h>
 #include <boost/optional.hpp>
 
 namespace olp {
@@ -74,7 +75,8 @@ class NamedMutexStorage {
  */
 class NamedMutex final {
  public:
-  NamedMutex(NamedMutexStorage& storage, const std::string& name);
+  NamedMutex(NamedMutexStorage& storage, const std::string& name,
+             const client::CancellationContext& context);
 
   NamedMutex(const NamedMutex&) = delete;
   NamedMutex(NamedMutex&&) = delete;
@@ -106,6 +108,8 @@ class NamedMutex final {
 
  private:
   NamedMutexStorage& storage_;
+  const client::CancellationContext& context_;
+  bool is_locked_;
   std::string name_;
   std::mutex& mutex_;
 };

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -242,7 +242,8 @@ PartitionsRepository::GetPartitionsExtendedResponse(
       partition_ids.empty() ? "" : HashPartitions(partition_ids);
   const auto version_str = version ? std::to_string(*version) : "";
 
-  NamedMutex mutex(storage_, catalog_str + layer_id_ + version_str + detail);
+  NamedMutex mutex(storage_, catalog_str + layer_id_ + version_str + detail,
+                   context);
   std::unique_lock<NamedMutex> lock(mutex, std::defer_lock);
 
   // If we are not planning to go online or access the cache, do not lock.
@@ -343,7 +344,7 @@ PartitionsResponse PartitionsRepository::GetPartitionById(
   const auto request_key =
       catalog_.ToString() + request.CreateKey(layer_id_, version);
 
-  NamedMutex mutex(storage_, request_key);
+  NamedMutex mutex(storage_, request_key, context);
   std::unique_lock<repository::NamedMutex> lock(mutex, std::defer_lock);
 
   // If we are not planning to go online or access the cache, do not lock.
@@ -431,7 +432,7 @@ QuadTreeIndexResponse PartitionsRepository::GetQuadTreeIndexForTile(
       catalog_.ToCatalogHRNString(), layer_id_, root_tile_key, version,
       kAggregateQuadTreeDepth);
 
-  NamedMutex mutex(storage_, quad_cache_key);
+  NamedMutex mutex(storage_, quad_cache_key, context);
   std::unique_lock<NamedMutex> lock(mutex, std::defer_lock);
 
   // If we are not planning to go online or access the cache, do not lock.

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -201,7 +201,7 @@ client::NetworkStatistics PrefetchTilesRepository::LoadAggregatedSubQuads(
       const auto quad_cache_key = cache::KeyGenerator::CreateQuadTreeKey(
           catalog_str_, layer_id_, root, version, kMaxQuadTreeIndexDepth);
 
-      NamedMutex mutex(storage_, quad_cache_key);
+      NamedMutex mutex(storage_, quad_cache_key, context);
       std::unique_lock<NamedMutex> lock(mutex);
 
       if (!cache_repository_.ContainsTree(root, kMaxQuadTreeIndexDepth,
@@ -229,7 +229,7 @@ SubQuadsResponse PrefetchTilesRepository::GetVersionedSubQuads(
   const auto quad_cache_key = cache::KeyGenerator::CreateQuadTreeKey(
       catalog_str_, layer_id_, tile, version, kMaxQuadTreeIndexDepth);
 
-  NamedMutex mutex(storage_, quad_cache_key);
+  NamedMutex mutex(storage_, quad_cache_key, context);
   std::lock_guard<NamedMutex> lock(mutex);
 
   if (cache_repository_.Get(tile, depth, version, quad_tree)) {


### PR DESCRIPTION
Pass CancellationContext to NamedMutex. Check IsCancelled before locking mutex. Add GetBlobDataCancelParralellRequest test.

Resolves: OLPSUP-20250
Signed-off-by: Yevhen Krasilnyk <ext-yevhen.krasilnyk@here.com>