### PR TITLE
Exclude gemnasium-maven:java scanner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ variables:
   ADB_INSTALL_TIMEOUT: "8"
 # Gitlab SAST scanner
   SAST_EXCLUDED_PATHS: "tests, examples, docs, scripts"
+  DS_EXCLUDED_ANALYZERS: "gemnasium-maven"
 
 stages:
   - build


### PR DESCRIPTION
Variable DS_EXCLUDED_ANALYZERS is used on
GitLab to exclude some dependency scanners like
gemnasium-maven which is used for java projects.

Relates-To: OLPEDGE-2762