### PR TITLE
Add Xcode13 job

### DIFF
--- a/.github/workflows/psv_pipelines.yml
+++ b/.github/workflows/psv_pipelines.yml
@@ -186,15 +186,27 @@ jobs:
       run: scripts/macos/psv/azure_macos_build_psv.sh
       shell: bash
 
-  psv-ios-xcode-14-2-build:
-    name: PSV.iOS.MacOS12.Xcode14.2
+  psv-ios-xcode-14-build:
+    name: PSV.iOS.MacOS12.Xcode14
     runs-on: macOS-12
     steps:
     - name: Check out repository
       uses: actions/checkout@v4
-    - name: iOS Xcode 14-2 Build
+    - name: iOS Xcode 14 Build
       run: scripts/ios/azure_ios_build_psv.sh
       shell: bash
+
+  psv-ios-xcode-13-build:
+    name: PSV.iOS.MacOS12.Xcode13
+    runs-on: macOS-12
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: iOS Xcode 13 Build
+        run: scripts/ios/azure_ios_build_psv.sh
+        shell: bash
+        env:
+          USE_LATEST_XCODE: 0
 
   psv-ios-os13-xcode-15-build:
     name: PSV.iOS.MacOS13.Xcode15

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,6 @@ image: ${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${DOCKER_IMAGE_VERSION}
 include:
   - template: Security/SAST.gitlab-ci.yml
   - template: Security/Secret-Detection.gitlab-ci.yml
-  - template: Security/License-Scanning.gitlab-ci.yml
   - template: Security/Dependency-Scanning.gitlab-ci.yml
 
 variables:

--- a/scripts/ios/azure_ios_build_psv.sh
+++ b/scripts/ios/azure_ios_build_psv.sh
@@ -26,7 +26,7 @@ if [[ ${USE_LATEST_XCODE} == 0 ]]; then
   # Due to some bug which is cmake cannot detect compiler while called
   # from cmake itself when project is compiled with XCode 12.4 we must
   # switch to old XCode as a workaround.
-  sudo xcode-select -s /Applications/Xcode_11.7.app
+  sudo xcode-select -s /Applications/Xcode_13.1.app
 fi
 
 mkdir -p build && cd build


### PR DESCRIPTION
After PR#1523 we are using only Xcode14 and 15 for builds
as they are default on macos-12, macos-13, macos-14.
However, macos-12 still contains Xcode13.1 which could be used.

Relates-To: MINOR-UPDATES-CI

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>