### PR TITLE
Censor credentials in debug log messages.

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -135,6 +135,7 @@ set(OLP_SDK_PORTING_HEADERS
 set(OLP_SDK_UTILS_HEADERS
     ./include/olp/core/utils/Base64.h
     ./include/olp/core/utils/Config.h
+    ./include/olp/core/utils/Credentials.h
     ./include/olp/core/utils/Dir.h
     ./include/olp/core/utils/LruCache.h
     ./include/olp/core/utils/Url.h
@@ -334,6 +335,7 @@ set(OLP_SDK_PLATFORM_SOURCES
 set(OLP_SDK_UTILS_SOURCES
     ./src/utils/Base64.cpp
     ./src/utils/BoostExceptionHandle.cpp
+    ./src/utils/Credentials.cpp
     ./src/utils/Dir.cpp
     ./src/utils/Url.cpp
 )

--- a/olp-cpp-sdk-core/include/olp/core/utils/Credentials.h
+++ b/olp-cpp-sdk-core/include/olp/core/utils/Credentials.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <string>
+
+namespace olp {
+namespace utils {
+/**
+ * Censores app_id and app_code parameter's values in the URL.
+ * @param[in] url The URL to be censored.
+ * @return An URL with censored app_id and app_code.
+ */
+std::string CensorCredentialsInUrl(std::string url);
+
+}  // namespace utils
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
@@ -45,6 +45,7 @@
 #include "olp/core/http/NetworkInitializationSettings.h"
 #include "olp/core/http/NetworkUtils.h"
 #include "olp/core/logging/Log.h"
+#include "olp/core/utils/Credentials.h"
 
 namespace olp {
 namespace http {
@@ -526,8 +527,10 @@ ErrorCode NetworkCurl::SendImplementation(
     return ErrorCode::NETWORK_OVERLOAD_ERROR;
   }
 
-  OLP_SDK_LOG_DEBUG(
-      kLogTag, "Send request with url=" << request.GetUrl() << ", id=" << id);
+  OLP_SDK_LOG_DEBUG(kLogTag,
+                    "Send request with url="
+                        << utils::CensorCredentialsInUrl(request.GetUrl())
+                        << ", id=" << id);
 
   handle->ignore_offset = false;  // request.IgnoreOffset();
   handle->skip_content = false;   // config->SkipContentWhenError();
@@ -982,7 +985,8 @@ void NetworkCurl::CompleteMessage(CURL* handle, CURLcode result) {
 
     OLP_SDK_LOG_DEBUG(kLogTag,
                       "Message completed, id="
-                          << rhandle.id << ", url='" << url << "', status=("
+                          << rhandle.id << ", url='"
+                          << utils::CensorCredentialsInUrl(url) << "', status=("
                           << status << ") " << error
                           << ", time=" << GetElapsedTime(rhandle.send_time)
                           << "ms, bytes=" << download_bytes + upload_bytes);

--- a/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
+++ b/olp-cpp-sdk-core/src/http/winhttp/NetworkWinHttp.cpp
@@ -32,6 +32,7 @@
 #include "olp/core/http/NetworkUtils.h"
 #include "olp/core/logging/Log.h"
 #include "olp/core/porting/make_unique.h"
+#include "olp/core/utils/Credentials.h"
 
 namespace {
 
@@ -410,7 +411,8 @@ SendOutcome NetworkWinHttp::Send(NetworkRequest request,
                        payload, request);
     if (handle == nullptr) {
       OLP_SDK_LOG_DEBUG(kLogTag,
-                        "All handles are in use, url=" << request.GetUrl());
+                        "All handles are in use, url="
+                            << utils::CensorCredentialsInUrl(request.GetUrl()));
       return SendOutcome(ErrorCode::NETWORK_OVERLOAD_ERROR);
     }
   }
@@ -591,8 +593,10 @@ SendOutcome NetworkWinHttp::Send(NetworkRequest request,
 
   handle->result_data->bytes_uploaded += content_length + headers.size();
 
-  OLP_SDK_LOG_DEBUG(kLogTag,
-                    "Send request, url=" << request.GetUrl() << ", id=" << id);
+  OLP_SDK_LOG_DEBUG(
+      kLogTag,
+      "Send request, url=" << utils::CensorCredentialsInUrl(request.GetUrl())
+                           << ", id=" << id);
 
   return SendOutcome(id);
 }

--- a/olp-cpp-sdk-core/src/utils/Credentials.cpp
+++ b/olp-cpp-sdk-core/src/utils/Credentials.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/core/utils/Credentials.h>
+
+namespace {
+void CensorCredentialsPart(std::string& url, std::size_t arguments_start,
+                           const std::string& credentials_part_name) {
+  const auto credentials_part_argument_start =
+      url.find(credentials_part_name, arguments_start);
+
+  if (credentials_part_argument_start == std::string::npos) {
+    return;
+  }
+
+  const auto credentials_part_value_start =
+      credentials_part_argument_start + credentials_part_name.length();
+  const auto credentials_part_argument_end =
+      url.find('&', credentials_part_value_start);
+  const auto credentials_part_value_end =
+      credentials_part_argument_end != std::string::npos
+          ? credentials_part_argument_end
+          : url.size();
+
+  const auto credentials_part_value_begin_it =
+      std::next(url.begin(), credentials_part_value_start);
+  const auto credentials_part_value_end_it =
+      std::next(url.begin(), credentials_part_value_end);
+  std::fill(credentials_part_value_begin_it, credentials_part_value_end_it,
+            '*');
+}
+}  // anonymous namespace
+
+namespace olp {
+namespace utils {
+std::string CensorCredentialsInUrl(std::string url) {
+  const auto arguments_start_pos = url.find('?');
+
+  if (arguments_start_pos == std::string::npos) {
+    return url;
+  }
+
+  static const std::string app_id_name = "app_id=";
+  CensorCredentialsPart(url, arguments_start_pos, app_id_name);
+
+  static const std::string app_code_name = "app_code=";
+  CensorCredentialsPart(url, arguments_start_pos, app_code_name);
+
+  static const std::string api_key_name = "apiKey=";
+  CensorCredentialsPart(url, arguments_start_pos, api_key_name);
+
+  return url;
+}
+
+}  // namespace utils
+}  // namespace olp

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -67,6 +67,8 @@ set(OLP_CPP_SDK_CORE_TESTS_SOURCES
 
     ./http/NetworkSettingsTest.cpp
     ./http/NetworkUtils.cpp
+
+    ./utils/UtilsTest.cpp
 )
 
 if (ANDROID OR IOS)

--- a/olp-cpp-sdk-core/tests/utils/UtilsTest.cpp
+++ b/olp-cpp-sdk-core/tests/utils/UtilsTest.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <olp/core/utils/Credentials.h>
+
+namespace {
+
+using UtilsTest = testing::Test;
+
+TEST(UtilsTest, Credentials) {
+  {
+    SCOPED_TRACE("Empty url");
+
+    EXPECT_TRUE(olp::utils::CensorCredentialsInUrl("").empty());
+  }
+
+  {
+    SCOPED_TRACE("Nothing to censor");
+
+    const std::string url{
+        "https://sab.metadata.data.api.platform.here.com/metadata/v1/"
+        "catalogs/"
+        "hrn:here:data::olp-here:ocm-patch/"
+        "versions?endVersion=46&startVersion=0"};
+
+    EXPECT_EQ(olp::utils::CensorCredentialsInUrl(url), url);
+  }
+
+  {
+    SCOPED_TRACE("Censoring app_id, app_code");
+
+    const std::string app_id{"2ARQ22QED2TMaSsPlC88DO"};
+
+    const std::string app_code{
+        "9849asdasdasYiukljbnSIUYAGlhbLASYJDgljkhjblhbuhblkSABLhb12312312321231"
+        "12"
+        "321312l;kasjdf"};
+
+    const std::string url_with_credentials{
+        "https://api-lookup.data.api.platform.here.com/lookup/v1/resources/"
+        "hrn:here:data::olp-here:ocm-patch/"
+        "apis?app_id=" +
+        app_id + "&app_code=" + app_code};
+
+    const auto result =
+        olp::utils::CensorCredentialsInUrl(url_with_credentials);
+
+    EXPECT_EQ(url_with_credentials.size(), result.size());
+    EXPECT_EQ(result.find(app_id, 0), std::string::npos);
+    EXPECT_EQ(result.find(app_code, 0), std::string::npos);
+  }
+
+  {
+    SCOPED_TRACE("Censoring apiKey");
+
+    const std::string appKey{"SomeApiKey"};
+
+    const std::string url_with_credentials{
+        "https://api-lookup.data.api.platform.here.com/lookup/v1/resources/"
+        "hrn:here:data::olp-here:ocm-patch/"
+        "apis?apiKey=" +
+        appKey};
+
+    const auto result =
+        olp::utils::CensorCredentialsInUrl(url_with_credentials);
+
+    EXPECT_EQ(url_with_credentials.size(), result.size());
+    EXPECT_EQ(result.find(appKey, 0), std::string::npos);
+  }
+}
+}  // namespace


### PR DESCRIPTION
Censoring of credentials was added to debug log messages for Windows, Android and curl implementation.

Resolves: OAM-2216