### PR TITLE
Add NetworkOffline for offline environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 HERE Europe B.V.
+# Copyright (C) 2019-2024 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ option(OLP_SDK_ENABLE_DEFAULT_CACHE "Enable default cache implementation based o
 option(OLP_SDK_ENABLE_DEFAULT_CACHE_LMDB "Enable default cache implementation based on LMDB" OFF)
 option(OLP_SDK_ENABLE_ANDROID_CURL "Enable curl based network layer for Android" OFF)
 option(OLP_SDK_ENABLE_IOS_BACKGROUND_DOWNLOAD "Enable iOS network layer downloading in background. Under testing." OFF)
+option(OLP_SDK_ENABLE_OFFLINE_MODE "Enable offline mode. Network layer is excluded from the build and all network requests returned with error." OFF)
 
 # C++ standard version. Minimum supported version is 11.
 set(CMAKE_CXX_STANDARD 11)

--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2023 HERE Europe B.V.
+# Copyright (C) 2019-2024 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ include(cmake/CompileChecks.cmake)
 
 porting_do_checks()
 
-if(IOS OR (WIN32 AND NOT MINGW))
+if(OLP_SDK_ENABLE_OFFLINE_MODE OR IOS OR (WIN32 AND NOT MINGW))
     set(NETWORK_NO_CURL ON)
 elseif(ANDROID)
     if(OLP_SDK_ENABLE_ANDROID_CURL)
@@ -56,10 +56,14 @@ endif()
 
 set(Network_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
-include(cmake/curl.cmake)
-include(cmake/winhttp.cmake)
-include(cmake/android.cmake)
-include(cmake/ios.cmake)
+if(OLP_SDK_ENABLE_OFFLINE_MODE)
+    include(cmake/offline.cmake)
+else()
+    include(cmake/curl.cmake)
+    include(cmake/winhttp.cmake)
+    include(cmake/android.cmake)
+    include(cmake/ios.cmake)
+endif()
 
 set(OLP_SDK_CACHE_HEADERS
     ./include/olp/core/cache/CacheSettings.h
@@ -299,41 +303,46 @@ set(OLP_SDK_PLATFORM_SOURCES
     ./src/context/ContextInternal.h
 )
 
-if (ANDROID)
-    # http network Android implementation:
-    set(OLP_SDK_HTTP_ANDROID_SOURCES
-        ./src/http/android/NetworkAndroid.h
-        ./src/http/android/NetworkAndroid.cpp
-        ./src/http/android/utils/JNIThreadBinder.h
-        ./src/http/android/utils/JNIScopedLocalReference.h
-    )
+if (NOT OLP_SDK_ENABLE_OFFLINE_MODE)
+    if (ANDROID)
+        # http network Android implementation:
+        set(OLP_SDK_HTTP_ANDROID_SOURCES
+            ./src/http/android/NetworkAndroid.h
+            ./src/http/android/NetworkAndroid.cpp
+            ./src/http/android/utils/JNIThreadBinder.h
+            ./src/http/android/utils/JNIScopedLocalReference.h
+        )
 
-    set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_ANDROID_SOURCES})
-    set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_HAS_ANDROID)
-endif()
-
-if (UNIX AND (NOT ANDROID OR OLP_SDK_ENABLE_ANDROID_CURL))
-    set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_CURL_SOURCES})
-
-    set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_HAS_CURL)
-endif()
-
-if (IOS)
-    set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_IOS_SOURCES})
-    set(OLP_SDK_PLATFORM_HEADERS ${OLP_SDK_PLATFORM_HEADERS} ${OLP_SDK_PLATFORM_IOS_HEADERS})
-    set(OLP_SDK_PLATFORM_SOURCES ${OLP_SDK_PLATFORM_SOURCES} ${OLP_SDK_PLATFORM_IOS_SOURCES})
-
-    set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_HAS_IOS)
-endif()
-
-if (WIN32)
-    if (MINGW)
-        set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_CURL_SOURCES})
-        set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_HAS_CURL)
-    else()
-        set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_WIN_SOURCES})
-        set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_HAS_WINHTTP)
+        set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_ANDROID_SOURCES})
+        set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_HAS_ANDROID)
     endif()
