### PR TITLE
CI: Add iOS/MacOS new parralel builds

### DIFF
--- a/.github/workflows/psv_pipelines.yml
+++ b/.github/workflows/psv_pipelines.yml
@@ -115,6 +115,16 @@ jobs:
       run: scripts/macos/psv/azure_macos_build_psv.sh
       shell: bash
 
+  psv-macos-12-xcode-14-build:
+    name: PSV.MacOS12.Xcode14
+    runs-on: macOS-12
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: MacOS Build
+      run: scripts/macos/psv/azure_macos_build_psv.sh
+      shell: bash
+
   psv-ios-xcode-11-build:
     name: PSV.iOS.MacOS11.Xcode11.7
     runs-on: macOS-11
@@ -124,6 +134,38 @@ jobs:
     - name: iOS Xcode 11-7 Build
       run: scripts/ios/azure_ios_build_psv.sh
       shell: bash
+      env:
+        USE_LATEST_XCODE: 0
+
+  psv-ios-xcode-14-2-build:
+    name: PSV.iOS.MacOS12.Xcode14.2
+    runs-on: macOS-12
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: iOS Xcode 14-2 Build
+      run: scripts/ios/azure_ios_build_psv.sh
+      shell: bash
+
+  psv-ios-os13-xcode-15-build:
+    name: PSV.iOS.MacOS13.Xcode15
+    runs-on: macOS-13
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: iOS Xcode 15 Build
+      run: scripts/ios/azure_ios_build_psv.sh
+      shell: bash
+
+  psv-ios-os14-xcode-15-build:
+    name: PSV.iOS.MacOS14.Xcode15
+    runs-on: macOS-14
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: iOS Xcode 15 Build
+        run: scripts/ios/azure_ios_build_psv.sh
+        shell: bash
 
   psv-commit-checker:
     name: PSV.Commit.Checker

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ The table below lists the platforms on which the Data SDK has been tested.
 The table below lists the dependencies of the Data SDK.
 
 | Library              | Recommended version |
-| :------------------- | :------------------ |
+| :------------------- |:--------------------|
 | libcurl              | 7.52.0              |
-| OpenSSL              | 1.1.1g              |
-| Boost (headers only) | 1.69.0              |
+| OpenSSL              | 1.1.1t              |
+| Boost (headers only) | 1.72.0              |
 | LevelDB              | 1.21                |
 | Snappy               | 1.1.7               |
 | RapidJSON            | latest              |

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 HERE Europe B.V.
+# Copyright (C) 2019-2024 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/ios/azure_ios_build_psv.sh
+++ b/scripts/ios/azure_ios_build_psv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (C) 2019-2021 HERE Europe B.V.
+# Copyright (C) 2019-2024 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,10 +22,12 @@
 # Sometimes there is no boost and there is no need to fail in this case.
 brew uninstall --ignore-dependencies boost || true
 
-# Due to some bug which is cmake cannot detect compiler while called
-# from cmake itself when project is compiled with XCode 12.4 we must
-# switch to old XCode as a workaround.
-sudo xcode-select -s /Applications/Xcode_11.7.app
+if [[ ${USE_LATEST_XCODE} == 0 ]]; then
+  # Due to some bug which is cmake cannot detect compiler while called
+  # from cmake itself when project is compiled with XCode 12.4 we must
+  # switch to old XCode as a workaround.
+  sudo xcode-select -s /Applications/Xcode_11.7.app
+fi
 
 mkdir -p build && cd build
 cmake ../ -GXcode \


### PR DESCRIPTION
Add all possible builds for iOS/MacOS.
Correct tools versions in README.md.

Relates-To: MINOR-IMPROVE-CI

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>