### PR TITLE
Add StreamLayerPartitions API 

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClient.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ class CORE_API OlpClient {
 
   /**
    * @brief Creates the `OlpClient` instance.
-   * 
+   *
    * @param settings The `OlpClientSettings` instance.
    * @param base_url The base URL to be used for all outgoing requests.
    */
@@ -159,6 +159,33 @@ class CORE_API OlpClient {
                        ParametersType header_params, ParametersType form_params,
                        RequestBodyType post_body, std::string content_type,
                        CancellationContext context) const;
+
+  /**
+   * @brief Executes the HTTP request through the network stack in a blocking
+   * way. The response content is consumed via data callback.
+   *
+   * @param path The path that is appended to the base URL.
+   * @param method Select one of the following methods: `GET`, `POST`, `DELETE`,
+   * or `PUT`.
+   * @param query_params The parameters that are appended to the URL path.
+   * @param header_params The headers used to customize the request.
+   * @param data_callback The network data callback to retrieve content.
+   * @param post_body For the `POST` request, populate `form_params` or
+   * `post_body`, but not both. This data must not be modified until
+   * the request is completed.
+   * @param content_type The content type for the `post_body` or `form_params`.
+   * @param context The `CancellationContext` instance that is used to cancel
+   * the request.
+   *
+   * @return The `HttpResponse` instance.
+   */
+  HttpResponse CallApiStream(std::string path, std::string method,
+                             ParametersType query_params,
+                             ParametersType header_params,
+                             http::Network::DataCallback data_callback,
+                             RequestBodyType post_body,
+                             std::string content_type,
+                             CancellationContext context) const;
 
  private:
   class OlpClientImpl;

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/Types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 HERE Europe B.V.
+ * Copyright (C) 2019-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,6 +152,12 @@ using CompatibleVersionsCallback = Callback<CompatibleVersionsResult>;
 
 /// The list of tile keys.
 using TileKeys = std::vector<geo::TileKey>;
+
+/// A callback type for partitions stream.
+using PartitionsStreamCallback = std::function<void(model::Partition)>;
+
+/// A type of callback that has no result, or an error.
+using CallbackNoResult = Callback<client::ApiNoResult>;
 
 }  // namespace read
 }  // namespace dataservice

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/VersionedLayerClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 HERE Europe B.V.
+ * Copyright (C) 2019-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -281,6 +281,28 @@ class DATASERVICE_READ_API VersionedLayerClient final {
    */
   client::CancellationToken GetPartitions(PartitionsRequest partitions_request,
                                           PartitionsResponseCallback callback);
+
+  /**
+   * @brief Fetches a list of partitions of the given generic layer
+   * asynchronously. Client does not cache the partitions, instead every
+   * partition is passed to the provided callback.
+   * 
+   * @note API is considered experimental and a subject to change.
+   *
+   * @param partitions_request The `PartitionsRequest` instance that contains
+   * a complete set of request parameters.
+   * @note Fetch option and partition list are not supported.
+   * @param partition_stream_callback The `PartitionsStreamCallback` that
+   * receives every fetched partition.
+   * @param callback The `CallbackNoResult` object that is invoked when
+   * operation is complete or an error is encountered.
+   *
+   * @return A token that can be used to cancel this request.
+   */
+  client::CancellationToken StreamLayerPartitions(
+      PartitionsRequest partitions_request,
+      PartitionsStreamCallback partition_stream_callback,
+      CallbackNoResult callback);
 
   /**
    * @brief Fetches a list of partitions of the given generic layer

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 HERE Europe B.V.
+ * Copyright (C) 2019-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,15 @@ client::CancellationToken VersionedLayerClient::GetPartitions(
     PartitionsRequest partitions_request, PartitionsResponseCallback callback) {
   return impl_->GetPartitions(std::move(partitions_request),
                               std::move(callback));
+}
+
+client::CancellationToken VersionedLayerClient::StreamLayerPartitions(
+    PartitionsRequest partitions_request,
+    PartitionsStreamCallback partition_stream_callback,
+    CallbackNoResult callback) {
+  return impl_->StreamLayerPartitions(std::move(partitions_request),
+                                      std::move(partition_stream_callback),
+                                      std::move(callback));
 }
 
 client::CancellableFuture<PartitionsResponse>

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 HERE Europe B.V.
+ * Copyright (C) 2019-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,11 @@ class VersionedLayerClientImpl {
 
   virtual client::CancellationToken GetPartitions(
       PartitionsRequest request, PartitionsResponseCallback callback);
+
+  virtual client::CancellationToken StreamLayerPartitions(
+      PartitionsRequest request,
+      PartitionsStreamCallback partition_stream_callback,
+      CallbackNoResult callback);
 
   virtual client::CancellableFuture<PartitionsResponse> GetPartitions(
       PartitionsRequest partitions_request);

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/MetadataApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/MetadataApi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 HERE Europe B.V.
+ * Copyright (C) 2019-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@
 
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
+#include <olp/core/http/Network.h>
 #include <boost/optional.hpp>
 #include "ExtendedApiResponse.h"
 #include "generated/model/LayerVersions.h"
@@ -83,7 +84,7 @@ class MetadataApi {
   /**
    * @brief Retrieves metadata for all partitions in a specified layer.
    * @param client Instance of OlpClient used to make REST request.
-   * @param layerId Layer id.
+   * @param layer_id Layer id.
    * @param version Specify the version for a versioned layer. Doesn't apply for
    * other layer types.
    * @param additional_fields Additional fields - dataSize, checksum,
@@ -104,11 +105,44 @@ class MetadataApi {
    * object with \c model::Partitions as a result.
    */
   static PartitionsExtendedResponse GetPartitions(
-      const client::OlpClient& client, const std::string& layerId,
+      const client::OlpClient& client, const std::string& layer_id,
       boost::optional<int64_t> version,
       const std::vector<std::string>& additional_fields,
       boost::optional<std::string> range,
       boost::optional<std::string> billing_tag,
+      const client::CancellationContext& context);
+
+  /**
+   * @brief Stream metadata for all partitions in a specified layer.
+   * @param client Instance of OlpClient used to make REST request.
+   * @param layer_id Layer id.
+   * @param version Specify the version for a versioned layer. Doesn't apply for
+   * other layer types.
+   * @param additional_fields Additional fields - dataSize, checksum,
+   * compressedDataSize.
+   * @param range Use this parameter to resume download of a large response for
+   * versioned layers when there is a connection issue between the client and
+   * server. Specify a single byte range offset like this: Range: bytes=10-.
+   * This parameter is compliant with RFC 7233, but note that this parameter
+   * only supports a single byte range. The range parameter can also be
+   * specified as a query parameter, i.e. range=bytes=10-. For volatile layers
+   * use the pagination links returned in the response body.
+   * @param billing_tag An optional free-form tag which is used for grouping
+   * billing records together. If supplied, it must be between 4 - 16
+   * characters, contain only alpha/numeric ASCII characters  [A-Za-z0-9].
+   * @param data_callback A data callback that is passed to the network.
+   * @param context A CancellationContext, which can be used to cancel request.
+   *
+   * @return  The result of this operation as an extended client::ApiResponse
+   * object with \c model::Partitions as a result.
+   */
+  static client::HttpResponse GetPartitionsStream(
+      const client::OlpClient& client, const std::string& layer_id,
+      boost::optional<int64_t> version,
+      const std::vector<std::string>& additional_fields,
+      boost::optional<std::string> range,
+      boost::optional<std::string> billing_tag,
+      http::Network::DataCallback data_callback,
       const client::CancellationContext& context);
 
   /**

--- a/olp-cpp-sdk-dataservice-read/src/repositories/AsyncJsonStream.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/AsyncJsonStream.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "AsyncJsonStream.h"
+
+#include <cstring>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+namespace repository {
+
+RapidJsonByteStream::Ch RapidJsonByteStream::Peek() const {
+  std::unique_lock<std::mutex> lock(mutex_);
+  cv_.wait(lock, [=]() { return !Empty(); });
+  return buffer_[count_];
+}
+
+RapidJsonByteStream::Ch RapidJsonByteStream::Take() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  cv_.wait(lock, [=]() { return !Empty(); });
+  return buffer_[count_++];
+}
+
+size_t RapidJsonByteStream::Tell() const { return count_; }
+
+// Not implemented
+char* RapidJsonByteStream::PutBegin() { return 0; }
+void RapidJsonByteStream::Put(char) {}
+void RapidJsonByteStream::Flush() {}
+size_t RapidJsonByteStream::PutEnd(char*) { return 0; }
+
+bool RapidJsonByteStream::Empty() const { return count_ == buffer_.size(); }
+
+void RapidJsonByteStream::AppendContent(const char* content, size_t length) {
+  std::unique_lock<std::mutex> lock(mutex_);
+
+  if (Empty()) {
+    buffer_.resize(length);
+    std::memcpy(buffer_.data(), content, length);
+    count_ = 0;
+  } else {
+    const auto buffer_size = buffer_.size();
+    buffer_.resize(buffer_size + length);
+    std::memcpy(buffer_.data() + buffer_size, content, length);
+  }
+
+  cv_.notify_one();
+}
+
+AsyncJsonStream::AsyncJsonStream()
+    : current_stream_(std::make_shared<RapidJsonByteStream>()),
+      closed_{false} {}
+
+std::shared_ptr<RapidJsonByteStream> AsyncJsonStream::GetCurrentStream() const {
+  std::unique_lock<std::mutex> lock(mutex_);
+  return current_stream_;
+}
+
+void AsyncJsonStream::AppendContent(const char* content, size_t length) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  if (closed_) {
+    return;
+  }
+  current_stream_->AppendContent(content, length);
+}
+
+void AsyncJsonStream::ResetStream(const char* content, size_t length) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  if (closed_) {
+    return;
+  }
+  current_stream_->AppendContent("\0", 1);
+  current_stream_ = std::make_shared<RapidJsonByteStream>();
+  current_stream_->AppendContent(content, length);
+}
+
+void AsyncJsonStream::CloseStream(boost::optional<client::ApiError> error) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  if (closed_) {
+    return;
+  }
+  current_stream_->AppendContent("\0", 1);
+  error_ = error;
+  closed_ = true;
+}
+
+boost::optional<client::ApiError> AsyncJsonStream::GetError() const {
+  std::unique_lock<std::mutex> lock(mutex_);
+  return error_;
+}
+
+bool AsyncJsonStream::IsClosed() const {
+  std::unique_lock<std::mutex> lock(mutex_);
+  return closed_;
+}
+
+}  // namespace repository
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/repositories/AsyncJsonStream.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/AsyncJsonStream.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+#include <vector>
+
+#include <boost/optional.hpp>
+
+#include <olp/core/client/ApiError.h>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+namespace repository {
+
+// Json byte stream class. Implements rapidjson input stream concept.
+class RapidJsonByteStream {
+ public:
+  typedef char Ch;
+
+  /// Read the current character from stream without moving the read cursor.
+  Ch Peek() const;
+
+  /// Read the current character from stream and moving the read cursor to next
+  /// character.
+  Ch Take();
+
+  /// Get the current read cursor.
+  size_t Tell() const;
+
+  // Not needed for reading.
+  char* PutBegin();
+  void Put(char);
+  void Flush();
+  size_t PutEnd(char*);
+
+  bool Empty() const;
+
+  void AppendContent(const char* content, size_t length);
+
+ private:
+  mutable std::mutex mutex_;
+  std::vector<char> buffer_;            // Current buffer
+  size_t count_{0};                     // Bytes read from the buffer
+  mutable std::condition_variable cv_;  // Condition for next portion of content
+};
+
+class AsyncJsonStream {
+ public:
+  AsyncJsonStream();
+
+  std::shared_ptr<RapidJsonByteStream> GetCurrentStream() const;
+
+  void AppendContent(const char* content, size_t length);
+
+  void ResetStream(const char* content, size_t length);
+
+  void CloseStream(boost::optional<client::ApiError> error);
+
+  boost::optional<client::ApiError> GetError() const;
+
+  bool IsClosed() const;
+
+ private:
+  mutable std::mutex mutex_;
+  std::shared_ptr<RapidJsonByteStream> current_stream_;
+  boost::optional<client::ApiError> error_;
+  bool closed_;
+};
+
+}  // namespace repository
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -35,6 +35,7 @@
 #include "olp/dataservice/read/PartitionsRequest.h"
 #include "olp/dataservice/read/Types.h"
 
+#include "AsyncJsonStream.h"
 #include "NamedMutex.h"
 #include "PartitionsCacheRepository.h"
 
@@ -48,7 +49,8 @@ namespace repository {
 
 /// The partition metadata response type.
 using PartitionResponse = Response<model::Partition, client::NetworkStatistics>;
-using QuadTreeIndexResponse = Response<QuadTreeIndex, client::NetworkStatistics>;
+using QuadTreeIndexResponse =
+    Response<QuadTreeIndex, client::NetworkStatistics>;
 
 class PartitionsRepository {
  public:
@@ -81,6 +83,17 @@ class PartitionsRepository {
                             client::CancellationContext context,
                             boost::optional<std::vector<std::string>>
                                 additional_fields = boost::none);
+
+  client::ApiNoResponse ParsePartitionsStream(
+      std::shared_ptr<AsyncJsonStream> async_stream,
+      PartitionsStreamCallback partition_callback,
+      client::CancellationContext context);
+
+  void StreamPartitions(std::shared_ptr<AsyncJsonStream> async_stream,
+                        std::int64_t version,
+                        const std::vector<std::string>& additional_fields,
+                        boost::optional<std::string> billing_tag,
+                        client::CancellationContext context);
 
  private:
   QuadTreeIndexResponse GetQuadTreeIndexForTile(

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsSaxHandler.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsSaxHandler.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "PartitionsSaxHandler.h"
+
+namespace olp {
+namespace dataservice {
+namespace read {
+namespace repository {
+
+namespace {
+
+constexpr unsigned long long int HashStringToInt(
+    const char* str, unsigned long long int hash = 0) {
+  return (*str == 0) ? hash : 101 * HashStringToInt(str + 1) + *str;
+}
+}  // namespace
+
+PartitionsSaxHandler::PartitionsSaxHandler(PartitionCallback partition_callback)
+    : partition_callback_(std::move(partition_callback)) {}
+
+bool PartitionsSaxHandler::StartObject() {
+  if (state_ == State::kWaitForRootObject) {
+    state_ = State::kWaitForRootPartitions;
+    return continue_parsing_;
+  }
+
+  if (state_ != State::kWaitForNextPartition) {
+    return false;
+  }
+
+  state_ = State::kProcessingAttribute;
+
+  return continue_parsing_;
+}
+
+bool PartitionsSaxHandler::String(const char* str, unsigned int length, bool) {
+  switch (state_) {
+    case State::kProcessingAttribute:
+      state_ = ProcessNextAttribute(str, length);
+      return continue_parsing_;
+
+    case State::kWaitForRootPartitions:
+      if (HashStringToInt("partitions") == HashStringToInt(str)) {
+        state_ = State::kWaitPartitionsArray;
+        return continue_parsing_;
+      } else {
+        return false;
+      }
+
+    case State::kParsingPartitionName:
+      partition_.SetPartition(std::string(str, length));
+      break;
+    case State::kParsingDataHandle:
+      partition_.SetDataHandle(std::string(str, length));
+      break;
+    case State::kParsingChecksum:
+      partition_.SetChecksum(std::string(str, length));
+      break;
+    case State::kParsingCrc:
+      partition_.SetCrc(std::string(str, length));
+      break;
+    case State::kParsingIgnoreAttribute:
+      break;
+
+    case State::kWaitForRootObject:     // Not expected
+    case State::kWaitForNextPartition:  // Not expected
+    case State::kWaitForRootObjectEnd:  // Not expected
+    case State::kParsingVersion:        // Version is not a string
+    case State::kParsingDataSize:       // DataSize is not a string
+    default:
+      return false;
+  }
+
+  state_ = State::kProcessingAttribute;
+
+  return continue_parsing_;
+}
+
+bool PartitionsSaxHandler::Uint(unsigned int value) {
+  if (state_ == State::kParsingVersion) {
+    partition_.SetVersion(value);
+  } else if (state_ == State::kParsingDataSize) {
+    partition_.SetDataSize(value);
+  } else {
+    return false;
+  }
+
+  state_ = State::kProcessingAttribute;
+  return continue_parsing_;
+}
+
+bool PartitionsSaxHandler::EndObject(unsigned int) {
+  if (state_ == State::kWaitForRootObjectEnd) {
+    state_ = State::kParsingComplete;
+    return true;  // complete
+  }
+
+  if (state_ != State::kProcessingAttribute) {
+    return false;
+  }
+
+  if (partition_.GetDataHandle().empty() || partition_.GetPartition().empty()) {
+    return false;  // partition is not valid
+  }
+
+  partition_callback_(std::move(partition_));
+
+  state_ = State::kWaitForNextPartition;
+
+  return continue_parsing_;
+}
+
+bool PartitionsSaxHandler::StartArray() {
+  // We expect only a single array in whol response
+  if (state_ != State::kWaitPartitionsArray) {
+    return false;
+  }
+
+  state_ = State::kWaitForNextPartition;
+
+  return continue_parsing_;
+}
+
+bool PartitionsSaxHandler::EndArray(unsigned int) {
+  if (state_ != State::kWaitForNextPartition) {
+    return false;
+  }
+
+  state_ = State::kWaitForRootObjectEnd;
+  return continue_parsing_;
+}
+
+bool PartitionsSaxHandler::Default() { return false; }
+
+void PartitionsSaxHandler::Abort() { continue_parsing_.store(true); }
+
+PartitionsSaxHandler::State PartitionsSaxHandler::ProcessNextAttribute(
+    const char* name, unsigned int /*length*/) {
+  switch (HashStringToInt(name)) {
+    case HashStringToInt("dataHandle"):
+      return State::kParsingDataHandle;
+    case HashStringToInt("partition"):
+      return State::kParsingPartitionName;
+    case HashStringToInt("checksum"):
+      return State::kParsingChecksum;
+    case HashStringToInt("dataSize"):
+      return State::kParsingDataSize;
+    case HashStringToInt("version"):
+      return State::kParsingVersion;
+    case HashStringToInt("crc"):
+      return State::kParsingCrc;
+    default:
+      return State::kParsingIgnoreAttribute;
+  }
+}
+
+}  // namespace repository
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsSaxHandler.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsSaxHandler.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <atomic>
+#include <functional>
+
+#include "rapidjson/reader.h"
+
+#include <olp/dataservice/read/model/Partitions.h>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+namespace repository {
+
+class PartitionsSaxHandler
+    : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
+                                          PartitionsSaxHandler> {
+ public:
+  using PartitionCallback = std::function<void(model::Partition)>;
+
+  explicit PartitionsSaxHandler(PartitionCallback partition_callback);
+
+  /// Json object events
+  bool StartObject();
+  bool EndObject(unsigned int);
+
+  /// Json array events
+  bool StartArray();
+  bool EndArray(unsigned int);
+
+  /// Json attributes events
+  bool String(const char* str, unsigned int length, bool);
+  bool Uint(unsigned int value);
+  bool Default();
+
+  /// Abort parsing
+  void Abort();
+
+ private:
+  enum class State {
+    kWaitForRootObject,
+    kWaitForRootPartitions,
+    kWaitPartitionsArray,
+    kWaitForNextPartition,
+    kWaitForRootObjectEnd,
+
+    kProcessingAttribute,
+
+    kParsingVersion,
+    kParsingPartitionName,
+    kParsingDataHandle,
+    kParsingChecksum,
+    kParsingDataSize,
+    kParsingCrc,
+    kParsingIgnoreAttribute,
+
+    kParsingComplete,
+  };
+
+  State ProcessNextAttribute(const char* name, unsigned int length);
+
+  State state_{State::kWaitForRootObject};
+  model::Partition partition_;
+  PartitionCallback partition_callback_;
+  std::atomic_bool continue_parsing_{true};
+};
+
+}  // namespace repository
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/tests/AsyncJsonStreamTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/AsyncJsonStreamTest.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gtest/gtest.h>
+
+#include "repositories/AsyncJsonStream.h"
+
+namespace {
+
+namespace repository = olp::dataservice::read::repository;
+
+TEST(AsyncJsonStreamTest, NormalFlow) {
+  repository::AsyncJsonStream stream;
+
+  auto current_stream = stream.GetCurrentStream();
+
+  stream.AppendContent("123", 3);
+
+  EXPECT_EQ(current_stream->Peek(), '1');
+  EXPECT_EQ(current_stream->Take(), '1');
+  EXPECT_EQ(current_stream->Take(), '2');
+  EXPECT_EQ(current_stream->Take(), '3');
+
+  stream.ResetStream("234", 3);
+
+  auto new_current_stream = stream.GetCurrentStream();
+  EXPECT_NE(current_stream.get(), new_current_stream.get());
+
+  EXPECT_EQ(current_stream->Peek(), '\0');
+  EXPECT_EQ(current_stream->Take(), '\0');
+  EXPECT_TRUE(current_stream->Empty());
+
+  EXPECT_EQ(new_current_stream->Peek(), '2');
+  EXPECT_EQ(new_current_stream->Take(), '2');
+  EXPECT_EQ(new_current_stream->Take(), '3');
+  EXPECT_EQ(new_current_stream->Take(), '4');
+  EXPECT_TRUE(new_current_stream->Empty());
+
+  stream.AppendContent("5", 1);
+  EXPECT_FALSE(new_current_stream->Empty());
+
+  stream.CloseStream(olp::client::ApiError::Cancelled());
+
+  EXPECT_EQ(new_current_stream->Take(), '5');
+  EXPECT_EQ(new_current_stream->Take(), '\0');
+
+  EXPECT_TRUE(stream.IsClosed());
+
+  auto error = stream.GetError();
+  EXPECT_TRUE(error &&
+              error->GetErrorCode() == olp::client::ErrorCode::Cancelled);
+}
+
+}  // namespace

