### PR TITLE
Optimizing hot code allocations

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/generated/api/BlobApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/BlobApi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@
 #include <boost/optional.hpp>
 #include "ExtendedApiResponse.h"
 #include "olp/dataservice/read/model/Data.h"
+#include "olp/dataservice/read/model/Partitions.h"
 
 namespace olp {
 namespace client {
@@ -48,7 +49,7 @@ class BlobApi {
    * @brief Retrieves a data blob for specified handle.
    * @param client Instance of OlpClient used to make REST request.
    * @param layer_id Layer id.
-   * @param data_handle Indentifies a specific blob.
+   * @param partition The blob metadata.
    * @param billing_tag An optional free-form tag which is used for grouping
    * billing records together. If supplied, it must be between 4 - 16
    * characters, contain only alpha/numeric ASCII characters  [A-Za-z0-9].
@@ -66,7 +67,7 @@ class BlobApi {
    */
   static DataResponse GetBlob(const client::OlpClient& client,
                               const std::string& layer_id,
-                              const std::string& data_handle,
+                              const model::Partition& partition,
                               boost::optional<std::string> billing_tag,
                               boost::optional<std::string> range,
                               const client::CancellationContext& context);

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,11 +57,11 @@ class DataRepository final {
                                         client::CancellationContext context,
                                         bool fail_on_cache_error = false);
 
-  BlobApi::DataResponse GetBlobData(const std::string& layer,
-                                    const std::string& service,
-                                    const DataRequest& request,
-                                    client::CancellationContext context,
-                                    bool fail_on_cache_error = false);
+  BlobApi::DataResponse GetBlobData(
+      const std::string& layer, const std::string& service,
+      const model::Partition& partition, FetchOptions fetch_option,
+      const boost::optional<std::string>& billing_tag,
+      client::CancellationContext context, bool fail_on_cache_error = false);
 
  private:
   client::HRN catalog_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/QuadTreeIndex.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 HERE Europe B.V.
+ * Copyright (C) 2020-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ class QuadTreeIndex {
   };
 
   QuadTreeIndex() = default;
-  explicit QuadTreeIndex(cache::KeyValueCache::ValueTypePtr data);
+  explicit QuadTreeIndex(const cache::KeyValueCache::ValueTypePtr& data);
   QuadTreeIndex(const olp::geo::TileKey& root, int depth,
                 std::stringstream& json_stream);
 
@@ -67,7 +67,7 @@ class QuadTreeIndex {
   boost::optional<IndexData> Find(const olp::geo::TileKey& tile_key,
                                   bool aggregated) const;
 
-  inline const cache::KeyValueCache::ValueTypePtr GetRawData() const {
+  inline cache::KeyValueCache::ValueTypePtr GetRawData() const {
     return raw_data_;
   }
 

--- a/olp-cpp-sdk-dataservice-read/tests/MetadataApiTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/MetadataApiTest.cpp
@@ -83,7 +83,7 @@ TEST_F(MetadataApiTest, GetListVersions) {
         olp::client::CancellationContext{});
 
     ASSERT_TRUE(index_response.IsSuccessful());
-    auto result = index_response.GetResult();
+    const auto& result = index_response.GetResult();
 
     ASSERT_EQ(1u, result.GetVersions().size());
     ASSERT_EQ(4, result.GetVersions().front().GetVersion());
@@ -106,7 +106,7 @@ TEST_F(MetadataApiTest, GetListVersions) {
         olp::client::CancellationContext{});
 
     ASSERT_TRUE(response.IsSuccessful());
-    auto result = response.GetResult();
+    const auto& result = response.GetResult();
 
     ASSERT_EQ(1u, result.GetVersions().size());
     ASSERT_EQ(4, result.GetVersions().front().GetVersion());
@@ -123,7 +123,7 @@ TEST_F(MetadataApiTest, GetListVersions) {
         *client_, kStartVersion, kEndVersion, boost::none, context);
 
     ASSERT_FALSE(index_response.IsSuccessful());
-    auto error = index_response.GetError();
+    const auto& error = index_response.GetError();
     ASSERT_EQ(olp::client::ErrorCode::Cancelled, error.GetErrorCode());
   }
 }
@@ -173,10 +173,10 @@ TEST_P(MetadataApiParamTest, GetPartitionsStream) {
   EXPECT_CALL(*network_mock_, Send(AllOf(IsGetRequest(test_params.url),
                                          HeadersContainOptional(range_header)),
                                    _, _, _, _))
-      .WillOnce(ReturnHttpResponseWithDataCallback(
-          olp::http::NetworkResponse().WithStatus(
-              olp::http::HttpStatusCode::OK),
-          ref_stream_data, offset));
+      .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                       olp::http::HttpStatusCode::OK),
+                                   ref_stream_data, {},
+                                   std::chrono::milliseconds(50), 5, offset));
 
   client::HttpResponse response =
       olp::dataservice::read::MetadataApi::GetPartitionsStream(

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -2052,14 +2052,14 @@ TEST_F(PartitionsRepositoryTest, StreamPartitions) {
 
     EXPECT_CALL(*network,
                 Send(IsGetRequest(kOlpSdkUrlVersionedPartitions), _, _, _, _))
-        .WillOnce(ReturnHttpResponseWithDataCallback(
-            olp::http::NetworkResponse().WithStatus(
-                olp::http::HttpStatusCode::OK),
-            ref_stream_data, 0))
-        .WillOnce(ReturnHttpResponseWithDataCallback(
-            olp::http::NetworkResponse().WithStatus(
-                olp::http::HttpStatusCode::OK),
-            ref_stream_data, 10));
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     ref_stream_data, {},
+                                     std::chrono::milliseconds(50), 5, 0))
+        .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
+                                         olp::http::HttpStatusCode::OK),
+                                     ref_stream_data, {},
+                                     std::chrono::milliseconds(50), 5, 10));
 
     repository.StreamPartitions(async_stream, kVersion, additional_fields,
                                 billing_tag, context);

