### PR TITLE
Add a new Promote API to KeyValueCache

### DIFF
--- a/.github/workflows/psv_pipelines.yml
+++ b/.github/workflows/psv_pipelines.yml
@@ -22,7 +22,7 @@ jobs:
       CXX: g++-7
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: "C++ Lint checker script"
         run: ./scripts/misc/cpplint_ci.sh
         shell: bash
@@ -42,9 +42,9 @@ jobs:
       CXX: g++-9
     steps:
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install Ubuntu dependencies
-      run: sudo apt-get update && sudo apt-get install -y libboost-all-dev ccache libssl-dev libcurl4-openssl-dev gcc-9 g++-9 --no-install-recommends
+      run: sudo rm /etc/apt/sources.list.d/microsoft-prod.list && sudo apt-get update && sudo apt-get install -y libboost-all-dev ccache libssl-dev libcurl4-openssl-dev gcc-9 g++-9 --no-install-recommends
       shell: bash
     - name: Compile project with cmake and ccache
       run: gcc --version && ./scripts/linux/psv/build_psv.sh
@@ -63,7 +63,7 @@ jobs:
       CXX: g++-7
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install Ubuntu dependencies
       run: sudo apt-get update && sudo apt-get install -y libboost-all-dev libssl-dev libcurl4-openssl-dev gcc-7 g++-7 --no-install-recommends
       shell: bash
@@ -78,9 +78,9 @@ jobs:
       BUILD_TYPE: RelWithDebInfo
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Ubuntu dependencies
-        run: sudo apt-get update && sudo apt-get install -y libboost-all-dev ccache libssl-dev libcurl4-openssl-dev --no-install-recommends
+        run: sudo rm /etc/apt/sources.list.d/microsoft-prod.list && sudo apt-get update && sudo apt-get install -y libboost-all-dev ccache libssl-dev libcurl4-openssl-dev --no-install-recommends
         shell: bash
       - name: Compile project with cmake and ccache
         run: gcc --version && ./scripts/linux/psv/build_psv.sh
@@ -95,9 +95,9 @@ jobs:
       CXX: g++-13
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install Ubuntu dependencies
-      run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test && sudo apt-get update && sudo apt-get install -y libboost-all-dev libssl-dev libcurl4-openssl-dev gcc-13 g++-13 --no-install-recommends
+      run: sudo rm /etc/apt/sources.list.d/microsoft-prod.list && sudo add-apt-repository ppa:ubuntu-toolchain-r/test && sudo apt-get update && sudo apt-get install -y libboost-all-dev libssl-dev libcurl4-openssl-dev gcc-13 g++-13 --no-install-recommends
       shell: bash
     - name: Compile project without cache
       run: ./scripts/linux/psv/build_psv_no_cache.sh
@@ -112,9 +112,9 @@ jobs:
       CXX: g++-13
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Ubuntu dependencies
-        run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test && sudo apt-get update && sudo apt-get install -y libboost-all-dev ccache libssl-dev libcurl4-openssl-dev --no-install-recommends
+        run: sudo rm /etc/apt/sources.list.d/microsoft-prod.list && sudo add-apt-repository ppa:ubuntu-toolchain-r/test && sudo apt-get update && sudo apt-get install -y libboost-all-dev ccache libssl-dev libcurl4-openssl-dev --no-install-recommends
         shell: bash
       - name: Compile project with cmake and ccache
         run: gcc --version && ./scripts/linux/psv/build_psv.sh
@@ -127,9 +127,9 @@ jobs:
       BUILD_TYPE: RelWithDebInfo
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install Ubuntu dependencies
-      run: sudo apt-get update && sudo apt-get install -y libboost-all-dev libssl-dev libcurl4-openssl-dev --no-install-recommends
+      run: sudo rm /etc/apt/sources.list.d/microsoft-prod.list && sudo apt-get update && sudo apt-get install -y libboost-all-dev libssl-dev libcurl4-openssl-dev --no-install-recommends
       shell: bash
     - name: Compile project without cache
       run: ./scripts/linux/psv/build_psv_no_cache.sh