--- a/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 HERE Europe B.V.
+# Copyright (C) 2019-2023 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 
 set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     ApiClientLookupTest.cpp
+    AsyncJsonStreamTest.cpp
     CatalogCacheRepositoryTest.cpp
     CatalogClientTest.cpp
     CatalogRepositoryTest.cpp
@@ -28,6 +29,7 @@ set(OLP_SDK_DATASERVICE_READ_TEST_SOURCES
     ParserTest.cpp
     PartitionsCacheRepositoryTest.cpp
     PartitionsRepositoryTest.cpp
+    PartitionsSaxHandlerTest.cpp
     PrefetchRepositoryTest.cpp
     PrefetchTilesRequestTest.cpp
     QuadTreeIndexTest.cpp

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsSaxHandlerTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsSaxHandlerTest.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gtest/gtest.h>
+
+#include "repositories/PartitionsSaxHandler.h"
+
+namespace {
+
+namespace repository = olp::dataservice::read::repository;
+namespace model = olp::dataservice::read::model;
+
+const char* kPartitions = "partitions";
+
+const char* kDataHandle = "dataHandle";
+const char* kPartition = "partition";
+const char* kChecksum = "checksum";
+const char* kDataSize = "dataSize";
+const char* kVersion = "version";
+const char* kCrc = "crc";
+
+const char* kDataHandleValue = "DEADBEEF";
+const char* kPartitionValue = "123456";
+const char* kChecksumValue = "0123456789abcdef";
+const char* kCrcValue = "abcdef";
+
+unsigned int len(const char* str) {
+  return static_cast<unsigned int>(strlen(str));
+}
+
+TEST(PartitionsSaxHandlerTest, NormalFlow) {
+  model::Partition parsed_partition;
+  auto callback = [&](model::Partition partition) {
+    parsed_partition = partition;
+  };
+
+  repository::PartitionsSaxHandler handler(callback);
+
+  ASSERT_TRUE(handler.StartObject());
+  ASSERT_TRUE(handler.String(kPartitions, len(kPartitions), true));
+  ASSERT_TRUE(handler.StartArray());
+
+  ASSERT_TRUE(handler.StartObject());
+  ASSERT_TRUE(handler.String(kDataHandle, len(kDataHandle), true));
+  ASSERT_TRUE(handler.String(kDataHandleValue, len(kDataHandleValue), true));
+  ASSERT_TRUE(handler.String(kPartition, len(kPartition), true));
+  ASSERT_TRUE(handler.String(kPartitionValue, len(kPartitionValue), true));
+  ASSERT_TRUE(handler.String(kChecksum, len(kChecksum), true));
+  ASSERT_TRUE(handler.String(kChecksumValue, len(kChecksumValue), true));
+  ASSERT_TRUE(handler.String(kDataSize, len(kDataSize), true));
+  ASSERT_TRUE(handler.Uint(150));
+  ASSERT_TRUE(handler.String(kVersion, len(kVersion), true));
+  ASSERT_TRUE(handler.Uint(6));
+  ASSERT_TRUE(handler.String(kCrc, len(kCrc), true));
+  ASSERT_TRUE(handler.String(kCrcValue, len(kCrcValue), true));
+  ASSERT_TRUE(handler.EndObject(0));
+
+  ASSERT_TRUE(handler.EndArray(0));
+  ASSERT_TRUE(handler.EndObject(0));
+
+  EXPECT_EQ(parsed_partition.GetDataHandle(), std::string(kDataHandleValue));
+  EXPECT_EQ(parsed_partition.GetPartition(), std::string(kPartitionValue));
+  EXPECT_EQ(parsed_partition.GetChecksum().get_value_or(""),
+            std::string(kChecksumValue));
+  EXPECT_EQ(parsed_partition.GetCrc().get_value_or(""), std::string(kCrcValue));
+  EXPECT_EQ(parsed_partition.GetDataSize().get_value_or(0), 150);
+  EXPECT_EQ(parsed_partition.GetVersion().get_value_or(0), 6);
+}
+
+TEST(PartitionsSaxHandlerTest, WrongJSONStructure) {
+  auto callback = [&](model::Partition) {};
+
+  repository::PartitionsSaxHandler handler(callback);
+
+  // Initial state expects an object
+  ASSERT_FALSE(handler.String(kPartitions, len(kPartitions), true));
+  ASSERT_FALSE(handler.Uint(6));
+  ASSERT_FALSE(handler.StartArray());
+  ASSERT_FALSE(handler.EndArray(0));
+  ASSERT_FALSE(handler.EndObject(0));
+
+  ASSERT_TRUE(handler.StartObject());
+
+  // next state expects a partitions string
+  ASSERT_FALSE(handler.String(kDataHandle, len(kDataHandle), true));
+  ASSERT_FALSE(handler.Uint(6));
+  ASSERT_FALSE(handler.StartArray());
+  ASSERT_FALSE(handler.StartObject());
+  ASSERT_FALSE(handler.EndObject(0));
+  ASSERT_FALSE(handler.EndArray(0));
+
+  ASSERT_TRUE(handler.String(kPartitions, len(kPartitions), true));
+
+  // expect partitions array
+  ASSERT_FALSE(handler.String(kDataHandle, len(kDataHandle), true));
+  ASSERT_FALSE(handler.Uint(6));
+  ASSERT_FALSE(handler.StartObject());
+  ASSERT_FALSE(handler.EndObject(0));
+  ASSERT_FALSE(handler.EndArray(0));
+
+  ASSERT_TRUE(handler.StartArray());
+
+  // expect partition object
+  ASSERT_FALSE(handler.String(kDataHandle, len(kDataHandle), true));
+  ASSERT_FALSE(handler.Uint(6));
+  ASSERT_FALSE(handler.StartArray());
+  ASSERT_FALSE(handler.EndObject(0));
+
+  ASSERT_TRUE(handler.StartObject());
+
+  // object is not valid
+  ASSERT_FALSE(handler.EndObject(0));
+
+  // expect partition attribute
+  ASSERT_FALSE(handler.Uint(6));
+  ASSERT_FALSE(handler.StartArray());
+
+  ASSERT_TRUE(handler.String(kDataHandle, len(kDataHandle), true));
+
+  // expect string attribute value
+  ASSERT_FALSE(handler.Uint(6));
+  ASSERT_FALSE(handler.StartArray());
+  ASSERT_FALSE(handler.EndObject(0));
+
+  ASSERT_TRUE(handler.String(kDataHandleValue, len(kDataHandleValue), true));
+
+  // object is not valid
+  ASSERT_FALSE(handler.EndObject(0));
+
+  // integer properties
+  ASSERT_TRUE(handler.String(kDataSize, len(kDataSize), true));
+
+  ASSERT_FALSE(handler.String(kDataHandle, len(kDataHandle), true));
+  ASSERT_FALSE(handler.StartArray());
+  ASSERT_FALSE(handler.EndArray(0));
+  ASSERT_FALSE(handler.StartObject());
+  ASSERT_FALSE(handler.EndObject(0));
+
+  ASSERT_TRUE(handler.Uint(6));
+
+  ASSERT_TRUE(handler.String(kPartition, len(kPartition), true));
+  ASSERT_TRUE(handler.String(kPartitionValue, len(kPartitionValue), true));
+
+  // complete partition
+  ASSERT_TRUE(handler.EndObject(0));
+
+  // complete partitions array
+  ASSERT_TRUE(handler.EndArray(0));
+
+  // complete the json
+  ASSERT_TRUE(handler.EndObject(0));
+
+  // nothing works anymore
+  ASSERT_FALSE(handler.String(kDataHandle, len(kDataHandle), true));
+  ASSERT_FALSE(handler.Uint(6));
+  ASSERT_FALSE(handler.StartArray());
+  ASSERT_FALSE(handler.EndArray(0));
+  ASSERT_FALSE(handler.StartObject());
+  ASSERT_FALSE(handler.EndObject(0));
+}
+
+}  // namespace


### PR DESCRIPTION
The new API uses a SAX parser and a JSON byte stream to parse the
layer partitions while they are downloading. Using this approach we
can process large responses without any memory impact, since we do not
wait for the full response, and parse it afterward.

Relates-To: OLPEDGE-2832

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>