### PR TITLE
Supports option max connection lifetime

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkSettings.h
@@ -120,6 +120,22 @@ class CORE_API NetworkSettings final {
   NetworkSettings& WithTransferTimeout(int timeout);
 
   /**
+   * @brief Gets max lifetime (since creation) allowed for reusing a connection.
+   *
+   * @return The lifetime.
+   */
+  std::chrono::seconds GetMaxConnectionLifetime() const;
+
+  /**
+   * @brief Sets max lifetime (since creation) allowed for reusing a connection.
+   * Supported only for CURL implementation. If set to 0, this behavior is
+   * disabled: all connections are eligible for reuse.
+   *
+   * @return A reference to *this.
+   */
+  NetworkSettings& WithMaxConnectionLifetime(std::chrono::seconds lifetime);
+
+  /**
    * @brief Sets the transfer timeout.
    *
    * @param[in] timeout The transfer timeout.
@@ -151,6 +167,8 @@ class CORE_API NetworkSettings final {
   std::chrono::milliseconds connection_timeout_ = std::chrono::seconds(60);
   /// The transfer timeout.
   std::chrono::milliseconds transfer_timeout_ = std::chrono::seconds(30);
+  /// The max lifetime since creation allowed for reusing a connection.
+  std::chrono::seconds connection_lifetime_{0};
   /// The network proxy settings.
   NetworkProxySettings proxy_settings_;
 };

--- a/olp-cpp-sdk-core/src/http/NetworkSettings.cpp
+++ b/olp-cpp-sdk-core/src/http/NetworkSettings.cpp
@@ -45,6 +45,10 @@ std::chrono::milliseconds NetworkSettings::GetTransferTimeoutDuration() const {
   return transfer_timeout_;
 }
 
+std::chrono::seconds NetworkSettings::GetMaxConnectionLifetime() const {
+  return connection_lifetime_;
+}
+
 const NetworkProxySettings& NetworkSettings::GetProxySettings() const {
   return proxy_settings_;
 }
@@ -71,6 +75,12 @@ NetworkSettings& NetworkSettings::WithTransferTimeout(int timeout) {
 NetworkSettings& NetworkSettings::WithTransferTimeout(
     std::chrono::milliseconds timeout) {
   transfer_timeout_ = timeout;
+  return *this;
+}
+
+NetworkSettings& NetworkSettings::WithMaxConnectionLifetime(
+    std::chrono::seconds lifetime) {
+  connection_lifetime_ = lifetime;
   return *this;
 }
 

--- a/olp-cpp-sdk-core/tests/http/NetworkSettingsTest.cpp
+++ b/olp-cpp-sdk-core/tests/http/NetworkSettingsTest.cpp
@@ -66,6 +66,17 @@ TEST(NetworkSettingsTest, WithRetriesDeprecated) {
   EXPECT_EQ(settings.GetRetries(), 5);
 }
 
+TEST(NetworkSettingsTest, WithMaxConnectionLifetimeDefault) {
+  const auto settings = olp::http::NetworkSettings();
+  EXPECT_EQ(settings.GetMaxConnectionLifetime(), std::chrono::seconds(0));
+}
+
+TEST(NetworkSettingsTest, WithMaxConnectionLifetime) {
+  const auto settings = olp::http::NetworkSettings().WithMaxConnectionLifetime(
+      std::chrono::seconds(15));
+  EXPECT_EQ(settings.GetMaxConnectionLifetime(), std::chrono::seconds(15));
+}
+
 }  // namespace
 
 PORTING_POP_WARNINGS()


### PR DESCRIPTION
This option configures maximum lifetime for connection in CURL based implementation. It's important for server based code which uptime is long to recreate connections more often to deal with load ballancer.

Relates-To: OLPSUP-23436