### PR TITLE
Deprecates unused methods in network settings

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkSettings.h
@@ -41,6 +41,7 @@ class CORE_API NetworkSettings final {
    *
    * @return The maximum number of retries for the HTTP request.
    */
+  OLP_SDK_DEPRECATED("Will be removed by 04.2024")
   std::size_t GetRetries() const;
 
   /**
@@ -50,6 +51,7 @@ class CORE_API NetworkSettings final {
    *
    * @return A reference to *this.
    */
+  OLP_SDK_DEPRECATED("Will be removed by 04.2024")
   NetworkSettings& WithRetries(std::size_t retries);
 
   /**

--- a/olp-cpp-sdk-core/src/client/OlpClient.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClient.cpp
@@ -580,7 +580,6 @@ CancellationToken OlpClient::OlpClientImpl::CallApi(
       http::NetworkSettings()
           .WithConnectionTimeout(std::chrono::seconds(retry_settings.timeout))
           .WithTransferTimeout(std::chrono::seconds(retry_settings.timeout))
-          .WithRetries(retry_settings.max_attempts)
           .WithProxySettings(std::move(proxy)));
 
   auto network = settings_.network_request_handler;

--- a/olp-cpp-sdk-core/tests/http/NetworkSettingsTest.cpp
+++ b/olp-cpp-sdk-core/tests/http/NetworkSettingsTest.cpp
@@ -61,6 +61,11 @@ TEST(NetworkSettingsTest, WithTransferTimeout) {
   EXPECT_EQ(settings.GetTransferTimeoutDuration(), std::chrono::seconds(15));
 }
 
+TEST(NetworkSettingsTest, WithRetriesDeprecated) {
+  const auto settings = olp::http::NetworkSettings().WithRetries(5);
+  EXPECT_EQ(settings.GetRetries(), 5);
+}
+
 }  // namespace
 
 PORTING_POP_WARNINGS()


### PR DESCRIPTION
NetworkSettings::GetRetries() is not used in any of network implementations so it can be freely deprecated and removed. Related method NetworkSettings::WithRetries(...) can aslo be deprecated and removed.

Relates-To: OLPSUP-23500