### PR TITLE
Fix minimum curl version for CURLOPT_CAINFO_BLOB

### DIFF
--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
@@ -49,7 +49,9 @@
 #endif
 #endif
 
-#if CURL_AT_LEAST_VERSION(7, 71, 0)
+// CURLOPT_CAINFO_BLOB has become available only in curl-7.77
+// cf. https://curl.se/libcurl/c/CURLOPT_CAINFO_BLOB.html,
+#if CURL_AT_LEAST_VERSION(7, 77, 0)
 #define OLP_SDK_CURL_HAS_SUPPORT_SSL_BLOBS
 #endif
 


### PR DESCRIPTION
This MR fixes compilation on Rocky Linux 9 (and thus likely also on
RHEL9), which uses curl-7.76 and thus - as noted on
https://curl.se/libcurl/c/CURLOPT_CAINFO_BLOB.html - does not yet have
support for CURLOPT_CAINFO_BLOB.

Relates-To: OLPSUP-27800

Signed-off-by: Robert Buchholz <robert.buchholz@here.com>