### PR TITLE
Use USERPROFILE env variable to get home path on Windows

### DIFF
--- a/olp-cpp-sdk-authentication/src/AuthenticationCredentials.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationCredentials.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,10 @@ const std::string kHereTokenEndpointUrl = "here.token.endpoint.url";
 std::string GetDefaultPath() {
   const char* env;
 #ifdef _WIN32
+  if ((env = std::getenv("USERPROFILE")) != nullptr) {
+    return std::string(env).append("\\.here\\credentials.properties");
+  }
+
   if ((env = std::getenv("HOMEDRIVE")) != nullptr) {
     std::string path{env};
 


### PR DESCRIPTION
Some Windows distributions have no HOMEDRIVE or/and HOMEPATH vars set by default. They have USERPROFILE variable instead.

Relates-To: OCMAM-115