### PR TITLE
Fixes another warning about dangling pointer

### DIFF
--- a/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplTest.cpp
@@ -544,7 +544,8 @@ TEST_F(VersionedLayerClientImplTest, CompleteBatchCancel) {
   const auto catalog = kHrn.ToCatalogHRNString();
   const auto apis =
       mockserver::DefaultResponses::GenerateResourceApisResponse(catalog);
-  const auto apis_response = olp::serializer::serialize(apis).c_str();
+  const auto apis_response_str = olp::serializer::serialize(apis);
+  const auto apis_response = apis_response_str.c_str();
   const auto publication =
       mockserver::DefaultResponses::GeneratePublicationResponse({kLayer}, {});
   ASSERT_TRUE(publication.GetId());


### PR DESCRIPTION
Compiler found that pointer to temp object was used. The behaviour of such code is unpredictable.

Relates-To: OLPSUP-23470