### PR TITLE
Detect unexpected directories in the cache

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/utils/Dir.h
+++ b/olp-cpp-sdk-core/include/olp/core/utils/Dir.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,9 @@ class CORE_API Dir {
  public:
   /// An alias for the filter function.
   using FilterFunction = std::function<bool(const std::string&)>;
+
+  /// An alias for the path callback function.
+  using PathCallback = std::function<void(const std::string&)>;
 
   /**
    * @brief Checks whether a directory exists.
@@ -143,6 +146,15 @@ class CORE_API Dir {
    * path.
    */
   static bool IsReadOnly(const std::string& path);
+
+  /**
+   * @brief Iterates through all directories in the provided path and calls the
+   * provided callback function for each directory.
+   *
+   * @param path The path of the root directory.
+   * @param path_fn The callback function.
+   */
+  static void ForEachDirectory(const std::string& path, PathCallback path_fn);
 };
 
 }  // namespace utils

--- a/olp-cpp-sdk-core/src/cache/DiskCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.cpp
@@ -204,6 +204,23 @@ OpenResult DiskCache::Open(const std::string& data_path,
     }
   }
 
+  // Check cache path for unexpected directories
+  const std::vector<std::string> expected_dirs = {disk_cache_path_ +
+                                                  kLevelDbLostFolder};
+  bool unexpected_dirs = false;
+  utils::Dir::ForEachDirectory(disk_cache_path_, [&](const std::string& dir) {
+    if (std::find(expected_dirs.begin(), expected_dirs.end(), dir) ==
+        expected_dirs.end()) {
+      OLP_SDK_LOG_WARNING_F(
+          kLogTag, "Open: unexpected directory found, path='%s'", dir.c_str());
+      unexpected_dirs = true;
+    }
+  });
+
+  if (unexpected_dirs) {
+    return OpenResult::Fail;
+  }
+
   enforce_immediate_flush_ = settings.enforce_immediate_flush;
 
   max_size_ = settings.max_disk_storage;


### PR DESCRIPTION
Scan cache folder for the unexpected directories as their presence means that the cache was changed outside of Data SDK, or the wrong cache was used in a first place.

Relates-To: OLPEDGE-2857