### PR TITLE
Use custom token endpoint url from AuthenticationCredentials

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/Settings.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/Settings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,8 +53,7 @@ struct AUTHENTICATION_API Settings {
    *
    * @param credentials Your access credentials to the HERE platform.
    */
-  Settings(AuthenticationCredentials credentials)
-      : credentials(std::move(credentials)) {}
+  explicit Settings(AuthenticationCredentials credentials);
 
   /**
    * @brief The access key ID and access key secret that you got from the HERE
@@ -86,7 +85,7 @@ struct AUTHENTICATION_API Settings {
    * @note Only standard OAuth2 Token URLs (those ending in `oauth2/token`) are
    * supported.
    */
-  std::string token_endpoint_url{kHereAccountProductionTokenUrl};
+  std::string token_endpoint_url;
 
   /**
    * @brief Uses system system time in authentication requests rather than

--- a/olp-cpp-sdk-authentication/src/Settings.cpp
+++ b/olp-cpp-sdk-authentication/src/Settings.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "olp/authentication/Settings.h"
+
+#include <utility>
+
+namespace olp {
+namespace authentication {
+
+Settings::Settings(AuthenticationCredentials credentials)
+    : credentials(std::move(credentials)),
+      token_endpoint_url{this->credentials.GetEndpointUrl().empty()
+                             ? kHereAccountProductionTokenUrl
+                             : this->credentials.GetEndpointUrl()} {}
+
+}  // namespace authentication
+}  // namespace olp


### PR DESCRIPTION
The token provider read from a credentials file in the method `AuthenticationCredentials::ReadFromStream()` was not used for the authentication request.

Relates-To: OLPEDGE-2834