### PR TITLE
Ignore brew boost uninstall error for iOS CI nodes

### DIFF
--- a/scripts/ios/azure_ios_build_psv.sh
+++ b/scripts/ios/azure_ios_build_psv.sh
@@ -18,8 +18,9 @@
 # License-Filename: LICENSE
 
 # Getting rid of boost installed to the CI image (not clear when it appeared)
-# asciidoc and source-highlight are using it so dependencies are ignored
-brew uninstall --ignore-dependencies boost
+# asciidoc and source-highlight are using it so dependencies are ignored.
+# Sometimes there is no boost and there is no need to fail in this case.
+brew uninstall --ignore-dependencies boost || true
 
 # Due to some bug which is cmake cannot detect compiler while called
 # from cmake itself when project is compiled with XCode 12.4 we must


### PR DESCRIPTION
It appeared not all images has boost installed from brew so we don't want to fail in that case

Relates-To: OLPEDGE-2861