### PR TITLE
Add Win build job

### DIFF
--- a/.github/workflows/psv_pipelines.yml
+++ b/.github/workflows/psv_pipelines.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Install Ubuntu dependencies
-      run: sudo rm /etc/apt/sources.list.d/microsoft-prod.list && sudo apt-get update && sudo apt-get install -y libboost-all-dev ccache libssl-dev libcurl4-openssl-dev gcc-9 g++-9 --no-install-recommends
+      run: sudo apt-get update && sudo apt-get install -y libboost-all-dev ccache libssl-dev libcurl4-openssl-dev gcc-9 g++-9 --no-install-recommends
       shell: bash
     - name: Compile project with cmake and ccache
       run: gcc --version && ./scripts/linux/psv/build_psv.sh
@@ -87,7 +87,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
       - name: Install Ubuntu dependencies
-        run: sudo rm /etc/apt/sources.list.d/microsoft-prod.list && sudo apt-get update && sudo apt-get install -y libboost-all-dev ccache libssl-dev libcurl4-openssl-dev --no-install-recommends
+        run: sudo apt-get update && sudo apt-get install -y libboost-all-dev ccache libssl-dev libcurl4-openssl-dev --no-install-recommends
         shell: bash
       - name: Compile project with cmake and ccache
         run: gcc --version && ./scripts/linux/psv/build_psv.sh
@@ -121,7 +121,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
       - name: Install Ubuntu dependencies
-        run: sudo rm /etc/apt/sources.list.d/microsoft-prod.list && sudo add-apt-repository ppa:ubuntu-toolchain-r/test && sudo apt-get update && sudo apt-get install -y libboost-all-dev ccache libssl-dev libcurl4-openssl-dev gcc-13 g++-13 --no-install-recommends
+        run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test && sudo apt-get update && sudo apt-get install -y libboost-all-dev ccache libssl-dev libcurl4-openssl-dev gcc-13 g++-13 --no-install-recommends
         shell: bash
       - name: Compile project with cmake and ccache
         run: gcc --version && ./scripts/linux/psv/build_psv.sh
@@ -136,7 +136,7 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Install Ubuntu dependencies
-      run: sudo rm /etc/apt/sources.list.d/microsoft-prod.list && sudo apt-get update && sudo apt-get install -y libboost-all-dev libssl-dev libcurl4-openssl-dev --no-install-recommends
+      run: sudo apt-get update && sudo apt-get install -y libboost-all-dev libssl-dev libcurl4-openssl-dev --no-install-recommends
       shell: bash
     - name: Compile project without cache
       run: ./scripts/linux/psv/build_psv_no_cache.sh
@@ -256,6 +256,19 @@ jobs:
         uses: actions/checkout@v4
       - name: iOS Xcode 15 Build
         run: scripts/ios/azure_ios_build_psv.sh
+        shell: bash
+
+  psv-win-16-vc2019-build:
+    name: PSV.Win.VC2019
+    runs-on: windows-2019
+    env:
+      BUILD_TYPE: RelWithDebInfo
+      GENERATOR: "Visual Studio 16 2019"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Build
+        run: scripts/windows/build.sh
         shell: bash
 
   psv-commit-checker:

--- a/scripts/windows/build.sh
+++ b/scripts/windows/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (C) 2019-2021 HERE Europe B.V.
+# Copyright (C) 2019-2024 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-
+env
 [[ -d "build" ]] && rm -rf build
 mkdir build && cd build
-cmake .. -G "Visual Studio 16 2019" -A x64 \
-        -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+cmake .. -G "${GENERATOR}" -A x64 \
+        -DBUILD_TYPE=$BUILD_TYPE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 cmake --build . --config $BUILD_TYPE


### PR DESCRIPTION
Add Win build job to have minimal verification on
Windows. Use the image with VC 2019.
Minor updates in jobs to remove temporary tips.



Relates-To: OLPEDGE-2873, DATASDK-53