### PR TITLE
Fix the Dir::Size API for Windows

### DIFF
--- a/olp-cpp-sdk-core/src/utils/Dir.cpp
+++ b/olp-cpp-sdk-core/src/utils/Dir.cpp
@@ -418,14 +418,14 @@ uint64_t Dir::Size(const std::string& path, FilterFunction filter_fn) {
         continue;
       }
 
-      if (filter_fn && !filter_fn(find_data.cFileName)) {
-        continue;
-      }
-
       if (find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
         current_path = path + "\\" + find_data.cFileName;
         result += Size(current_path, filter_fn);
       } else {
+        if (filter_fn && !filter_fn(find_data.cFileName)) {
+          continue;
+        }
+
         LARGE_INTEGER size;
         size.LowPart = find_data.nFileSizeLow;
         size.HighPart = find_data.nFileSizeHigh;

--- a/tests/functional/olp-cpp-sdk-core/DirTest.cpp
+++ b/tests/functional/olp-cpp-sdk-core/DirTest.cpp
@@ -116,6 +116,17 @@ TEST(DirTest, CheckDirSize) {
     CreateFile(PathBuild(path, "sub", "subsub", "subsub_file2"), 10);
     EXPECT_EQ(Dir::Size(path), 60u);
   }
+  {
+    SCOPED_TRACE("Filtering");
+    CreateFile(PathBuild(path, "file3.hpp"), 10);
+    CreateFile(PathBuild(path, "sub", "sub_file2"), 10);
+    CreateFile(PathBuild(path, "sub", "subsub", "subsub_file2"), 10);
+    EXPECT_EQ(Dir::Size(path,
+                        [](const std::string& filename) {
+                          return filename.find(".hpp") != std::string::npos;
+                        }),
+              10u);
+  }
   Dir::Remove(path);
 }
 


### PR DESCRIPTION
Filtering should be applied for files only.

Relates-To: OLPEDGE-2733

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>