### PR TITLE
New error code "NoSpaceLeft"

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/ErrorCode.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ErrorCode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,7 +90,12 @@ enum class ErrorCode {
   /**
    * A failed cache IO operation.
    */
-  CacheIO
+  CacheIO,
+
+  /**
+   * The device is full and cannot store more data.
+   */
+  NoSpaceLeft,
 };
 
 }  // namespace client


### PR DESCRIPTION
This error code may be used to signal shortage of available space on the target device.

Relates-To: OCMAM-3, OAM-2431