### PR TITLE
Suppress ignoring return value warning

### DIFF
--- a/tests/functional/olp-cpp-sdk-core/DirTest.cpp
+++ b/tests/functional/olp-cpp-sdk-core/DirTest.cpp
@@ -47,7 +47,8 @@ void CreateDirectory(const std::string& path) { Dir::Create(path); }
 
 void CreateSymLink(const std::string& to, const std::string& link) {
 #if !defined(_WIN32) || defined(__MINGW32__)
-  static_cast<void>(symlink(to.c_str(), link.c_str()));
+  // Suppress unused-result warning
+  (void)!symlink(to.c_str(), link.c_str());
 #else
   CreateSymbolicLink(to.c_str(), link.c_str(), 0);
 #endif


### PR DESCRIPTION
Another try. This commit fixes the warning treated as an error. It was a blocker for gcc-7 job.

Relates-To: OLPEDGE-2780

Signed-off-by: Mykola Malik <ext-mykola.malik@here.com>