### PR TITLE
Exclude commit checker job on master

### DIFF
--- a/.github/workflows/psv_pipelines.yml
+++ b/.github/workflows/psv_pipelines.yml
@@ -234,6 +234,7 @@ jobs:
   psv-commit-checker:
     name: PSV.Commit.Checker
     runs-on: ubuntu-20.04
+    if: github.ref_name != 'master'
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Exclude commit checker job on master
as it's failing due to GitHub feature
which adds PR# to every title afterwards.
This will make post submit workflow green.

Resolves: MINOR-IMPROVEMENT