### PR TITLE
Supports Android-like build on desktop

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/context/Context.h
+++ b/olp-cpp-sdk-core/include/olp/core/context/Context.h
@@ -26,7 +26,7 @@
 
 #include <olp/core/CoreApi.h>
 
-#ifdef ANDROID
+#if defined(ANDROID) || defined(ANDROID_HOST)
 #include <jni.h>
 #endif
 
@@ -98,7 +98,7 @@ class CORE_API Context {
      */
     Scope();
 
-#ifdef ANDROID
+#if defined(ANDROID) || defined(ANDROID_HOST)
     /**
      * @brief Creates the `Scope` instance.
      *
@@ -147,13 +147,13 @@ class CORE_API Context {
   /// deinitialize the Context
   static void deinit();
 
-#ifdef ANDROID
+#if defined(ANDROID) || defined(ANDROID_HOST)
   /// initialize the Context
   static void init(JavaVM* vm, jobject application);
 #endif
 
  public:
-#ifdef ANDROID
+#if defined(ANDROID) || defined(ANDROID_HOST)
   /**
    * @brief Gets the `JavaVM` object.
    *

--- a/olp-cpp-sdk-core/src/context/ContextInternal.h
+++ b/olp-cpp-sdk-core/src/context/ContextInternal.h
@@ -29,9 +29,11 @@
 #include <string>
 #endif
 
-#ifdef ANDROID
+#if defined(ANDROID) || defined(ANDROID_HOST)
 #include <jni.h>
-#elif defined(__APPLE__)
+#endif
+
+#if defined(__APPLE__)
 #include <olp/core/context/EnterBackgroundSubscriber.h>
 #endif
 
@@ -45,7 +47,7 @@ struct ContextData {
 
   std::mutex context_mutex;
   size_t context_instance_counter = 0;
-#ifdef ANDROID
+#if defined(ANDROID) || defined(ANDROID_HOST)
   JavaVM* java_vm = nullptr;
   jobject context = nullptr;
 #elif defined(__APPLE__)

--- a/olp-cpp-sdk-core/src/http/android/NetworkAndroid.h
+++ b/olp-cpp-sdk-core/src/http/android/NetworkAndroid.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__) || defined(ANDROID_HOST)
 
 #include <condition_variable>
 #include <future>

--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
@@ -54,7 +54,7 @@ namespace {
 
 const char* kLogTag = "CURL";
 
-#ifdef OLP_SDK_ENABLE_ANDROID_CURL
+#if defined(OLP_SDK_ENABLE_ANDROID_CURL) && !defined(ANDROID_HOST)
 const auto kCurlAndroidCaBundleFolder = "/system/etc/security/cacerts";
 
 #ifdef OLP_SDK_USE_MD5_CERT_LOOKUP
@@ -251,7 +251,7 @@ void GetTrafficData(CURL* handle, uint64_t& upload_bytes,
 CURLcode SetCaBundlePaths(CURL* handle) {
   OLP_SDK_CORE_UNUSED(handle);
 
-#ifdef OLP_SDK_ENABLE_ANDROID_CURL
+#if defined(OLP_SDK_ENABLE_ANDROID_CURL) && !defined(ANDROID_HOST)
   // FIXME: We could disable this lookup as it won't work on most devices
   //  (probably all of them) since OpenSSL still will be trying to find
   //  certificate with SHA1 lookup
@@ -331,7 +331,7 @@ NetworkCurl::NetworkCurl(NetworkInitializationSettings settings)
 #endif
 
   std::string ca_bundle_path;
-#ifdef OLP_SDK_ENABLE_ANDROID_CURL
+#if defined(OLP_SDK_ENABLE_ANDROID_CURL) && !defined(ANDROID_HOST)
   ca_bundle_path = kCurlAndroidCaBundleFolder;
 #elif OLP_SDK_NETWORK_HAS_OPENSSL
   ca_bundle_path = CaBundlePath();

--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
@@ -33,7 +33,7 @@
 
 #include <boost/optional.hpp>
 
-#ifdef OLP_SDK_ENABLE_ANDROID_CURL
+#if defined(OLP_SDK_ENABLE_ANDROID_CURL) && !defined(ANDROID_HOST)
 #ifdef OLP_SDK_NETWORK_HAS_OPENSSL
 #include <openssl/ossl_typ.h>
 


### PR DESCRIPTION
Such environment is set up when one wants to run unit tests in Android Studio. Unit tests are run on host (not in emulator), but JNI and even many Android's core API like Context are still provided by Robolectric. On the other hand typical Android C++ headers like <android/log.h> are not accessible.

This patch adds checks for macro ANDROID_HOST which is defined on such enviroment.

Relates-To: HERESDK-1085