### PR TITLE
Skip LevelDB init attempt in read only mode.

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DiskCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.cpp
@@ -239,7 +239,7 @@ OpenResult DiskCache::Open(const std::string& data_path,
                                      << status.ToString());
   }
 
-  if (status.IsInvalidArgument() && is_read_only) {
+  if (status.IsInvalidArgument() && !is_read_only) {
     // Maybe folder with cache is an empty, so trying to create db and reopen it
     status = InitializeDB(settings, versioned_data_path);
     if (!status.ok()) {


### PR DESCRIPTION
This can happen if the cache location is an empty read only directory. It should fail anyway but why should we even try. Maybe just a typo.

Relates-To: OLPEDGE-2857