### PR TITLE
Fix utils::Dir::Size() issue on missing filter.

### DIFF
--- a/olp-cpp-sdk-core/src/utils/Dir.cpp
+++ b/olp-cpp-sdk-core/src/utils/Dir.cpp
@@ -465,7 +465,7 @@ uint64_t Dir::Size(const std::string& path, FilterFunction filter_fn) {
       if (::lstat64(full_path.c_str(), &path_stat) == 0) {
 #endif
         if (S_ISREG(path_stat.st_mode)) {
-          if (filter_fn && filter_fn(entry_name)) {
+          if (!filter_fn || filter_fn(entry_name)) {
             result += path_stat.st_size;
           }
         } else if (S_ISDIR(path_stat.st_mode)) {


### PR DESCRIPTION
When filter was not passed to the olp::utils::Dir::Size() method than all files were filtered out resulting always in 0 size returned back. This is not fixed.

Relates-To: OLPEDGE-2700

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>