### PR TITLE
Adapt Datetime parser to DST timezones

### DIFF
--- a/olp-cpp-sdk-authentication/tests/AuthenticationClientTest.cpp
+++ b/olp-cpp-sdk-authentication/tests/AuthenticationClientTest.cpp
@@ -29,6 +29,8 @@
 
 namespace {
 constexpr auto kTime = "Fri, 29 May 2020 11:07:45 GMT";
+constexpr auto kEpochTime = "Thu, 1 Jan 1970 00:00:00 GMT";
+constexpr auto kSummerTime = "Tue, 18 Jun 2024 12:25:35 GMT";
 }  // namespace
 
 namespace auth = olp::authentication;
@@ -236,6 +238,16 @@ TEST(AuthenticationClientTest, TimeParsing) {
   {
     SCOPED_TRACE("Parse time");
     EXPECT_EQ(auth::ParseTime(kTime), 1590750465);
+  }
+
+  {
+    SCOPED_TRACE("Parse epoch time");
+    EXPECT_EQ(auth::ParseTime(kEpochTime), 0);
+  }
+
+  {
+    SCOPED_TRACE("Parse summer time");
+    EXPECT_EQ(auth::ParseTime(kSummerTime), 1718713535);
   }
 }
 


### PR DESCRIPTION
When iOS device locale is set to location
which uses different timezeons depending on
daylight saving time (eg PST and PDT for
Los Angeles), then different `gmtoff` applied
by `strptime` for 'summer' and 'winter'
timestamps.

This results in the wrong translation of
datetime string into epoch.

Adapt code to iOS/MacOS behaviour, where
`timegm` updates an input parameter and
erases `gmtoff` value:
- remove logic to infer the offset using epoch datetime;
- store `gmtoff` value before calling `timegm`;
- offset result returned from `timegm` by saved `gmtoff`.

Relates-To: HERESDK-2568