### PR TITLE
Change Android sdkmanager location

### DIFF
--- a/scripts/android/build.sh
+++ b/scripts/android/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright (C) 2019-2021 HERE Europe B.V.
+# Copyright (C) 2019-2024 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,9 +25,10 @@
 
 # Install required NDK version (output disabled as it causes issues during page loading)
 env
-${ANDROID_HOME}/tools/bin/sdkmanager --list
-${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.3.6528147" --sdk_root=${ANDROID_HOME} >/dev/null
-${ANDROID_HOME}/tools/bin/sdkmanager --list
+${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --list
+${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install "ndk;21.3.6528147" --sdk_root=${ANDROID_HOME} >/dev/null
+${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install "platforms;android-28" >/dev/null
+${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --list
 export ANDROID_NDK_HOME=$ANDROID_HOME/ndk/21.3.6528147
 env
 # Verify content of NDK directories


### PR DESCRIPTION
Looks like latest Android studios changed that. Trying to follow.
Adapted to latest Ubuntu20-04 image updates in 
https://github.com/actions/runner-images/releases/tag/ubuntu20%2F20240107.1

Relates-To: OLPEDGE-2855