@@ -145,7 +145,7 @@ jobs:
       CXX: clang++-7
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install Ubuntu dependencies
       run: sudo apt-get update -y && sudo apt-get install clang-7 ccache libcurl4-openssl-dev -y --no-install-recommends --fix-missing
       shell: bash
@@ -161,7 +161,7 @@ jobs:
       BUILD_TYPE: RelWithDebInfo
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Verification of prerequisites
       run: env && ls -la $ANDROID_HOME
       shell: bash
@@ -174,7 +174,7 @@ jobs:
     runs-on: macOS-11
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: MacOS Build
       run: scripts/macos/psv/azure_macos_build_psv.sh
       shell: bash
@@ -184,7 +184,7 @@ jobs:
     runs-on: macOS-12
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: MacOS Build
       run: scripts/macos/psv/azure_macos_build_psv.sh
       shell: bash
@@ -194,7 +194,7 @@ jobs:
     runs-on: macOS-11
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: iOS Xcode 11-7 Build
       run: scripts/ios/azure_ios_build_psv.sh
       shell: bash
@@ -206,7 +206,7 @@ jobs:
     runs-on: macOS-12
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: iOS Xcode 14-2 Build
       run: scripts/ios/azure_ios_build_psv.sh
       shell: bash
@@ -216,7 +216,7 @@ jobs:
     runs-on: macOS-13
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: iOS Xcode 15 Build
       run: scripts/ios/azure_ios_build_psv.sh
       shell: bash
@@ -226,7 +226,7 @@ jobs:
     runs-on: macOS-14
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: iOS Xcode 15 Build
         run: scripts/ios/azure_ios_build_psv.sh
         shell: bash
@@ -236,7 +236,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.ref_name != 'master'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set tags env variables.

--- a/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -253,6 +253,13 @@ class CORE_API DefaultCache : public KeyValueCache {
    * otherwise.
    */
   bool IsProtected(const std::string& key) const override;
+
+  /**
+   * @brief Promotes a key in the cache LRU when applicable.
+   *
+   * @param key The key to promote in the cache LRU.
+   */
+  void Promote(const std::string& key) override;
 
   /**
    * @brief Gets size of the corresponding cache.

--- a/olp-cpp-sdk-core/include/olp/core/cache/KeyValueCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/KeyValueCache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include <time.h>
+#include <ctime>
 #include <functional>
 #include <limits>
 #include <memory>
@@ -174,6 +174,13 @@ class CORE_API KeyValueCache {
     OLP_SDK_CORE_UNUSED(key);
     return false;
   }
+
+  /**
+   * @brief Promotes a key in the cache LRU when applicable.
+   *
+   * @param key The key to promote in the cache LRU.
+   */
+  virtual void Promote(const std::string& key) { OLP_SDK_CORE_UNUSED(key); }
 };
 
 }  // namespace cache

--- a/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,8 @@
  * License-Filename: LICENSE
  */
 
-#include "DefaultCacheImpl.h"
 #include "olp/core/cache/DefaultCache.h"
-#include "olp/core/porting/warning_disable.h"
+#include "DefaultCacheImpl.h"
 
 namespace olp {
 namespace cache {
@@ -88,6 +87,8 @@ uint64_t DefaultCache::Size(CacheType cache_type) const {
 }
 
 uint64_t DefaultCache::Size(uint64_t new_size) { return impl_->Size(new_size); }
+
+void DefaultCache::Promote(const std::string& key) { impl_->Promote(key); }
 
 }  // namespace cache
 }  // namespace olp

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -508,7 +508,7 @@ bool DefaultCacheImpl::AddKeyLru(std::string key, const leveldb::Slice& value) {
       // end, this could cause exception in std::stoll. This is fixed by
       // constructing a string, (We rely on small string optimization here).
       std::string timestamp(value.data(), value.size());
-      props.expiry = std::stoll(timestamp.c_str());
+      props.expiry = std::stoll(timestamp);
     } else {
       props.size = value.size();
     }
