### PR TITLE
Adapt PartitionsCacheRepository to use Write

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/ApiError.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/ApiError.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,6 +95,18 @@ class CORE_API ApiError {
    */
   static ApiError NotFound(const char* message = "Resource not found") {
     return {ErrorCode::NotFound, message};
+  }
+
+  /**
+   * @brief Creates the `ApiError` instance with the cache IO error code and
+   * description.
+   *
+   * @param description The optional description.
+   *
+   * @return The `ApiError` instance.
+   */
+  static ApiError CacheIO(const char* description = "Cache IO") {
+    return {ErrorCode::CacheIO, description};
   }
 
   /**

--- a/olp-cpp-sdk-core/include/olp/core/generated/parser/JsonParser.h
+++ b/olp-cpp-sdk-core/include/olp/core/generated/parser/JsonParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,10 @@
 
 #pragma once
 
+#include <memory>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include <rapidjson/document.h>
 #include <rapidjson/istreamwrapper.h>
@@ -58,6 +60,17 @@ template <typename T>
 inline T parse(std::stringstream& json_stream) {
   bool res = true;
   return parse<T>(json_stream, res);
+}
+
+template <typename T>
+inline T parse(const std::shared_ptr<std::vector<unsigned char>>& json_bytes) {
+  rapidjson::Document doc;
+  doc.Parse(reinterpret_cast<char*>(json_bytes->data()), json_bytes->size());
+  T result{};
+  if (doc.IsObject() || doc.IsArray()) {
+    from_json(doc, result);
+  }
+  return result;
 }
 
 }  // namespace parser

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -675,8 +675,7 @@ OperationOutcomeEmpty DefaultCacheImpl::PutMutableCache(
                              kExpiryValueSize;
   if (!mutable_cache_lru_ && expected_size > settings_.max_disk_storage) {
     // FIXME: This error is not correct
-    return client::ApiError(client::ErrorCode::CacheIO,
-                            "Cache is full and eviction is disabled");
+    return client::ApiError::CacheIO("Cache is full and eviction is disabled");
   }
 
   uint64_t added_data_size = 0u;
@@ -711,8 +710,7 @@ OperationOutcomeEmpty DefaultCacheImpl::PutMutableCache(
           kLogTag, "Failed to store value in mutable LRU cache, key %s",
           key.c_str());
       // FIXME: This error is not correct
-      return client::ApiError(client::ErrorCode::CacheIO,
-                              "Failed to store in mutable LRU cache");
+      return client::ApiError::CacheIO("Failed to store in mutable LRU cache");
     }
   }
 

--- a/olp-cpp-sdk-dataservice-read/src/generated/serializer/ByteVectorBuffer.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/serializer/ByteVectorBuffer.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+namespace olp {
+namespace serializer {
+
+class ByteVectorBuffer {
+ public:
+  using Ch = char;
+  using Buffer = std::shared_ptr<std::vector<unsigned char>>;
+
+  explicit ByteVectorBuffer(const size_t capacity = kDefaultCapacity)
+      : buffer_(std::make_shared<Buffer::element_type>()) {
+    buffer_->reserve(capacity);
+  }
+
+  void Put(Ch c) { buffer_->emplace_back(c); }
+  void Pop(size_t count) { buffer_->resize(buffer_->size() - count); }
+
+  void Flush() {}
+  void Clear() { buffer_->clear(); }
+  void ShrinkToFit() { buffer_->shrink_to_fit(); }
+
+  void Reserve(size_t count) {
+    if (buffer_->capacity() < count) {
+      buffer_->reserve(buffer_->size() + count);
+    };
+  }
+  Ch* Push(size_t count) {
+    Reserve(count);
+    return reinterpret_cast<Ch*>(buffer_->data());
+  }
+
+  Buffer GetBuffer() { return buffer_; }
+
+ private:
+  // Using the same value as rapidjson
+  static constexpr auto kDefaultCapacity = 256u;
+  Buffer buffer_;
+};
+
+inline void PutReserve(ByteVectorBuffer& stream, size_t count) {
+  stream.Reserve(count);
+}
+
+inline void PutUnsafe(ByteVectorBuffer& stream, ByteVectorBuffer::Ch c) {
+  stream.Put(c);
+}
+}  // namespace serializer
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/generated/serializer/JsonSerializer.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/serializer/JsonSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
+#include "ByteVectorBuffer.h"
+
 namespace olp {
 namespace serializer {
 template <typename T>
@@ -37,6 +39,20 @@ inline std::string serialize(const T& object) {
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
   doc.Accept(writer);
   return buffer.GetString();
+}
+
+template <typename T>
+inline ByteVectorBuffer::Buffer serialize_bytes(const T& object) {
+  rapidjson::Document doc;
+  auto& allocator = doc.GetAllocator();
+
+  doc.SetObject();
+  to_json(object, doc, allocator);
+
+  ByteVectorBuffer buffer;
+  rapidjson::Writer<ByteVectorBuffer> writer(buffer);
+  doc.Accept(writer);
+  return buffer.GetBuffer();
 }
 
 }  // namespace serializer

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
@@ -54,9 +54,10 @@ client::ApiNoResponse DataCacheRepository::Put(const model::Data& data,
       cache::KeyGenerator::CreateDataHandleKey(hrn_, layer_id, data_handle);
   OLP_SDK_LOG_DEBUG_F(kLogTag, "Put -> '%s'", key.c_str());
 
-  if (!cache_->Put(key, data, default_expiry_)) {
+  auto write_result = cache_->Write(key, data, default_expiry_);
+  if (!write_result) {
     OLP_SDK_LOG_ERROR_F(kLogTag, "Failed to write -> '%s'", key.c_str());
-    return {{client::ErrorCode::CacheIO, "Put to cache failed"}};
+    return write_result.GetError();
   }
 
   return {client::ApiNoResult{}};

--- a/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
@@ -639,10 +639,10 @@ TEST_F(DataRepositoryTest, GetBlobDataFailedToCache) {
   settings_->propagate_all_cache_errors = true;
   settings_->cache = cache_mock;
 
-  EXPECT_CALL(*cache_mock, Put(testing::HasSubstr("::api"), _, _, _))
-      .WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(*cache_mock, Put(testing::HasSubstr("::Data"), _, _))
-      .WillRepeatedly(testing::Return(false));
+  EXPECT_CALL(*cache_mock, Write(testing::HasSubstr("::api"), _, _))
+      .WillRepeatedly(testing::Return(olp::client::ApiNoResult{}));
+  EXPECT_CALL(*cache_mock, Write(testing::HasSubstr("::Data"), _, _))
+      .WillRepeatedly(testing::Return(olp::client::ApiError::CacheIO()));
 
   EXPECT_CALL(*cache_mock, Get(_, _))
       .WillRepeatedly(testing::Return(boost::any()));
@@ -682,12 +682,12 @@ TEST_F(DataRepositoryTest, GetVersionedDataTileFailedToCache) {
   settings_->propagate_all_cache_errors = true;
   settings_->cache = cache_mock;
 
-  EXPECT_CALL(*cache_mock, Put(testing::HasSubstr("::api"), _, _, _))
-      .WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(*cache_mock, Put(testing::HasSubstr("::quadtree"), _, _))
-      .WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(*cache_mock, Put(testing::HasSubstr("::Data"), _, _))
-      .WillRepeatedly(testing::Return(false));
+  EXPECT_CALL(*cache_mock, Write(testing::HasSubstr("::api"), _, _))
+      .WillRepeatedly(testing::Return(olp::client::ApiNoResult{}));
+  EXPECT_CALL(*cache_mock, Write(testing::HasSubstr("::quadtree"), _, _))
+      .WillRepeatedly(testing::Return(olp::client::ApiNoResult{}));
+  EXPECT_CALL(*cache_mock, Write(testing::HasSubstr("::Data"), _, _))
+      .WillRepeatedly(testing::Return(olp::client::ApiError::CacheIO()));
 
   EXPECT_CALL(*cache_mock, Get(_, _))
       .WillRepeatedly(testing::Return(boost::any()));

--- a/tests/common/KeyValueCacheTestable.h
+++ b/tests/common/KeyValueCacheTestable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 HERE Europe B.V.
+ * Copyright (C) 2021-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,6 +70,26 @@ class KeyValueCacheTestable : public olp::cache::KeyValueCache {
     return base_cache_->IsProtected(key);
   }
 
+  olp::cache::OperationOutcome<KeyValueCache::ValueTypePtr> Read(
+      const std::string& key) override {
+    return base_cache_->Read(key);
+  }
+
+  olp::cache::OperationOutcomeEmpty Write(
+      const std::string& key, const KeyValueCache::ValueTypePtr& value,
+      time_t expiry) override {
+    return base_cache_->Write(key, value, expiry);
+  }
+
+  olp::cache::OperationOutcomeEmpty Delete(const std::string& key) override {
+    return base_cache_->Delete(key);
+  }
+
+  olp::cache::OperationOutcomeEmpty DeleteByPrefix(
+      const std::string& prefix) override {
+    return base_cache_->DeleteByPrefix(prefix);
+  }
+
  protected:
   std::shared_ptr<olp::cache::KeyValueCache> base_cache_;
 };
@@ -84,5 +104,11 @@ struct CacheWithPutErrors : public KeyValueCacheTestable {
 
   bool Put(const std::string&, const ValueTypePtr, time_t) override {
     return false;
+  }
+
+  olp::cache::OperationOutcomeEmpty Write(const std::string&,
+                                          const KeyValueCache::ValueTypePtr&,
+                                          time_t) override {
+    return olp::client::ApiError::CacheIO();
   }
 };

--- a/tests/common/mocks/CacheMock.h
+++ b/tests/common/mocks/CacheMock.h
@@ -24,6 +24,10 @@
 
 class CacheMock : public olp::cache::KeyValueCache {
  public:
+  template <typename Result>
+  using OperationOutcome = olp::cache::OperationOutcome<Result>;
+  using OperationOutcomeEmpty = olp::cache::OperationOutcomeEmpty;
+
   CacheMock();
 
   ~CacheMock() override;
@@ -56,4 +60,17 @@ class CacheMock : public olp::cache::KeyValueCache {
   MOCK_METHOD(bool, Release, (const KeyListType&), (override));
 
   MOCK_METHOD(void, Promote, (const std::string&), (override));
+
+  MOCK_METHOD(OperationOutcome<std::shared_ptr<std::vector<unsigned char>>>,
+              Read, (const std::string&), (override));
+
+  MOCK_METHOD(OperationOutcomeEmpty, Write,
+              (const std::string&,
+               const std::shared_ptr<std::vector<unsigned char>>&, time_t),
+              (override));
+
+  MOCK_METHOD(OperationOutcomeEmpty, Delete, (const std::string&), (override));
+
+  MOCK_METHOD(OperationOutcomeEmpty, DeleteByPrefix, (const std::string&),
+              (override));
 };

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -3389,16 +3389,15 @@ TEST_F(DataserviceReadVersionedLayerClientTest, CheckLookupApiCacheExpiration) {
       .Times(1)
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*cache, Get("hrn:here:data::olp-here-test:hereos-internal-test-"
-                          "v2::testlayer::269::4::partition",
-                          _))
+  EXPECT_CALL(*cache, Read("hrn:here:data::olp-here-test:hereos-internal-test-"
+                           "v2::testlayer::269::4::partition"))
       .Times(1)
-      .WillOnce(Return(boost::any()));
-  EXPECT_CALL(*cache, Put("hrn:here:data::olp-here-test:hereos-internal-test-"
-                          "v2::testlayer::269::4::partition",
-                          _, _, _))
+      .WillOnce(Return(client::ApiError::NotFound()));
+  EXPECT_CALL(*cache, Write("hrn:here:data::olp-here-test:hereos-internal-test-"
+                            "v2::testlayer::269::4::partition",
+                            _, _))
       .Times(1)
-      .WillOnce(Return(true));
+      .WillOnce(Return(client::ApiNoResult{}));
 
   EXPECT_CALL(*cache,
               Get("hrn:here:data::olp-here-test:hereos-internal-test-v2:"
@@ -3407,11 +3406,11 @@ TEST_F(DataserviceReadVersionedLayerClientTest, CheckLookupApiCacheExpiration) {
       .WillOnce(Return(nullptr));
 
   EXPECT_CALL(*cache,
-              Put("hrn:here:data::olp-here-test:hereos-internal-test-v2:"
-                  ":testlayer::4eed6ed1-0d32-43b9-ae79-043cb4256432::Data",
-                  _, _))
+              Write("hrn:here:data::olp-here-test:hereos-internal-test-v2:"
+                    ":testlayer::4eed6ed1-0d32-43b9-ae79-043cb4256432::Data",
+                    _, _))
       .Times(1)
-      .WillOnce(Return(true));
+      .WillOnce(Return(client::ApiNoResult{}));
 
   auto request = read::DataRequest()
                      .WithPartitionId(kTestPartition)


### PR DESCRIPTION
This is necessary to move forward with advanced cache error handling.

This commit also includes new way of serializing to bytes vector.

Relates-To: OCMAM-61