### PR TITLE
Replace spinlock with condition_variable

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/NamedMutex.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/NamedMutex.cpp
@@ -30,8 +30,10 @@ namespace repository {
 
 class NamedMutexStorage::Impl {
  public:
-  std::mutex& AquireLock(const std::string& resource);
+  std::mutex& AcquireLock(const std::string& resource);
   void ReleaseLock(const std::string& resource);
+  std::condition_variable& GetLockCondition(const std::string& resource);
+  std::mutex& GetLockMutex(const std::string& resource);
   void SetError(const std::string& resource, const client::ApiError& error);
   boost::optional<client::ApiError> GetError(const std::string& resource);
 
@@ -40,13 +42,15 @@ class NamedMutexStorage::Impl {
     std::mutex mutex;
     uint32_t use_count{0u};
     boost::optional<client::ApiError> optional_error;
+    std::condition_variable lock_condition;
+    std::mutex lock_mutex;
   };
 
   std::mutex mutex_;
   std::unordered_map<std::string, RefCounterMutex> mutexes_;
 };
 
-std::mutex& NamedMutexStorage::Impl::AquireLock(const std::string& resource) {
+std::mutex& NamedMutexStorage::Impl::AcquireLock(const std::string& resource) {
   std::lock_guard<std::mutex> lock(mutex_);
   RefCounterMutex& ref_mutex = mutexes_[resource];
   ref_mutex.use_count++;
@@ -64,6 +68,19 @@ void NamedMutexStorage::Impl::ReleaseLock(const std::string& resource) {
   if (--ref_mutex.use_count == 0u) {
     mutexes_.erase(mutex_it);
   }
+}
+
+std::condition_variable& NamedMutexStorage::Impl::GetLockCondition(
+    const std::string& resource) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  RefCounterMutex& ref_mutex = mutexes_[resource];
+  return ref_mutex.lock_condition;
+}
+
+std::mutex& NamedMutexStorage::Impl::GetLockMutex(const std::string& resource) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  RefCounterMutex& ref_mutex = mutexes_[resource];
+  return ref_mutex.lock_mutex;
 }
 
 void NamedMutexStorage::Impl::SetError(const std::string& resource,
@@ -88,12 +105,21 @@ boost::optional<client::ApiError> NamedMutexStorage::Impl::GetError(
 
 NamedMutexStorage::NamedMutexStorage() : impl_(std::make_shared<Impl>()) {}
 
-std::mutex& NamedMutexStorage::AquireLock(const std::string& resource) {
-  return impl_->AquireLock(resource);
+std::mutex& NamedMutexStorage::AcquireLock(const std::string& resource) {
+  return impl_->AcquireLock(resource);
 }
 
 void NamedMutexStorage::ReleaseLock(const std::string& resource) {
   impl_->ReleaseLock(resource);
+}
+
+std::condition_variable& NamedMutexStorage::GetLockCondition(
+    const std::string& resource) {
+  return impl_->GetLockCondition(resource);
+}
+
+std::mutex& NamedMutexStorage::GetLockMutex(const std::string& resource) {
+  return impl_->GetLockMutex(resource);
 }
 
 void NamedMutexStorage::SetError(const std::string& resource,
@@ -112,14 +138,17 @@ NamedMutex::NamedMutex(NamedMutexStorage& storage, const std::string& name,
       context_{context},
       is_locked_{false},
       name_{name},
-      mutex_{storage_.AquireLock(name_)} {}
+      mutex_{storage_.AcquireLock(name_)},
+      lock_condition_{storage_.GetLockCondition(name_)},
+      lock_mutex_{storage_.GetLockMutex(name_)} {}
 
 NamedMutex::~NamedMutex() { storage_.ReleaseLock(name_); }
 
 void NamedMutex::lock() {
-  while (!is_locked_ && !context_.IsCancelled()) {
-    is_locked_ = mutex_.try_lock();
-    std::this_thread::yield();
+  if (!context_.IsCancelled() && !try_lock()) {
+    std::unique_lock<std::mutex> unique_lock{lock_mutex_};
+    lock_condition_.wait(unique_lock,
+                         [&] { return context_.IsCancelled() || try_lock(); });
   }
 }
 
@@ -129,6 +158,7 @@ void NamedMutex::unlock() {
   if (is_locked_) {
     mutex_.unlock();
     is_locked_ = false;
+    lock_condition_.notify_all();
   }
 }
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/NamedMutex.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/NamedMutex.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -42,8 +43,11 @@ class NamedMutexStorage {
  public:
   NamedMutexStorage();
 
-  std::mutex& AquireLock(const std::string& resource);
+  std::mutex& AcquireLock(const std::string& resource);
   void ReleaseLock(const std::string& resource);
+
+  std::condition_variable& GetLockCondition(const std::string& resource);
+  std::mutex& GetLockMutex(const std::string& resource);
 
   /**
    * @brief Saves an error to share it among threads.
@@ -112,6 +116,8 @@ class NamedMutex final {
   bool is_locked_;
   std::string name_;
   std::mutex& mutex_;
+  std::condition_variable& lock_condition_;
+  std::mutex& lock_mutex_;
 };
 
 }  // namespace repository


### PR DESCRIPTION
Spinlock loads the CPU quite substantially, reduce it by using condition_variable

Relates-To: OAM-1784
Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>