### PR TITLE
Fix CodeCov job

### DIFF
--- a/.github/workflows/psv_pipelines.yml
+++ b/.github/workflows/psv_pipelines.yml
@@ -9,40 +9,73 @@ on:
       - '*'
 
 env:
-  BUILD_TYPE: COVERAGE
-  LD_PRELOAD: /lib/x86_64-linux-gnu/libSegFault.so
   SEGFAULT_SIGNALS: all
 
 jobs:
-  psv-linux-gcc-build-test-codecov:
+  psv-linux-18-04-gcc-build-test-cpplint-codecov:
     name: PSV / Linux gcc 7.5 / Tests / Code coverage
+    runs-on: ubuntu-18.04
+    env:
+      LD_PRELOAD: /lib/x86_64-linux-gnu/libSegFault.so
+      BUILD_TYPE: COVERAGE
+      CC: gcc-7
+      CXX: g++-7
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: "C++ Lint checker script"
+        run: ./scripts/misc/cpplint_ci.sh
+        shell: bash
+      - name: Install Ubuntu dependencies
+        run: sudo apt-get update && sudo apt-get install -y libboost-all-dev ccache libssl-dev libcurl4-openssl-dev gcc-7 g++-7 --no-install-recommends
+        shell: bash
+      - name: Compile project with cmake and ccache
+        run: gcc --version && ./scripts/linux/psv/build_psv.sh
+        shell: bash
+      - name: Run unit and integration tests
+        run: ./scripts/linux/psv/test_psv.sh
+        shell: bash
+
+  psv-linux-20-04-gcc-build:
+    name: PSV / Linux gcc 7.5
     runs-on: ubuntu-20.04
     env:
+      LD_PRELOAD: /lib/x86_64-linux-gnu/libSegFault.so
       BUILD_TYPE: RelWithDebInfo
       CC: gcc-7
       CXX: g++-7
     steps:
     - name: Check out repository
       uses: actions/checkout@v3
-    - name: "C++ Lint checker script"
-      run: ./scripts/misc/cpplint_ci.sh
-      shell: bash
     - name: Install Ubuntu dependencies
       run: sudo apt-get update && sudo apt-get install -y libboost-all-dev ccache libssl-dev libcurl4-openssl-dev gcc-7 g++-7 --no-install-recommends
       shell: bash
     - name: Compile project with cmake and ccache
       run: gcc --version && ./scripts/linux/psv/build_psv.sh
       shell: bash
-    - name: Run unit and integration tests
-      run: ./scripts/linux/psv/test_psv.sh
+
+  psv-linux-22-04-gcc9-build:
+    name: PSV / Linux gcc 9
+    runs-on: ubuntu-22.04
+    env:
+      BUILD_TYPE: RelWithDebInfo
+      CC: gcc-9
+      CXX: g++-9
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+    - name: Install Ubuntu dependencies
+      run: sudo apt-get update && sudo apt-get install -y libboost-all-dev ccache libssl-dev libcurl4-openssl-dev gcc-9 g++-9 --no-install-recommends
       shell: bash
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+    - name: Compile project with cmake and ccache
+      run: gcc --version && ./scripts/linux/psv/build_psv.sh
+      shell: bash
 
   psv-linux-gcc-build-no-cache:
     name: PSV / Linux gcc 7.5 / OLP_SDK_ENABLE_DEFAULT_CACHE=OFF
     runs-on: ubuntu-20.04
     env:
+      LD_PRELOAD: /lib/x86_64-linux-gnu/libSegFault.so
       BUILD_TYPE: RelWithDebInfo
       CC: gcc-7
       CXX: g++-7

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,25 +1,25 @@
 coverage:
-  range: 60..100
+  range: 60..85
   round: nearest
-  precision: 1
+  precision: 2
   status:
     project:
       core:
         paths:
           - olp-cpp-sdk-core
-        threshold: 1
+        threshold: 1%
       authentication:
         paths:
           - olp-cpp-sdk-authentication
-        threshold: 1
+        threshold: 1%
       dataservice-read:
         paths:
           - olp-cpp-sdk-dataservice-read
-        threshold: 1
+        threshold: 1%
       dataservice-write:
         paths:
           - olp-cpp-sdk-dataservice-write
-        threshold: 1
+        threshold: 1%
 ignore:
   - olp-cpp-sdk-authentication/tests
   - olp-cpp-sdk-core/src/http/android

--- a/scripts/linux/psv/test_psv.sh
+++ b/scripts/linux/psv/test_psv.sh
@@ -41,3 +41,17 @@ $CPP_TEST_SOURCE_DARASERVICE_WRITE/olp-cpp-sdk-dataservice-write-tests \
 echo ">>> Integration Test ... >>>"
 $CPP_TEST_SOURCE_INTEGRATION/olp-cpp-sdk-integration-tests \
     --gtest_output="xml:olp-cpp-sdk-integration-tests-report.xml"
+
+# CodeCov
+# Find all .cpp.o and run gcov for them
+pip install coveragepy
+
+curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+curl -Os https://uploader.codecov.io/latest/linux/codecov
+curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+
+gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+shasum -a 256 -c codecov.SHA256SUM
+chmod +x codecov
+./codecov -g -v -t ${CODECOV_TOKEN}

--- a/tests/common/PlatformUrlsGenerator.cpp
+++ b/tests/common/PlatformUrlsGenerator.cpp
@@ -19,6 +19,7 @@
 
 #include "PlatformUrlsGenerator.h"
 
+#include <algorithm>
 #include <utility>
 
 #include <olp/dataservice/read/model/Partitions.h>


### PR DESCRIPTION
Corrected BUILD_TYPE to COVERAGE.
Add extra ubuntu 18.04 job which now passes Codecov.
Previously, switch to 20.04 caused failure on Codecov.
Also add extra 22.04 job on gcc-9.
Fix test to adapt to gcc-9.

Relates-TO: OLPEDGE-2799