### PR TITLE
Ignore `NotFound` error for partitions removal

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
@@ -278,7 +278,8 @@ bool PartitionsCacheRepository::ClearPartitionMetadata(
 
   auto read_response = cache_->Read(key);
   if (!read_response) {
-    return false;
+    return read_response.GetError().GetErrorCode() ==
+           client::ErrorCode::NotFound;
   }
 
   out_partition = parser::parse<model::Partition>(read_response.GetResult());

--- a/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientImplTest.cpp
@@ -148,7 +148,7 @@ TEST(VersionedLayerClientTest, RemoveFromCachePartition) {
     EXPECT_CALL(*cache_mock, Read(_)).WillOnce([](const std::string&) {
       return olp::client::ApiError::NotFound();
     });
-    ASSERT_FALSE(client.RemoveFromCache(kPartitionId));
+    ASSERT_TRUE(client.RemoveFromCache(kPartitionId));
   }
   {
     SCOPED_TRACE("Partition cache failure");

--- a/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VolatileLayerClientImplTest.cpp
@@ -404,7 +404,7 @@ TEST(VolatileLayerClientImplTest, RemoveFromCachePartition) {
     EXPECT_CALL(*cache_mock, Read(_)).WillOnce([](const std::string&) {
       return olp::client::ApiError::NotFound();
     });
-    ASSERT_FALSE(client.RemoveFromCache(kPartitionId));
+    ASSERT_TRUE(client.RemoveFromCache(kPartitionId));
   }
   {
     SCOPED_TRACE("Partition cache failure");
@@ -465,7 +465,7 @@ TEST(VolatileLayerClientImplTest, RemoveFromCacheTileKey) {
     EXPECT_CALL(*cache_mock, Read(_)).WillOnce([](const std::string&) {
       return olp::client::ApiError::NotFound();
     });
-    ASSERT_FALSE(client.RemoveFromCache(tile_key));
+    ASSERT_TRUE(client.RemoveFromCache(tile_key));
   }
   {
     SCOPED_TRACE("Partition cache failure");


### PR DESCRIPTION
This is an old behavior that was changed in the previous commit. Returning it as it breaks API expectations.

Relates-To: OCMAM-61