### PR TITLE
Fix the boost::optional usage

### DIFF
--- a/olp-cpp-sdk-dataservice-read/tests/MetadataApiTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/MetadataApiTest.cpp
@@ -162,7 +162,7 @@ TEST_P(MetadataApiParamTest, GetPartitionsStream) {
   const std::uint64_t offset{7};
 
   const auto range_header = [&]() -> boost::optional<olp::http::Header> {
-    if (test_params.range.has_value()) {
+    if (test_params.range) {
       return olp::http::Header{"Range", test_params.range.value()};
     }
     return boost::none;
@@ -184,7 +184,7 @@ TEST_P(MetadataApiParamTest, GetPartitionsStream) {
 
   EXPECT_EQ(response.GetStatus(), http::HttpStatusCode::OK);
   EXPECT_STREQ(ref_stream_data.c_str(), received_stream_data.c_str());
-  EXPECT_TRUE(received_offset.has_value());
+  EXPECT_TRUE(received_offset);
   EXPECT_EQ(received_offset.value_or(0), offset);
 }
 

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -1887,7 +1887,7 @@ TEST_F(PartitionsRepositoryTest, StreamPartitions) {
     repository.StreamPartitions(async_stream, kVersion, additional_fields,
                                 billing_tag, context);
     EXPECT_TRUE(async_stream->IsClosed());
-    EXPECT_FALSE(async_stream->GetError().has_value());
+    EXPECT_FALSE(async_stream->GetError());
     EXPECT_STREQ(ref_stream_data.c_str(),
                  get_stream_content(*async_stream).c_str());
 
@@ -1902,7 +1902,7 @@ TEST_F(PartitionsRepositoryTest, StreamPartitions) {
                                   billing_tag, context);
 
       EXPECT_TRUE(second_stream->IsClosed());
-      EXPECT_FALSE(second_stream->GetError().has_value());
+      EXPECT_FALSE(second_stream->GetError());
       EXPECT_STREQ((initial_value + ref_stream_data).c_str(),
                    get_stream_content(*second_stream).c_str());
     }


### PR DESCRIPTION
Remove the has_value usage, since it's not available in old boost

Relates-To: OLPEDGE-2853