### PR TITLE
Sync info message with actual behavior.

### DIFF
--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
@@ -301,7 +301,7 @@ NetworkCurl::NetworkCurl(NetworkInitializationSettings settings)
 #else
   OLP_SDK_LOG_INFO_F(
       kLogTag,
-      "CURL does not support SSL info with blobs, required 7.71.0, detected %s",
+      "CURL does not support SSL info with blobs, required 7.77.0, detected %s",
       LIBCURL_VERSION);
 #endif
 }


### PR DESCRIPTION
A previous commit correctly raised the CURL version that's necessary to support SSL info with blobs to 7.77, but the corresponding log message still stayed at the old value of 7.71.

Relates-To: OLPSUP-27800