### PR TITLE
Allow to cancel partitions stream on parsing

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -633,8 +633,10 @@ client::ApiNoResponse PartitionsRepository::ParsePartitionsStream(
     auto partitions_handler =
         std::make_shared<repository::PartitionsSaxHandler>(partition_callback);
 
-    auto reader_cancellation_token =
-        client::CancellationToken([=]() { partitions_handler->Abort(); });
+    auto reader_cancellation_token = client::CancellationToken([=]() {
+      partitions_handler->Abort();
+      async_stream->CloseStream(client::ApiError::Cancelled());
+    });
 
     if (!context.ExecuteOrCancelled(
             [=]() { return reader_cancellation_token; })) {

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsSaxHandler.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsSaxHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 HERE Europe B.V.
+ * Copyright (C) 2023-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,7 +149,7 @@ bool PartitionsSaxHandler::EndArray(unsigned int) {
 
 bool PartitionsSaxHandler::Default() { return false; }
 
-void PartitionsSaxHandler::Abort() { continue_parsing_.store(true); }
+void PartitionsSaxHandler::Abort() { continue_parsing_.store(false); }
 
 PartitionsSaxHandler::State PartitionsSaxHandler::ProcessNextAttribute(
     const char* name, unsigned int /*length*/) {

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1714,6 +1714,8 @@ TEST_F(PartitionsRepositoryTest, ParsePartitionsStream) {
       parsing_promise.set_value();
     }).detach();
 
+    // give the parsing time to start
+    std::this_thread::sleep_for(std::chrono::milliseconds(100u));
     context_to_cancel.CancelOperation();
 
     EXPECT_EQ(parsing_promise.get_future().wait_for(kTimeout),


### PR DESCRIPTION
PartitionsSaxHandler::Abort() was useless. And it is not enough to Abort() when we are waiting for characters in the stream.

Relates-To: OLPEDGE-2859