### PR TITLE
Add logging of per-context variables to logging system and network stack

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -156,6 +156,7 @@ set(OLP_SDK_LOGGING_HEADERS
     ./include/olp/core/logging/Format.h
     ./include/olp/core/logging/Level.h
     ./include/olp/core/logging/Log.h
+    ./include/olp/core/logging/LogContext.h
     ./include/olp/core/logging/LogMessage.h
     ./include/olp/core/logging/MessageFormatter.h
 )
@@ -361,6 +362,7 @@ set(OLP_SDK_LOGGING_SOURCES
     ./src/logging/FilterGroup.cpp
     ./src/logging/Format.cpp
     ./src/logging/Log.cpp
+    ./src/logging/LogContext.cpp
     ./src/logging/MessageFormatter.cpp
     ./src/logging/ThreadId.cpp
     ./src/logging/ThreadId.h

--- a/olp-cpp-sdk-core/include/olp/core/logging/Log.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/Log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
  */
 #define OLP_SDK_DO_LOG(level, tag, message)                             \
   do {                                                                  \
-    std::stringstream __strm;                                           \
+    std::ostringstream __strm;                                          \
     __strm << message;                                                  \
     ::olp::logging::Log::logMessage(level, tag, __strm.str(), __FILE__, \
                                     __LINE__, __FUNCTION__,             \

--- a/olp-cpp-sdk-core/include/olp/core/logging/LogContext.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/LogContext.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2019-2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <olp/core/CoreApi.h>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+/**
+ * @brief The LogContext object stores per-thread key/value pairs that can be
+ * picked up in log messages using the
+ * 'olp::logging::MessageFormatter::ElementType::ContextValue' logging element.
+ */
+namespace olp {
+namespace logging {
+/// A context key/value map.  The keys are required to be const and immutable.
+using LogContext = std::unordered_map<std::string, std::string>;
+
+/// A function that sets the current log context.
+using LogContextSetter = std::function<void(std::shared_ptr<const LogContext>)>;
+
+/// A function that gets the current log context.
+using LogContextGetter = std::function<std::shared_ptr<const LogContext>()>;
+
+/**
+ * Sets the getter and setter for the log context.
+ *
+ * @param[in] getter The log context getter, or the default getter if
+ * nullptr.
+ * @param[in] setter The log context setter, or the default setter if
+ * nullptr.
+ */
+CORE_API void SetLogContextGetterSetter(LogContextGetter getter,
+                                        LogContextSetter setter);
+
+/// Gets the current thread context.
+CORE_API std::shared_ptr<const LogContext> GetContext();
+
+/// Gets a value from the current thread context.
+CORE_API const std::string& GetContextValue(const std::string& key);
+
+/**
+ * @brief The ScopedLogContext class takes ownership of a log context
+ * and makes it active on construction and restores the previous context on
+ * destruction.
+ *
+ * Passing 'nullptr' is the same as passing an empty LogContext.
+ *
+ * @see MessageFormatter::ElementType::Context
+ */
+class CORE_API ScopedLogContext final {
+ public:
+  ScopedLogContext(const std::shared_ptr<const LogContext>& context);
+  ~ScopedLogContext();
+
+ private:
+  std::shared_ptr<const LogContext> context_;
+  std::shared_ptr<const LogContext> prev_context_;
+};
+}  // namespace logging
+}  // namespace olp

--- a/olp-cpp-sdk-core/include/olp/core/logging/MessageFormatter.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/MessageFormatter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,8 +91,9 @@ class CORE_API MessageFormatter {
              ///  `strftime()`.
     TimeMs,  ///< The millisecond portion of the timestamp. It is formatted as
              ///< an unsigned integer.
-    ThreadId  ///< The thread ID of the thread that generated the message.
+    ThreadId, ///< The thread ID of the thread that generated the message.
               ///< It is formatted as an unsigned long.
+    ContextValue,  ///< A key/value literal from LogContext; 'format' is the key to look up.
   };
 
   /**

--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
@@ -844,6 +844,7 @@ NetworkCurl::RequestHandle* NetworkCurl::GetHandle(
       handle.send_time = std::chrono::steady_clock::now();
       handle.error_text[0] = 0;
       handle.skip_content = false;
+      handle.log_context = logging::GetContext();
 
       return &handle;
     }
@@ -1004,8 +1005,9 @@ void NetworkCurl::CompleteMessage(CURL* handle, CURLcode result) {
   int index = GetHandleIndex(handle);
   if (index >= 0 && index < static_cast<int>(handles_.size())) {
     RequestHandle& rhandle = handles_[index];
-
+    logging::ScopedLogContext scopedLogContext(rhandle.log_context);
     auto callback = rhandle.callback;
+
     if (!callback) {
       OLP_SDK_LOG_WARNING(
           kLogTag,
@@ -1196,6 +1198,8 @@ void NetworkCurl::Run() {
           int handle_index = GetHandleIndex(handle);
           if (handle_index >= 0) {
             RequestHandle& rhandle = handles_[handle_index];
+            logging::ScopedLogContext scopedLogContext(rhandle.log_context);
+
             auto callback = rhandle.callback;
             if (!callback) {
               OLP_SDK_LOG_WARNING(

--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,7 @@
 #include "olp/core/http/Network.h"
 #include "olp/core/http/NetworkInitializationSettings.h"
 #include "olp/core/http/NetworkRequest.h"
+#include "olp/core/logging/LogContext.h"
 
 namespace olp {
 namespace http {
@@ -134,6 +135,7 @@ class NetworkCurl : public olp::http::Network,
     bool cancelled{};
     bool skip_content{};
     char error_text[CURL_ERROR_SIZE]{};
+    std::shared_ptr<const logging::LogContext> log_context;
   };
 
   /**

--- a/olp-cpp-sdk-core/src/logging/Log.cpp
+++ b/olp-cpp-sdk-core/src/logging/Log.cpp
@@ -180,6 +180,7 @@ void LogImpl::appendLogItem(const LogItem& log_item) {
       appender_with_log_level.appender->append(log_item);
   }
 }
+
 // implementation of public static Log API
 //--------------------------------------------------------
 

--- a/olp-cpp-sdk-core/src/logging/LogContext.cpp
+++ b/olp-cpp-sdk-core/src/logging/LogContext.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2019-2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/core/logging/LogContext.h>
+
+#include <cassert>
+
+namespace olp {
+namespace logging {
+namespace {
+thread_local std::shared_ptr<const LogContext> tls_logContext;
+
+LogContextSetter s_defaultLogContextSetter =
+    [](std::shared_ptr<const LogContext> context) {
+      tls_logContext = std::move(context);
+    };
+
+LogContextSetter s_logContextSetter = s_defaultLogContextSetter;
+
+LogContextGetter s_defaultLogContextGetter = []() { return tls_logContext; };
+LogContextGetter s_logContextGetter = s_defaultLogContextGetter;
+
+}  // namespace
+
+void SetLogContextGetterSetter(LogContextGetter getter,
+                               LogContextSetter setter) {
+  s_logContextGetter = getter ? std::move(getter) : s_defaultLogContextGetter;
+  s_logContextSetter = setter ? std::move(setter) : s_defaultLogContextSetter;
+}
+
+std::shared_ptr<const LogContext> GetContext() {
+  assert(s_logContextGetter && "Invalid LogContext getter");
+  return s_logContextGetter();
+}
+
+const std::string& GetContextValue(const std::string& key) {
+  static std::string s_empty = "";
+  auto ctx = GetContext();
+  if (!ctx || key.empty())
+    return s_empty;
+
+  auto it = ctx->find(key);
+  if (it == ctx->end())
+    return s_empty;
+
+  return it->second;
+}
+
+ScopedLogContext::ScopedLogContext(
+    const std::shared_ptr<const LogContext>& context)
+    : context_(context) {
+  prev_context_ = GetContext();
+  assert(s_logContextSetter && "Invalid LogContext setter");
+  s_logContextSetter(context_);
+}
+
+ScopedLogContext::~ScopedLogContext() {
+  assert(s_logContextSetter && "Invalid LogContext setter");
+  s_logContextSetter(std::move(prev_context_));
+}
+
+}  // namespace logging
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/logging/MessageFormatter.cpp
+++ b/olp-cpp-sdk-core/src/logging/MessageFormatter.cpp
@@ -22,7 +22,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
-#include <functional>
 #include <string>
 
 namespace olp {

--- a/olp-cpp-sdk-core/src/logging/MessageFormatter.cpp
+++ b/olp-cpp-sdk-core/src/logging/MessageFormatter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,9 @@
  */
 
 #include <olp/core/logging/Format.h>
+#include <olp/core/logging/LogContext.h>
 #include <olp/core/logging/MessageFormatter.h>
+
 #include <algorithm>
 #include <cassert>
 #include <cstring>
@@ -178,6 +180,11 @@ std::string MessageFormatter::format(const LogMessage& message) const {
       case ElementType::ThreadId:
         curElement =
             curElementBuffer.format(element.format.c_str(), message.threadId);
+        break;
+      case ElementType::ContextValue:
+        // 'format' is key to lookup
+        curElement = curElementBuffer.format(
+            "%s", GetContextValue(element.format).c_str());
         break;
       default:
         continue;

--- a/tests/common/ResponseGenerator.h
+++ b/tests/common/ResponseGenerator.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This change adds a per-thread logging context to the logging system, which can be set by the user and will then be logged from all threads and tasks created with that context.

This is useful to correlate requests from the client to any network requests made based on that request.

The logging formatter must be set up by including a `MessageFormatter::ElementType::ContextValue` with the 'format' set to the context key to use:

```c++
using ElementT = olp::logging::MessageFormatter::ElementType;
std::vector<ElementT> elements = {
    ElementT(ElementType::Time, "%F %T"),
    ElementT(ElementType::TimeMs, ".%03u "),
    ElementT(ElementType::Level, "%s ["),
    ElementT(ElementType::ContextValue, X_CORRELATION_ID),
    ElementT(ElementType::Tag, "] %s: "),
    ElementT(ElementType::Message, "%s")
};
```

The log context must then be created and set up once manually from the top-most thread:

```c++
std::shared_ptr<olp::logging::LogContext>
createLogContext(const std::string& correlationID)
{
    auto context = std::make_shared<olp::logging::LogContext>();
    (*context)[X_CORRELATION_ID] = correlationID;

    return context;
}
```

The log context is stored for each thread, so whenever a new thread or task is created, this context must somehow be copied into the thread-local storage of that new thread.

For `ThreadPoolTaskScheduler`, the current log context is captured for the new task lambda and made active when the task is activated.

For `NetworkCurl`, the current log context is captured inside the `RequestHandle` on creation and subsequently made active whenever this request is processed.

Resolves: OLPEDGE-2893