### PR TITLE
Syncronize DefaultCacheImpl::Size

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -1087,6 +1087,7 @@ void DefaultCacheImpl::SetEvictionPortion(uint64_t size) {
 }
 
 uint64_t DefaultCacheImpl::Size(CacheType type) const {
+  std::lock_guard<std::mutex> lock(cache_lock_);
   if (type == CacheType::kMutable) {
     return mutable_cache_data_size_;
   }


### PR DESCRIPTION
Fixes data race between Open/Close and Size.

Relates-To: OLPSUP-27831