+
+    if (UNIX AND (NOT ANDROID OR OLP_SDK_ENABLE_ANDROID_CURL))
+        set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_CURL_SOURCES})
+
+        set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_HAS_CURL)
+    endif()
+
+    if (IOS)
+        set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_IOS_SOURCES})
+        set(OLP_SDK_PLATFORM_HEADERS ${OLP_SDK_PLATFORM_HEADERS} ${OLP_SDK_PLATFORM_IOS_HEADERS})
+        set(OLP_SDK_PLATFORM_SOURCES ${OLP_SDK_PLATFORM_SOURCES} ${OLP_SDK_PLATFORM_IOS_SOURCES})
+
+        set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_HAS_IOS)
+    endif()
+
+    if (WIN32)
+        if (MINGW)
+            set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_CURL_SOURCES})
+            set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_HAS_CURL)
+        else()
+            set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_WIN_SOURCES})
+            set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_HAS_WINHTTP)
+        endif()
+    endif()
+else()
+    set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_OFFLINE_SOURCES})
+    set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_OFFLINE)
 endif()
 
 set(OLP_SDK_UTILS_SOURCES
@@ -509,7 +518,7 @@ if(IOS)
     target_link_libraries(${PROJECT_NAME} PRIVATE ${OLP_SDK_CORE_FOUNDATION_FRAMEWORK}
                                                   ${OLP_SDK_SECURITY_FRAMEWORK}
                                                   ${OLP_SDK_CFNETWORK_FRAMEWORK})
-elseif(ANDROID AND NOT OLP_SDK_ENABLE_ANDROID_CURL)
+elseif(ANDROID AND NOT OLP_SDK_ENABLE_ANDROID_CURL AND NOT OLP_SDK_ENABLE_OFFLINE_MODE)
     # Make sure that OlpHttpClient.jar is built before olp-cpp-sdk-core
     add_dependencies(${PROJECT_NAME} ${OLP_SDK_ANDROID_HTTP_CLIENT_JAR})
 endif()

--- a/olp-cpp-sdk-core/cmake/offline.cmake
+++ b/olp-cpp-sdk-core/cmake/offline.cmake
@@ -1,0 +1,24 @@
+# Copyright (C) 2024 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+
+set(OLP_SDK_HTTP_OFFLINE_SOURCES
+    "${CMAKE_CURRENT_LIST_DIR}/../src/http/offline/NetworkOffline.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/../src/http/offline/NetworkOffline.h"
+)
+
+add_definitions(-DOLP_SDK_NETWORK_OFFLINE)

--- a/olp-cpp-sdk-core/src/http/Network.cpp
+++ b/olp-cpp-sdk-core/src/http/Network.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,9 @@
 #include "http/DefaultNetwork.h"
 #include "olp/core/utils/WarningWorkarounds.h"
 
-#ifdef OLP_SDK_NETWORK_HAS_CURL
+#ifdef OLP_SDK_NETWORK_OFFLINE
+#include "offline/NetworkOffline.h"
+#elif OLP_SDK_NETWORK_HAS_CURL
 #include "curl/NetworkCurl.h"
 #elif OLP_SDK_NETWORK_HAS_ANDROID
 #include "android/NetworkAndroid.h"
@@ -39,7 +41,9 @@ namespace {
 std::shared_ptr<Network> CreateDefaultNetworkImpl(
     NetworkInitializationSettings settings) {
   OLP_SDK_CORE_UNUSED(settings);
-#ifdef OLP_SDK_NETWORK_HAS_CURL
+#ifdef OLP_SDK_NETWORK_OFFLINE
+  return std::make_shared<NetworkOffline>();
+#elif OLP_SDK_NETWORK_HAS_CURL
   return std::make_shared<NetworkCurl>(settings);
 #elif OLP_SDK_NETWORK_HAS_ANDROID
   return std::make_shared<NetworkAndroid>(settings.max_requests_count);

--- a/olp-cpp-sdk-core/src/http/offline/NetworkOffline.cpp
+++ b/olp-cpp-sdk-core/src/http/offline/NetworkOffline.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "NetworkOffline.h"
+
+#include <memory>
+
+#include "olp/core/http/HttpStatusCode.h"
+#include "olp/core/logging/Log.h"
+
+namespace olp {
+namespace http {
+
+namespace {
+
+const char* kLogTag = "NetworkOffline";
+
+}  // anonymous namespace
+
+NetworkOffline::NetworkOffline() {
+  OLP_SDK_LOG_TRACE(kLogTag, "Created NetworkOffline with address=" << this);
+}
+
+NetworkOffline::~NetworkOffline() {
+  OLP_SDK_LOG_TRACE(kLogTag, "Destroyed NetworkOffline object, this=" << this);
+}
+
+SendOutcome NetworkOffline::Send(NetworkRequest request,
+                                 std::shared_ptr<std::ostream> payload,
+                                 Network::Callback callback,
+                                 Network::HeaderCallback header_callback,
+                                 Network::DataCallback data_callback) {
+  OLP_SDK_CORE_UNUSED(payload);
+  OLP_SDK_CORE_UNUSED(callback);
+  OLP_SDK_CORE_UNUSED(header_callback);
+  OLP_SDK_CORE_UNUSED(data_callback);
+  OLP_SDK_LOG_ERROR(
+      kLogTag, "Send failed - network is offline, url=" << request.GetUrl());
+  return SendOutcome(ErrorCode::OFFLINE_ERROR);
+}
+
+void NetworkOffline::Cancel(RequestId id) {
+  OLP_SDK_LOG_ERROR(kLogTag, "Cancel failed - network is offline, id=" << id);
+  return;
+}
+
+}  // namespace http
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/http/offline/NetworkOffline.h
+++ b/olp-cpp-sdk-core/src/http/offline/NetworkOffline.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include "olp/core/http/Network.h"
+#include "olp/core/http/NetworkRequest.h"
+
+namespace olp {
+namespace http {
+
+/**
+ * @brief The implementation of Network based on cURL.
+ */
+class NetworkOffline : public olp::http::Network,
+                       public std::enable_shared_from_this<NetworkOffline> {
+ public:
+  /**
+   * @brief NetworkOffline constructor.
+   */
+  NetworkOffline();
+
+  /**
+   * @brief ~NetworkOffline destructor.
+   */
+  ~NetworkOffline() override;
+
+  /**
+   * @brief Not copyable.
+   */
+  NetworkOffline(const NetworkOffline& other) = delete;
+
+  /**
+   * @brief Not movable.
+   */
+  NetworkOffline(NetworkOffline&& other) = delete;
+
+  /**
+   * @brief Not copy-assignable.
+   */
+  NetworkOffline& operator=(const NetworkOffline& other) = delete;
+
+  /**
+   * @brief Not move-assignable.
+   */
+  NetworkOffline& operator=(NetworkOffline&& other) = delete;
+
+  /**
+   * @brief Implementation of Send method from Network abstract class.
+   */
+  SendOutcome Send(NetworkRequest request, Payload payload, Callback callback,
+                   HeaderCallback header_callback = nullptr,
+                   DataCallback data_callback = nullptr) override;
+
+  /**
+   * @brief Implementation of Cancel method from Network abstract class.
+   */
+  void Cancel(RequestId id) override;
+};
+
+}  // namespace http
+}  // namespace olp


### PR DESCRIPTION
There are cases where device want to rely on the offline data only or even want to completely avoid network related libs like libcurl and libssl.

Relates-To: OLPEDGE-2861