### PR TITLE
Use service name for client's base URL

### DIFF
--- a/olp-cpp-sdk-core/tests/client/ApiLookupClientImplTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/ApiLookupClientImplTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -470,7 +470,8 @@ TEST_F(ApiLookupClientImplTest, CustomCatalogProvider) {
   const std::string service_url = "http://random_service.com";
   const std::string service_version = "v8";
   const std::string provider_url = "https://some-lookup-url.com/lookup/v1";
-  const std::string static_base_url = provider_url + "/catalogs/" + catalog;
+  const std::string static_base_url =
+      provider_url + '/' + service_name + "/catalogs/" + catalog;
   const std::string lookup_url =
       "https://api-lookup.data.api.platform.here.com/lookup/v1/resources/" +
       catalog + "/apis";
@@ -922,7 +923,8 @@ TEST_F(ApiLookupClientImplTest, CustomCatalogProviderAsync) {
   const std::string service_url = "http://random_service.com";
   const std::string service_version = "v8";
   const std::string provider_url = "https://some-lookup-url.com/lookup/v1";
-  const std::string static_base_url = provider_url + "/catalogs/" + catalog;
+  const std::string static_base_url =
+      provider_url + '/' + service_name + "/catalogs/" + catalog;
   const std::string lookup_url =
       "https://api-lookup.data.api.platform.here.com/lookup/v1/resources/" +
       catalog + "/apis";

--- a/tests/common/PlatformUrlsGenerator.cpp
+++ b/tests/common/PlatformUrlsGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,16 @@
 #include <olp/dataservice/read/model/Partitions.h>
 #include <olp/dataservice/read/model/VersionResponse.h>
 #include "ApiDefaultResponses.h"
+
+namespace {
+std::string GetUrlForService(const std::string& service) {
+  if (service == "blob") {
+    return "/blobstore";
+  }
+
+  return '/' + service;
+}
+}  // namespace
 
 PlatformUrlsGenerator::PlatformUrlsGenerator(olp::client::Apis apis,
                                              const std::string& layer)
@@ -104,7 +114,7 @@ std::string PlatformUrlsGenerator::FullPath(const std::string& service,
       }
       url = "/" + service + "/" + v + "/catalogs/" + catalog_;
     } else {
-      url = http_prefix_ + "/catalogs/" + catalog_;
+      url = http_prefix_ + GetUrlForService(service) + "/catalogs/" + catalog_;
     }
   } else {
     auto it = find_if(apis_->begin(), apis_->end(), [&](olp::client::Api api) {

--- a/tests/integration/olp-cpp-sdk-core/ApiLookupClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-core/ApiLookupClientTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -634,7 +634,8 @@ TEST_F(ApiLookupClientTest, CustomCatalogProvider) {
   const std::string service_url = "http://random_service.com";
   const std::string service_version = "v8";
   const std::string provider_url = "https://some-lookup-url.com/lookup/v1";
-  const std::string static_base_url = provider_url + "/catalogs/" + catalog;
+  const std::string static_base_url =
+      provider_url + '/' + service_name + "/catalogs/" + catalog;
   const std::string lookup_url =
       "https://api-lookup.data.api.platform.here.com/lookup/v1/resources/" +
       catalog + "/apis";
@@ -692,7 +693,8 @@ TEST_F(ApiLookupClientTest, CustomCatalogProviderAsync) {
   const std::string service_url = "http://random_service.com";
   const std::string service_version = "v8";
   const std::string provider_url = "https://some-lookup-url.com/lookup/v1";
-  const std::string static_base_url = provider_url + "/catalogs/" + catalog;
+  const std::string static_base_url =
+      provider_url + '/' + service_name + "/catalogs/" + catalog;
   const std::string lookup_url =
       "https://api-lookup.data.api.platform.here.com/lookup/v1/resources/" +
       catalog + "/apis";

--- a/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/CatalogClientCacheTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,11 +170,13 @@ TEST_P(CatalogClientCacheTest, GetCatalog) {
 TEST_P(CatalogClientCacheTest, GetCatalogUsingCatalogEndpointProvider) {
   olp::client::HRN hrn(GetTestCatalog());
 
+  std::string service_name = "/config";
   std::string provider_url =
       "https://api-lookup.data.api.platform.here.com/lookup/v1";
-  EXPECT_CALL(*network_mock_, Send(IsGetRequest(provider_url + "/catalogs/" +
-                                                hrn.ToCatalogHRNString()),
-                                   _, _, _, _))
+  EXPECT_CALL(*network_mock_,
+              Send(IsGetRequest(provider_url + service_name + "/catalogs/" +
+                                hrn.ToCatalogHRNString()),
+                   _, _, _, _))
       .WillOnce(::testing::Return(
           olp::http::SendOutcome(olp::http::ErrorCode::SUCCESS)));
 


### PR DESCRIPTION
Required for usage with DSP in order to not confuse different endpoints. 
This is an ugly hack.

Relates-To: OAM-1783
Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>