### PR TITLE
Fix olp::utils::Dir::Size() recursive behaviour.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/utils/Dir.h
+++ b/olp-cpp-sdk-core/include/olp/core/utils/Dir.h
@@ -28,7 +28,7 @@ namespace olp {
 namespace utils {
 
 /** @brief Manages directories.
-*/
+ */
 class CORE_API Dir {
  public:
   /// An alias for the filter function.
@@ -115,8 +115,11 @@ class CORE_API Dir {
   /**
    * @brief Calculates the size of a directory.
    *
-   * Use a filter to exclude
-   * unnecessary files or directories from the calculation.
+   * Use a filter to exclude unnecessary files or directories from the
+   * calculation.
+   *
+   * @note This method will go all the way recursive for as long as needed
+   * to gather all files which pass the given filter.
    *
    * @param path The path of the directory.
    * @param filter_fn The filter function.


### PR DESCRIPTION
This commit fixes the recursive behaviour of the olp::utils::Dir::Size() method to go all the way deep and find all not filtered out files to consider for calculating the dir size.
This is done by using a queue to push every found dir inside the currently scanned dir onto it for further dept scanning.

Relates-To: OLPEDGE-2700

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>