### PR TITLE
Avoid redundant move. gcc13

### DIFF
--- a/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 HERE Europe B.V.
+ * Copyright (C) 2020-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,10 @@
 
 #include <chrono>
 #include <iomanip>
+#include <limits>
 #include <sstream>
 #include <thread>
+#include <utility>
 
 #include <rapidjson/document.h>
 #include <rapidjson/istreamwrapper.h>
@@ -590,7 +592,7 @@ client::CancellationToken AuthenticationClientImpl::SignUpHereUser(
   };
 
   return AddTask(settings_.task_scheduler, pending_requests_,
-                 std::move(signup_task), std::move(callback));
+                 std::move(signup_task), callback);
 }
 
 client::CancellationToken AuthenticationClientImpl::SignOut(
@@ -635,7 +637,7 @@ client::CancellationToken AuthenticationClientImpl::SignOut(
   };
 
   return AddTask(settings_.task_scheduler, pending_requests_,
-                 std::move(sign_out_task), std::move(callback));
+                 std::move(sign_out_task), callback);
 }
 
 client::CancellationToken AuthenticationClientImpl::IntrospectApp(

--- a/olp-cpp-sdk-core/src/client/OlpClient.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -560,8 +560,7 @@ CancellationToken OlpClient::OlpClientImpl::CallApi(
 
   if (merge) {
     // Add callback and prepare CancellationToken
-    auto call_id =
-        pending_requests->Append(url, std::move(callback), request_ptr);
+    auto call_id = pending_requests->Append(url, callback, request_ptr);
     cancellation_token =
         CancellationToken([=] { pending_requests->Cancel(url, call_id); });
 
@@ -577,7 +576,7 @@ CancellationToken OlpClient::OlpClientImpl::CallApi(
     request_ptr = std::make_shared<PendingUrlRequest>();
 
     // Add callback and prepare CancellationToken
-    auto call_id = request_ptr->Append(std::move(callback));
+    auto call_id = request_ptr->Append(callback);
     cancellation_token =
         CancellationToken([=] { request_ptr->Cancel(call_id); });
   }

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/StreamApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/StreamApi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,9 @@
 #include "StreamApi.h"
 
 #include <map>
+#include <memory>
+#include <utility>
+#include <vector>
 
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/HttpResponse.h>
@@ -93,7 +96,7 @@ StreamApi::SubscribeApiResponse StreamApi::Subscribe(
 
   auto http_response = client.CallApi(
       metadata_uri, "POST", std::move(query_params), std::move(header_params),
-      {}, data, "application/json", std::move(context));
+      {}, data, "application/json", context);
   if (http_response.status != http::HttpStatusCode::CREATED) {
     return client::ApiError(http_response.status, http_response.response.str());
   }
@@ -127,7 +130,7 @@ StreamApi::ConsumeDataApiResponse StreamApi::ConsumeData(
 
   auto http_response = client.CallApi(
       metadata_uri, "GET", std::move(query_params), std::move(header_params),
-      {}, nullptr, std::string{}, std::move(context));
+      {}, nullptr, std::string{}, context);
   if (http_response.status != http::HttpStatusCode::OK) {
     return client::ApiError(http_response.status, http_response.response.str());
   }
@@ -178,7 +181,7 @@ StreamApi::UnsubscribeApiResponse StreamApi::DeleteSubscription(
 
   const auto http_response = client.CallApi(
       metadata_uri, "DELETE", std::move(query_params), std::move(header_params),
-      {}, nullptr, std::string{}, std::move(context));
+      {}, nullptr, std::string{}, context);
   if (http_response.status != http::HttpStatusCode::OK) {
     return client::ApiError(http_response.status, http_response.response.str());
   }
@@ -217,7 +220,7 @@ Response<int> StreamApi::HandleOffsets(
 
   const auto http_response = client.CallApi(
       metadata_uri, "PUT", std::move(query_params), std::move(header_params),
-      {}, data, "application/json", std::move(context));
+      {}, data, "application/json", context);
   if (http_response.status != http::HttpStatusCode::OK) {
     return client::ApiError(http_response.status, http_response.response.str());
   }

--- a/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,8 @@
 #include "generated/IndexApi.h"
 
 #include <atomic>
+#include <string>
+#include <utility>
 
 namespace {
 std::string GenerateUuid() {
@@ -208,7 +210,7 @@ client::CancellationToken IndexLayerClientImpl::PublishIndex(
   };
 
   return AddTask(settings_.task_scheduler, pending_requests_,
-                 std::move(publish_task), std::move(callback));
+                 std::move(publish_task), callback);
 }
 
 client::CancellableFuture<DeleteIndexDataResponse>

--- a/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,11 @@
 
 #include "BlobApi.h"
 
+#include <map>
 #include <memory>
 #include <sstream>
+#include <utility>
+#include <vector>
 
 #include <olp/core/client/HttpResponse.h>
 #include <olp/core/http/HttpStatusCode.h>
@@ -87,7 +90,7 @@ PutBlobResponse BlobApi::PutBlob(
   header_params.insert(std::make_pair("Accept", "application/json"));
 
   if (!content_encoding.empty()) {
-      header_params.insert(std::make_pair("Content-Encoding", content_encoding));
+    header_params.insert(std::make_pair("Content-Encoding", content_encoding));
   }
 
   if (billing_tag) {
@@ -99,8 +102,8 @@ PutBlobResponse BlobApi::PutBlob(
 
   auto http_response =
       client.CallApi(std::move(put_blob_uri), "PUT", std::move(query_params),
-                     std::move(header_params), std::move(form_params),
-                     std::move(data), std::move(content_type), cancel_context);
+                     std::move(header_params), std::move(form_params), data,
+                     content_type, cancel_context);
 
   if (http_response.status != olp::http::HttpStatusCode::OK &&
       http_response.status != olp::http::HttpStatusCode::NO_CONTENT) {

--- a/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplPublishToBatchTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplPublishToBatchTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 HERE Europe B.V.
+ * Copyright (C) 2020-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,7 +158,7 @@ class VersionedLayerClientImplPublishToBatchTest : public ::testing::Test {
             ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(status),
                                olp::serializer::serialize(apis)));
 
-    return std::move(service_api);
+    return service_api;
   }
 
   write::model::Apis CreateApiResponse(const std::string& service) {

--- a/tests/integration/olp-cpp-sdk-dataservice-write/VersionedLayerClientPublishToBatchTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/VersionedLayerClientPublishToBatchTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 HERE Europe B.V.
+ * Copyright (C) 2020-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,7 +155,7 @@ class VersionedLayerClientPublishToBatchTest : public ::testing::Test {
             ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(status),
                                olp::serializer::serialize(apis)));
 
-    return std::move(service_api);
+    return service_api;
   }
 
   write::model::Apis CreateApiResponse(const std::string& service) {


### PR DESCRIPTION
The argument is constant reference
Fixing gcc13 warning