### PR TITLE
Extension of KeyValueCache interface

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
@@ -262,6 +262,47 @@ class CORE_API DefaultCache : public KeyValueCache {
   void Promote(const std::string& key) override;
 
   /**
+   * @brief Gets the binary data from the cache.
+   *
+   * @param key The key that is used to look for the binary data.
+   *
+   * @return The binary data or an error if the data could not be retrieved from
+   * the cache.
+   */
+  OperationOutcome<ValueTypePtr> Read(const std::string& key) override;
+
+  /**
+   * @brief Stores the raw binary data as a value in the cache.
+   *
+   * @param key The key for this value.
+   * @param value The binary data that should be stored.
+   * @param expiry The expiry time (in seconds) of the key-value pair.
+   *
+   * @return An error if the data could not be written to the cache.
+   */
+  OperationOutcomeEmpty Write(const std::string& key, const ValueTypePtr& value,
+                              time_t expiry) override;
+
+  /**
+   * @brief Removes the key-value pair from the cache.
+   *
+   * @param key The key for the value.
+   *
+   * @return An error if the data could not be removed from the cache.
+   */
+  OperationOutcomeEmpty Delete(const std::string& key) override;
+
+  /**
+   * @brief Removes the values with the keys that match the given
+   * prefix from the cache.
+   *
+   * @param prefix The prefix that matches the keys.
+   *
+   * @return An error if the data could not be removed from the cache.
+   */
+  OperationOutcomeEmpty DeleteByPrefix(const std::string& prefix) override;
+
+  /**
    * @brief Gets size of the corresponding cache.
    *
    * @param cache_type The type of a cache.

--- a/olp-cpp-sdk-core/include/olp/core/cache/KeyValueCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/KeyValueCache.h
@@ -27,6 +27,9 @@
 #include <vector>
 
 #include <olp/core/CoreApi.h>
+#include <olp/core/client/ApiError.h>
+#include <olp/core/client/ApiNoResult.h>
+#include <olp/core/client/ApiResponse.h>
 #include <olp/core/utils/WarningWorkarounds.h>
 #include <boost/any.hpp>
 
@@ -35,6 +38,10 @@ namespace cache {
 
 using Encoder = std::function<std::string()>;
 using Decoder = std::function<boost::any(const std::string&)>;
+
+template <typename Result>
+using OperationOutcome = client::ApiResponse<Result, client::ApiError>;
+using OperationOutcomeEmpty = OperationOutcome<client::ApiNoResult>;
 
 /// An interface for a cache that expects a key-value pair.
 class CORE_API KeyValueCache {
@@ -181,6 +188,62 @@ class CORE_API KeyValueCache {
    * @param key The key to promote in the cache LRU.
    */
   virtual void Promote(const std::string& key) { OLP_SDK_CORE_UNUSED(key); }
+
+  /**
+   * @brief Gets the binary data from the cache.
+   *
+   * @param key The key that is used to look for the binary data.
+   *
+   * @return The binary data or an error if the data could not be retrieved from
+   * the cache.
+   */
+  virtual OperationOutcome<ValueTypePtr> Read(const std::string& key) {
+    OLP_SDK_CORE_UNUSED(key);
+    return client::ApiError(client::ErrorCode::Unknown, "Not implemented");
+  }
+
+  /**
+   * @brief Stores the raw binary data as a value in the cache.
+   *
+   * @param key The key for this value.
+   * @param value The binary data that should be stored.
+   * @param expiry The expiry time (in seconds) of the key-value pair.
+   *
+   * @return An error if the data could not be written to the cache.
+   */
+  virtual OperationOutcomeEmpty Write(const std::string& key,
+                                      const ValueTypePtr& value,
+                                      time_t expiry = kDefaultExpiry) {
+    OLP_SDK_CORE_UNUSED(key);
+    OLP_SDK_CORE_UNUSED(value);
+    OLP_SDK_CORE_UNUSED(expiry);
+    return client::ApiError(client::ErrorCode::Unknown, "Not implemented");
+  }
+
+  /**
+   * @brief Removes the key-value pair from the cache.
+   *
+   * @param key The key for the value.
+   *
+   * @return An error if the data could not be removed from the cache.
+   */
+  virtual OperationOutcomeEmpty Delete(const std::string& key) {
+    OLP_SDK_CORE_UNUSED(key);
+    return client::ApiError(client::ErrorCode::Unknown, "Not implemented");
+  }
+
+  /**
+   * @brief Removes the values with the keys that match the given
+   * prefix from the cache.
+   *
+   * @param prefix The prefix that matches the keys.
+   *
+   * @return An error if the data could not be removed from the cache.
+   */
+  virtual OperationOutcomeEmpty DeleteByPrefix(const std::string& prefix) {
+    OLP_SDK_CORE_UNUSED(prefix);
+    return client::ApiError(client::ErrorCode::Unknown, "Not implemented");
+  }
 };
 
 }  // namespace cache

--- a/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
@@ -90,5 +90,24 @@ uint64_t DefaultCache::Size(uint64_t new_size) { return impl_->Size(new_size); }
 
 void DefaultCache::Promote(const std::string& key) { impl_->Promote(key); }
 
