### PR TITLE
New client option to propagate cache errors

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -232,12 +232,20 @@ struct CORE_API OlpClientSettings {
    * This setting only applies to the mutable cache and to the in-memory cache,
    * but should not affect the protected cache as no entries are added to the
    * protected cache in read-only mode. Set to std::chrono::seconds::max() to
-   * disable expiration. By default expiration is disabled.
+   * disable expiration. By default, expiration is disabled.
    *
    * @note This only makes sense for data that has an expiration limit, e.g.
    * volatile or versioned, and which is stored in cache.
    */
   std::chrono::seconds default_cache_expiration = std::chrono::seconds::max();
+
+  /**
+   * @brief The flag to enable or disable the propagation of all cache errors.
+   *
+   * When set to `false` only critical cache errors are propagated to the user.
+   * By default, this setting is set to `false`.
+   */
+  bool propagate_all_cache_errors = false;
 };
 
 }  // namespace client

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -191,7 +191,8 @@ client::CancellationToken VersionedLayerClientImpl::GetData(
 
     repository::DataRepository repository(catalog_, settings_, lookup_client_,
                                           mutex_storage_);
-    return repository.GetVersionedData(layer_id_, request, version, context);
+    return repository.GetVersionedData(layer_id_, request, version, context,
+                                       settings_.propagate_all_cache_errors);
   };
 
   return task_sink_.AddTask(std::move(data_task), std::move(callback),
@@ -841,7 +842,8 @@ client::CancellationToken VersionedLayerClientImpl::GetAggregatedData(
     repository::DataRepository data_repository(catalog_, settings_,
                                                lookup_client_, mutex_storage_);
     auto data_response = data_repository.GetVersionedData(
-        layer_id_, data_request, version, context);
+        layer_id_, data_request, version, context,
+        settings_.propagate_all_cache_errors);
 
     const auto aggregated_network_statistics =
         partition_response.GetPayload() + data_response.GetPayload();

--- a/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VolatileLayerClientImpl.cpp
@@ -112,7 +112,8 @@ client::CancellationToken VolatileLayerClientImpl::GetData(
   auto task = [=](client::CancellationContext context) {
     repository::DataRepository repository(catalog_, settings_, lookup_client_,
                                           mutex_storage_);
-    return repository.GetVolatileData(layer_id_, request, context);
+    return repository.GetVolatileData(layer_id_, request, std::move(context),
+                                      settings_.propagate_all_cache_errors);
   };
 
   return task_sink_.AddTask(std::move(task), std::move(callback),

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -74,7 +74,8 @@ DataResponse DataRepository::GetVersionedTile(
 
   auto data_response =
       GetBlobData(layer_id, kBlobService, partition, request.GetFetchOption(),
-                  request.GetBillingTag(), std::move(context));
+                  request.GetBillingTag(), std::move(context),
+                  settings_.propagate_all_cache_errors);
   network_statistics += data_response.GetPayload();
 
   if (data_response) {

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.h
@@ -50,18 +50,18 @@ class DataRepository final {
                                          const DataRequest& request,
                                          int64_t version,
                                          client::CancellationContext context,
-                                         bool fail_on_cache_error = false);
+                                         bool fail_on_cache_error);
 
   BlobApi::DataResponse GetVolatileData(const std::string& layer_id,
                                         const DataRequest& request,
                                         client::CancellationContext context,
-                                        bool fail_on_cache_error = false);
+                                        bool fail_on_cache_error);
 
   BlobApi::DataResponse GetBlobData(
       const std::string& layer, const std::string& service,
       const model::Partition& partition, FetchOptions fetch_option,
       const boost::optional<std::string>& billing_tag,
-      client::CancellationContext context, bool fail_on_cache_error = false);
+      client::CancellationContext context, bool fail_on_cache_error);
 
  private:
   client::HRN catalog_;


### PR DESCRIPTION
Previously, some client APIs may ignore cache errors as they were not critical for the API to operate correctly. New option allows to enforce errors propagation in all cases when cache consistency is a key.

Relates-To: DATASDK-10