### PR TITLE
Change the NamedMutex

### DIFF
--- a/.github/workflows/psv_pipelines.yml
+++ b/.github/workflows/psv_pipelines.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   psv-linux-gcc-build-test-codecov:
     name: PSV / Linux gcc 7.5 / Tests / Code coverage
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Check out repository
       uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
 
   psv-linux-gcc-build-no-cache:
     name: PSV / Linux gcc 7.5 / OLP_SDK_ENABLE_DEFAULT_CACHE=OFF
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       BUILD_TYPE: RelWithDebInfo
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ variables:
 jobs:
 - job: Commit_checker
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-20.04'
   condition: eq(variables['Build.Reason'], 'PullRequest')
   steps:
     - bash: scripts/misc/commit_checker.sh

--- a/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.cpp
@@ -86,7 +86,7 @@ Response<rapidjson::Document> Parse(client::HttpResponse& http_response) {
                              "Failed to parse response"});
   }
 
-  return std::move(document);
+  return Response<rapidjson::Document>(std::move(document));
 }
 }  // namespace
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/NamedMutex.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/NamedMutex.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <condition_variable>
 #include <memory>
 #include <mutex>
@@ -121,6 +122,9 @@ class NamedMutex final {
   std::mutex& mutex_;
   std::condition_variable& lock_condition_;
   std::mutex& lock_mutex_;
+  // We can't check CancellationContext::IsCanceled, since it might result in a
+  // deadlock.
+  std::atomic<bool> is_canceled_;
 };
 
 }  // namespace repository


### PR DESCRIPTION
Change the IsCanceled call to the atomic_bool variable. Upon cancellation the variable is set to true, means we don't lock the mutex inside CancellationContext. Which eliminates the lock ordering problem. Move the token reset code out of lock_mutex_.

Relates-To: OAM-1807

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>