### PR TITLE
Return Postponed if protected cache failed to open

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -144,6 +144,7 @@ olp::cache::DefaultCache::StorageOpenResult ToStorageOpenResult(
       return StorageOpenResult::ProtectedCacheCorrupted;
     case olp::cache::OpenResult::Repaired:
     case olp::cache::OpenResult::Success:
+    case olp::cache::OpenResult::Postponed:
       return StorageOpenResult::Success;
   }
 

--- a/olp-cpp-sdk-core/src/cache/DiskCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -241,6 +241,15 @@ OpenResult DiskCache::Open(const std::string& data_path,
 
   if (status.IsInvalidArgument() && is_read_only) {
     // Maybe folder with cache is an empty, so trying to create db and reopen it
+    if (!repair_if_broken) {
+      OLP_SDK_LOG_WARNING_F(kLogTag,
+                            "Open: failed, initialize attempt postponed, "
+                            "cache_path='%s', error='%s'",
+                            versioned_data_path.c_str(),
+                            status.ToString().c_str());
+      return OpenResult::Postponed;
+    }
+
     status = InitializeDB(settings, versioned_data_path);
     if (!status.ok()) {
       return OpenResult::Fail;

--- a/olp-cpp-sdk-core/src/cache/DiskCache.h
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,9 @@ enum class OpenResult {
   /// broken.
   Repaired,
   /// The store was successfully opened.
-  Success
+  Success,
+  /// The openning was postponed. Could be empty readonly location.
+  Postponed
 };
 
 struct StorageSettings {


### PR DESCRIPTION
This allows read-only protected cache location at start. Later when there is a need to write to the protected cache it can be opened as mutable and it is going to be an error if we have no write permission at that time.

Relates-To: OLPEDGE-2858