--- a/tests/common/mocks/NetworkMock.h
+++ b/tests/common/mocks/NetworkMock.h
@@ -84,11 +84,12 @@ struct MockedResponseInformation {
  * Cancel();
  */
 std::tuple<olp::http::RequestId, NetworkCallback, CancelCallback>
-GenerateNetworkMockActions(std::shared_ptr<std::promise<void>> pre_signal,
-                           std::shared_ptr<std::promise<void>> wait_for_signal,
-                           MockedResponseInformation response_information,
-                           std::shared_ptr<std::promise<void>> post_signal =
-                               std::make_shared<std::promise<void>>());
+GenerateNetworkMockActions(
+    const std::shared_ptr<std::promise<void>>& pre_signal,
+    const std::shared_ptr<std::promise<void>>& wait_for_signal,
+    const MockedResponseInformation& response_information,
+    const std::shared_ptr<std::promise<void>>& post_signal =
+        std::make_shared<std::promise<void>>());
 
 ///
 /// NetworkMock Actions
@@ -103,6 +104,7 @@ GenerateNetworkMockActions(std::shared_ptr<std::promise<void>> pre_signal,
  * @param response_body Response payload.
  * @param headers Response headers (optional).
  * @param delay Response delay (optional).
+ * @param offset Payload offset (optional).
  *
  * @return A function that mimics Network::Send method.
  */
@@ -110,26 +112,7 @@ NetworkCallback ReturnHttpResponse(
     olp::http::NetworkResponse response, const std::string& response_body,
     const olp::http::Headers& headers = {},
     std::chrono::nanoseconds delay = std::chrono::milliseconds(50),
-    olp::http::RequestId request_id = 5);
-
-/**
- * @brief Helper function creates Network::Send mock function that returns a
- * specified response, body, headers after specified delay from a different
- * thread.
- *
- * @param response Network response.
- * @param response_body Response payload.
- * @param offset Payload offset (optional).
- * @param headers Response headers (optional).
- * @param delay Response delay (optional).
- *
- * @return A function that mimics Network::Send method.
- */
-NetworkCallback ReturnHttpResponseWithDataCallback(
-    olp::http::NetworkResponse response, const std::string& response_body,
-    std::uint64_t offset = 0, const olp::http::Headers& headers = {},
-    std::chrono::nanoseconds delay = std::chrono::milliseconds(50),
-    olp::http::RequestId request_id = 5);
+    olp::http::RequestId request_id = 5, std::uint64_t offset = 0);
 
 inline olp::http::NetworkResponse GetResponse(int status,
                                               int bytes_downloaded = 0,

--- a/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -267,10 +267,12 @@ TEST_F(ApiTest, GetBlob) {
 
   olp::client::CancellationContext context;
 
+  olp::dataservice::read::model::Partition partition;
+  partition.SetDataHandle("d5d73b64-7365-41c3-8faf-aa6ad5bab135");
+
   auto start_time = std::chrono::high_resolution_clock::now();
   auto data_response = olp::dataservice::read::BlobApi::GetBlob(
-      blob_client, "testlayer", "d5d73b64-7365-41c3-8faf-aa6ad5bab135",
-      boost::none, boost::none, context);
+      blob_client, "testlayer", partition, boost::none, boost::none, context);
   auto end = std::chrono::high_resolution_clock::now();
 
   std::chrono::duration<double> time = end - start_time;


### PR DESCRIPTION
Optimize allocations in QuadTreeIndex
Use a stream call API to download blobs to eliminate unnecessary copy

Relates-To: OLPEDGE-2444