### PR TITLE
Use request ID as task description

### DIFF
--- a/olp-cpp-sdk-core/src/http/ios/OLPHttpTask+Internal.h
+++ b/olp-cpp-sdk-core/src/http/ios/OLPHttpTask+Internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,5 +34,7 @@
 - (void)didReceiveData:(NSData*)data;
 
 - (void)didCompleteWithError:(NSError*)error;
+
+- (NSString*)createTaskDescription;
 
 @end

--- a/olp-cpp-sdk-core/src/http/ios/OLPHttpTask.mm
+++ b/olp-cpp-sdk-core/src/http/ios/OLPHttpTask.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,6 +98,7 @@ constexpr auto kLogTag = "OLPHttpTask";
   @synchronized(self) {
     if (!self.isCancelled) {
       _dataTask = [_urlSession dataTaskWithRequest:request];
+      _dataTask.taskDescription = [self createTaskDescription];
     }
   }
 
@@ -224,6 +225,10 @@ constexpr auto kLogTag = "OLPHttpTask";
   if (dataHandler) {
     dataHandler(data);
   }
+}
+
+- (NSString*) createTaskDescription {
+  return [NSString stringWithFormat:@"%llu", self.requestId];
 }
 
 #pragma mark - Inquiry methods


### PR DESCRIPTION
Currently task ID is used as a key in the map. This is OK while there is only one session because task ID is unique inside the session. We are creating separate session for requests with proxy so task ID is not unique anymore. Request ID is unique across the Network instance and task description is available same a the task ID.

Relates-To: OLPEDGE-2846