### PR TITLE
Remove MacOS 11 jobs

### DIFF
--- a/.github/workflows/psv_pipelines.yml
+++ b/.github/workflows/psv_pipelines.yml
@@ -176,16 +176,6 @@ jobs:
       run: scripts/android/build.sh
       shell: bash
 
-  psv-macos-11-xcode-13-build:
-    name: PSV.MacOS11.Xcode13
-    runs-on: macOS-11
-    steps:
-    - name: Check out repository
-      uses: actions/checkout@v4
-    - name: MacOS Build
-      run: scripts/macos/psv/azure_macos_build_psv.sh
-      shell: bash
-
   psv-macos-12-xcode-14-build:
     name: PSV.MacOS12.Xcode14
     runs-on: macOS-12
@@ -195,18 +185,6 @@ jobs:
     - name: MacOS Build
       run: scripts/macos/psv/azure_macos_build_psv.sh
       shell: bash
-
-  psv-ios-xcode-11-build:
-    name: PSV.iOS.MacOS11.Xcode11.7
-    runs-on: macOS-11
-    steps:
-    - name: Check out repository
-      uses: actions/checkout@v4
-    - name: iOS Xcode 11-7 Build
-      run: scripts/ios/azure_ios_build_psv.sh
-      shell: bash
-      env:
-        USE_LATEST_XCODE: 0
 
   psv-ios-xcode-14-2-build:
     name: PSV.iOS.MacOS12.Xcode14.2


### PR DESCRIPTION
Runners are deprecated and removed at this point.

Relates-To: DATASDK-17