### PR TITLE
Open cache in r/o mode on `no space left` errors

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DiskCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.cpp
@@ -247,6 +247,13 @@ OpenResult DiskCache::Open(const std::string& data_path,
 
   if (status.IsCorruption() || status.IsIOError()) {
     if (is_read_only || !repair_if_broken) {
+      if (status.IsIOError()) {
+        OLP_SDK_LOG_ERROR_F(
+            kLogTag, "Open: IO error, cache_path='%s', error='%s'",
+            versioned_data_path.c_str(), status.ToString().c_str());
+        return OpenResult::IOError;
+      }
+
       OLP_SDK_LOG_ERROR_F(
           kLogTag, "Open: cache corrupted, cache_path='%s', error='%s'",
           versioned_data_path.c_str(), status.ToString().c_str());

--- a/olp-cpp-sdk-core/src/cache/DiskCache.h
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.h
@@ -57,6 +57,8 @@ enum class OpenResult {
   Fail,
   /// The store was corrupted or store compaction was interrupted.
   Corrupted,
+  /// Opening the store failed due to IO error.
+  IOError,
   /// The store was corrupted and has been repaired. Internal integrity might be
   /// broken.
   Repaired,


### PR DESCRIPTION
Since protected cache could be used as a static cache it is expected to be able to use it even when there is no available space on device. But when protected cache is being open in R/W mode levelDb may try to create some files and this failure would be treated later as a corrupted cache.
Instead, on `no space left` errors we will try to open the cache again but in read-only mode to enforce static behavior.

Relates-To: OLPSUP-21193
Signed-off-by: Andrey Kashcheev <ext-andrey.kashcheev@here.com>