@@ -1137,6 +1137,13 @@ uint64_t DefaultCacheImpl::Size(uint64_t new_size) {
   mutable_cache_data_size_ -= evicted;
   mutable_cache_->Compact();
   return evicted;
+}
+
+void DefaultCacheImpl::Promote(const std::string& key) {
+  std::lock_guard<std::mutex> lock(cache_lock_);
+  if (mutable_cache_lru_) {
+    mutable_cache_lru_->Find(key);
+  }
 }
 
 }  // namespace cache

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ class DefaultCacheImpl {
   bool Protect(const DefaultCache::KeyListType& keys);
   bool Release(const DefaultCache::KeyListType& keys);
   bool IsProtected(const std::string& key) const;
+  void Promote(const std::string& key);
 
   uint64_t Size(DefaultCache::CacheType type) const;
   uint64_t Size(uint64_t new_size);
@@ -169,7 +170,8 @@ class DefaultCacheImpl {
   boost::optional<std::pair<std::string, time_t>> GetFromDiscCache(
       const std::string& key);
 
-  time_t GetExpiryForMemoryCache(const std::string& key, const time_t& expiry) const;
+  time_t GetExpiryForMemoryCache(const std::string& key,
+                                 const time_t& expiry) const;
 
   CacheSettings settings_;
   bool is_open_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,11 +78,8 @@ boost::optional<model::Data> DataCacheRepository::Get(
 
 bool DataCacheRepository::IsCached(const std::string& layer_id,
                                    const std::string& data_handle) const {
-  const auto key =
-      cache::KeyGenerator::CreateDataHandleKey(hrn_, layer_id, data_handle);
-  OLP_SDK_LOG_DEBUG_F(kLogTag, "IsCached key -> '%s'", key.c_str());
-
-  return cache_->Contains(key);
+  return cache_->Contains(
+      cache::KeyGenerator::CreateDataHandleKey(hrn_, layer_id, data_handle));
 }
 
 bool DataCacheRepository::Clear(const std::string& layer_id,
@@ -90,8 +87,12 @@ bool DataCacheRepository::Clear(const std::string& layer_id,
   const auto key =
       cache::KeyGenerator::CreateDataHandleKey(hrn_, layer_id, data_handle);
   OLP_SDK_LOG_DEBUG_F(kLogTag, "Clear -> '%s'", key.c_str());
-
   return cache_->RemoveKeysWithPrefix(key);
+}
+void DataCacheRepository::PromoteInCache(const std::string& layer_id,
+                                         const std::string& data_handle) {
+  cache_->Promote(
+      cache::KeyGenerator::CreateDataHandleKey(hrn_, layer_id, data_handle));
 }
 
 }  // namespace repository

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,9 @@ class DataCacheRepository final {
                                    const std::string& data_handle);
   bool IsCached(const std::string& layer_id,
                 const std::string& data_handle) const;
+
+  void PromoteInCache(const std::string& layer_id,
+                      const std::string& data_handle);
 
   bool Clear(const std::string& layer_id, const std::string& data_handle);
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,22 +19,16 @@
 
 #include "DataRepository.h"
 
-#include <algorithm>
-#include <sstream>
 #include <string>
 #include <utility>
 
 #include <olp/core/client/Condition.h>
 #include <olp/core/logging/Log.h>
-#include "CatalogRepository.h"
 #include "DataCacheRepository.h"
-#include "PartitionsCacheRepository.h"
 #include "PartitionsRepository.h"
 #include "generated/api/BlobApi.h"
 #include "generated/api/VolatileBlobApi.h"
 #include "olp/dataservice/read/CatalogRequest.h"
-#include "olp/dataservice/read/CatalogVersionRequest.h"
-#include "olp/dataservice/read/PartitionsRequest.h"
 #include "olp/dataservice/read/TileRequest.h"
 
 namespace olp {

--- a/tests/common/mocks/CacheMock.h
+++ b/tests/common/mocks/CacheMock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,4 +54,6 @@ class CacheMock : public olp::cache::KeyValueCache {
   MOCK_METHOD(bool, Protect, (const KeyListType&), (override));
 
   MOCK_METHOD(bool, Release, (const KeyListType&), (override));
+
+  MOCK_METHOD(void, Promote, (const std::string&), (override));
 };


### PR DESCRIPTION
Change the PrefetchTiles behavior to promote existing data when it is requested but available in cache.

Relates-To: OAM-2436