+OperationOutcome<KeyValueCache::ValueTypePtr> DefaultCache::Read(
+    const std::string& key) {
+  return impl_->Read(key);
+}
+
+OperationOutcomeEmpty DefaultCache::Write(
+    const std::string& key, const KeyValueCache::ValueTypePtr& value,
+    time_t expiry) {
+  return impl_->Write(key, value, expiry);
+}
+
+OperationOutcomeEmpty DefaultCache::Delete(const std::string& key) {
+  return impl_->Delete(key);
+}
+
+OperationOutcomeEmpty DefaultCache::DeleteByPrefix(const std::string& prefix) {
+  return impl_->DeleteByPrefix(prefix);
+}
+
 }  // namespace cache
 }  // namespace olp

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
@@ -68,6 +68,13 @@ class DefaultCacheImpl {
   bool IsProtected(const std::string& key) const;
   void Promote(const std::string& key);
 
+  OperationOutcome<KeyValueCache::ValueTypePtr> Read(const std::string& key);
+  OperationOutcomeEmpty Write(const std::string& key,
+                              const KeyValueCache::ValueTypePtr& value,
+                              time_t expiry);
+  OperationOutcomeEmpty Delete(const std::string& key);
+  OperationOutcomeEmpty DeleteByPrefix(const std::string& prefix);
+
   uint64_t Size(DefaultCache::CacheType type) const;
   uint64_t Size(uint64_t new_size);
 
@@ -153,8 +160,9 @@ class DefaultCacheImpl {
   int64_t MaybeUpdatedProtectedKeys(leveldb::WriteBatch& batch);
 
   /// Puts data into the mutable cache
-  bool PutMutableCache(const std::string& key, const leveldb::Slice& value,
-                       time_t expiry);
+  OperationOutcomeEmpty PutMutableCache(const std::string& key,
+                                        const leveldb::Slice& value,
+                                        time_t expiry);
 
   DefaultCache::StorageOpenResult SetupStorage();
 
@@ -164,8 +172,9 @@ class DefaultCacheImpl {
 
   void DestroyCache(DefaultCache::CacheType type);
 
-  bool GetFromDiskCache(const std::string& key,
-                        KeyValueCache::ValueTypePtr& value, time_t& expiry);
+  OperationOutcomeEmpty GetFromDiskCache(const std::string& key,
+                                         KeyValueCache::ValueTypePtr& value,
+                                         time_t& expiry);
 
   boost::optional<std::pair<std::string, time_t>> GetFromDiscCache(
       const std::string& key);

--- a/olp-cpp-sdk-core/tests/cache/DefaultCacheImplTest.cpp
+++ b/olp-cpp-sdk-core/tests/cache/DefaultCacheImplTest.cpp
@@ -122,7 +122,7 @@ class DefaultCacheImplHelper : public cache::DefaultCacheImpl {
       return false;
     }
 
-    return disk_cache->Get(key) != boost::none;
+    return disk_cache->Get(key).IsSuccessful();
   }
 
   uint64_t CalculateExpirySize(const std::string& key) const {
@@ -132,7 +132,12 @@ class DefaultCacheImplHelper : public cache::DefaultCacheImpl {
       return 0u;
     }
 
-    const auto expiry_str = disk_cache->Get(expiry_key).get_value_or({});
+    auto expiry_result = disk_cache->Get(expiry_key);
+    if (!expiry_result) {
+      return 0u;
+    }
+    std::string expiry_str(expiry_result.GetResult()->begin(),
+                           expiry_result.GetResult()->end());
     if (expiry_str.empty()) {
       return 0u;
     }

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogCacheRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogCacheRepositoryTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,23 +26,21 @@
 
 namespace {
 
-using namespace olp;
-using namespace olp::dataservice::read;
-
 constexpr auto kCatalog = "hrn:here:data::olp-here-test:catalog";
 
-TEST(PartitionsCacheRepositoryTest, DefaultExpiry) {
-  const auto hrn = client::HRN::FromString(kCatalog);
+TEST(CatalogCacheRepositoryTest, DefaultExpiry) {
+  const auto hrn = olp::client::HRN::FromString(kCatalog);
 
-  model::Catalog model_catalog;
+  olp::dataservice::read::model::Catalog model_catalog;
 
   {
     SCOPED_TRACE("Disable expiration");
 
     const auto default_expiry = std::chrono::seconds::max();
-    std::shared_ptr<cache::KeyValueCache> cache =
+    std::shared_ptr<olp::cache::KeyValueCache> cache =
         olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
-    repository::CatalogCacheRepository repository(hrn, cache, default_expiry);
+    olp::dataservice::read::repository::CatalogCacheRepository repository(
+        hrn, cache, default_expiry);
 
     repository.Put(model_catalog);
     const auto result = repository.Get();
@@ -54,9 +52,10 @@ TEST(PartitionsCacheRepositoryTest, DefaultExpiry) {
     SCOPED_TRACE("Expired");
 
     const auto default_expiry = std::chrono::seconds(-1);
-    std::shared_ptr<cache::KeyValueCache> cache =
+    std::shared_ptr<olp::cache::KeyValueCache> cache =
         olp::client::OlpClientSettingsFactory::CreateDefaultCache({});
-    repository::CatalogCacheRepository repository(hrn, cache, default_expiry);
+    olp::dataservice::read::repository::CatalogCacheRepository repository(
+        hrn, cache, default_expiry);
 
     repository.Put(model_catalog);
     const auto result = repository.Get();


### PR DESCRIPTION
Added main operations like Read, Write, Remove.
The difference with the old one is that new API may return actual error instead of cryptic `false`.
DefaultCache implementation was extended as well
to cover new methods.

Relates-To: OCMAM-3, OAM-2431