### PR TITLE
Change the GetPartitions API

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 HERE Europe B.V.
+ * Copyright (C) 2019-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,10 +57,6 @@ class PartitionsRepository {
                        client::ApiLookupClient client,
                        NamedMutexStorage storage = NamedMutexStorage());
 
-  PartitionsResponse GetVersionedPartitions(
-      const read::PartitionsRequest& request, std::int64_t version,
-      client::CancellationContext context);
-
   PartitionsResponse GetVolatilePartitions(
       const read::PartitionsRequest& request,
       client::CancellationContext context);
@@ -93,18 +89,20 @@ class PartitionsRepository {
       boost::optional<std::vector<std::string>> additional_fields =
           boost::none);
 
-  PartitionsResponse GetPartitions(
-      const read::PartitionsRequest& request,
-      boost::optional<std::int64_t> version,
-      client::CancellationContext context,
-      boost::optional<time_t> expiry = boost::none);
-
   QueryApi::PartitionsExtendedResponse GetPartitionsExtendedResponse(
       const read::PartitionsRequest& request,
       boost::optional<std::int64_t> version,
       client::CancellationContext context,
       boost::optional<time_t> expiry = boost::none,
       bool fail_on_cache_error = false);
+
+  QueryApi::PartitionsExtendedResponse QueryPartitionsInBatches(
+      const client::OlpClient& client,
+      const PartitionsRequest::PartitionIds& partitions,
+      boost::optional<std::int64_t> version,
+      const PartitionsRequest::AdditionalFields& additional_fields,
+      boost::optional<std::string> billing_tag,
+      client::CancellationContext context);
 
   const client::HRN catalog_;
   const std::string layer_id_;

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 HERE Europe B.V.
+ * Copyright (C) 2019-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -625,8 +625,8 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
     request.WithPartitionIds({kPartitionId, kInvalidPartitionId});
     request.WithFetchOption(read::CacheOnly);
 
-    auto response =
-        repository.GetVersionedPartitions(request, kVersion, context);
+    auto response = repository.GetVersionedPartitionsExtendedResponse(
+        request, kVersion, context);
 
     ASSERT_FALSE(response.IsSuccessful());
     EXPECT_TRUE(response.GetResult().GetPartitions().empty());
@@ -658,8 +658,8 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
     read::PartitionsRequest request;
     request.WithPartitionIds({kPartitionId});
 
-    auto response =
-        repository.GetVersionedPartitions(request, kVersion, context);
+    auto response = repository.GetVersionedPartitionsExtendedResponse(
+        request, kVersion, context);
 
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
     EXPECT_EQ(response.GetResult().GetPartitions().size(), 1);
@@ -690,15 +690,16 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitions) {
                                                 settings, lookup_client);
     read::PartitionsRequest request;
 
-    auto response =
-        repository.GetVersionedPartitions(request, kVersion, context);
+    auto response = repository.GetVersionedPartitionsExtendedResponse(
+        request, kVersion, context);
 
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
     EXPECT_TRUE(response.GetResult().GetPartitions().empty());
 
     request.WithFetchOption(read::CacheOnly);
 
-    response = repository.GetVersionedPartitions(request, kVersion, context);
+    response = repository.GetVersionedPartitionsExtendedResponse(
+        request, kVersion, context);
 
     ASSERT_TRUE(response.IsSuccessful()) << response.GetError().GetMessage();
     EXPECT_TRUE(response.GetResult().GetPartitions().empty());
@@ -817,7 +818,8 @@ TEST_F(PartitionsRepositoryTest, AdditionalFields) {
                                 read::PartitionsRequest::kCrc,
                                 read::PartitionsRequest::kDataSize});
 
-  auto response = repository.GetVersionedPartitions(request, kVersion, context);
+  auto response = repository.GetVersionedPartitionsExtendedResponse(
+      request, kVersion, context);
 
   ASSERT_TRUE(response.IsSuccessful());
   auto result = response.GetResult();
@@ -830,8 +832,8 @@ TEST_F(PartitionsRepositoryTest, AdditionalFields) {
 
   request.WithFetchOption(read::CacheOnly);
 
-  auto response_2 =
-      repository.GetVersionedPartitions(request, kVersion, context);
+  auto response_2 = repository.GetVersionedPartitionsExtendedResponse(
+      request, kVersion, context);
 
   ASSERT_TRUE(response_2.IsSuccessful());
 


### PR DESCRIPTION
Change the GetPartitions API, now it supports requests with more than 100 partitions which is an backend API limit.

Relates-To: OLPSUP-25510