### PR TITLE
Changed name argument to const

### DIFF
--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
@@ -67,7 +67,7 @@ int Md5LookupCtrl(X509_LOOKUP* ctx, int, const char*, long, char**) {
 }
 
 int Md5LookupGetBySubject(X509_LOOKUP* ctx, X509_LOOKUP_TYPE type,
-                          X509_NAME* name, X509_OBJECT* ret) {
+                          const X509_NAME* name, X509_OBJECT* ret) {
   if (type != X509_LU_X509) {
     OLP_SDK_LOG_ERROR_F(kLogTag, "Unsupported lookup type, type=%d", type);
     return 0;


### PR DESCRIPTION
Changed name argument to const in Md5LookupGetBySubject to support OpenSSL v3.1.4

Relates-To: OLPEDGE-2876