### PR TITLE
Change the NamedMutex

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/NamedMutex.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/NamedMutex.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <condition_variable>
 #include <memory>
 #include <mutex>
@@ -121,6 +122,9 @@ class NamedMutex final {
   std::mutex& mutex_;
   std::condition_variable& lock_condition_;
   std::mutex& lock_mutex_;
+  // We can't check CancellationContext::IsCanceled, since it might result in a
+  // deadlock.
+  std::atomic<bool> is_canceled_;
 };
 
 }  // namespace repository


### PR DESCRIPTION
Change the IsCanceled call to the atomic_bool variable. Upon cancellation the variable is set to true, means we don't lock the mutex inside CancellationContext. Which eliminates the lock ordering problem. Move the token reset code out of lock_mutex_.

Relates-To: OAM-1807

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>