### PR TITLE
Avoid `boost::optional::has_value()` in tests.

### DIFF
--- a/tests/common/matchers/NetworkUrlMatchers.h
+++ b/tests/common/matchers/NetworkUrlMatchers.h
@@ -100,7 +100,7 @@ MATCHER_P(HeadersContain, expected_header, "") {
 }
 
 MATCHER_P(HeadersContainOptional, expected_optional, "") {
-  if (!expected_optional.has_value()) {
+  if (!expected_optional) {
     return true;
   }
   const auto& expected_header = expected_optional.value();


### PR DESCRIPTION
Use casting to `bool` instead.
There is `has_value()` in the boost 1.69 listed as a dependency. On the other hand there are CI nodes with boost 1.65 without it. So there are no reasons to decrease compatibility.

Relates-To: OLPEDGE-2845