### PR TITLE
Add thread name for olp threads

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -142,6 +142,7 @@ set(OLP_SDK_UTILS_HEADERS
     ./include/olp/core/utils/Credentials.h
     ./include/olp/core/utils/Dir.h
     ./include/olp/core/utils/LruCache.h
+    ./include/olp/core/utils/Thread.h
     ./include/olp/core/utils/Url.h
     ./include/olp/core/utils/WarningWorkarounds.h
 )
@@ -351,6 +352,7 @@ set(OLP_SDK_UTILS_SOURCES
     ./src/utils/BoostExceptionHandle.cpp
     ./src/utils/Credentials.cpp
     ./src/utils/Dir.cpp
+    ./src/utils/Thread.cpp
     ./src/utils/Url.cpp
 )
 

--- a/olp-cpp-sdk-core/include/olp/core/utils/Thread.h
+++ b/olp-cpp-sdk-core/include/olp/core/utils/Thread.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+#include <string>
+#include <olp/core/CoreApi.h>
+
+namespace olp {
+namespace utils {
+
+/** @brief Manages threads.
+ */
+class CORE_API Thread {
+ public:
+
+  /**
+   * @brief Set the name of current thread.
+   *
+   * @param name The new name of thread.
+   *
+   */
+   static void SetCurrentThreadName(const std::string& name);
+};
+
+}  // namespace utils
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/cache/DiskCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.cpp
@@ -36,11 +36,13 @@
 #include "olp/core/logging/Log.h"
 #include "olp/core/porting/make_unique.h"
 #include "olp/core/utils/Dir.h"
+#include "olp/core/utils/Thread.h"
 
 namespace olp {
 namespace cache {
 
 namespace {
+constexpr auto THREAD_NAME_COMPACT_DB = "CompactDB";
 constexpr auto kLogTag = "DiskCache";
 constexpr auto kLevelDbLostFolder = "lost";
 constexpr auto kMaxL0Files = 4;
@@ -433,6 +435,7 @@ DiskCache::OperationOutcome<> DiskCache::ApplyBatch(
 
       compaction_thread_ = std::thread([this]() {
         OLP_SDK_LOG_INFO(kLogTag, "Compacting database started");
+        olp::utils::Thread::SetCurrentThreadName(THREAD_NAME_COMPACT_DB);
         database_->CompactRange(nullptr, nullptr);
         compacting_ = false;
         OLP_SDK_LOG_INFO(kLogTag, "Compacting database finished");

--- a/olp-cpp-sdk-core/src/thread/ThreadPoolTaskScheduler.cpp
+++ b/olp-cpp-sdk-core/src/thread/ThreadPoolTaskScheduler.cpp
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  * License-Filename: LICENSE
  */
-
+#include "olp/core/utils/Thread.h"
 #include "olp/core/thread/ThreadPoolTaskScheduler.h"
 
 #if defined(PORTING_PLATFORM_QNX)
@@ -35,7 +35,6 @@
 #include "olp/core/logging/LogContext.h"
 #include "olp/core/porting/platform.h"
 #include "olp/core/thread/SyncQueue.h"
-#include "olp/core/utils/WarningWorkarounds.h"
 #include "thread/PriorityQueueExtended.h"
 
 namespace olp {
@@ -43,24 +42,6 @@ namespace thread {
 
 namespace {
 constexpr auto kLogTag = "ThreadPoolTaskScheduler";
-
-void SetCurrentThreadName(const std::string& thread_name) {
-  // Currently only supported for pthread users
-  OLP_SDK_CORE_UNUSED(thread_name);
-
-#if defined(PORTING_PLATFORM_MAC)
-  // Note that in Mac based systems the pthread_setname_np takes 1 argument
-  // only.
-  pthread_setname_np(thread_name.c_str());
-#elif defined(OLP_SDK_HAVE_PTHREAD_SETNAME_NP)  // Linux, Android, QNX
-  // QNX allows 100 but Linux only 16 so select min value and apply for both.
-  // If maximum length is exceeded on some systems, e.g. Linux, the name is not
-  // set at all. So better truncate it to have at least the minimum set.
-  constexpr size_t kMaxThreadNameLength = 16u;
-  std::string truncated_name = thread_name.substr(0, kMaxThreadNameLength - 1);
-  pthread_setname_np(pthread_self(), truncated_name.c_str());
-#endif  // OLP_SDK_HAVE_PTHREAD_SETNAME_NP
-}
 
 struct PrioritizedTask {
   TaskScheduler::CallFuncType function;
@@ -76,7 +57,7 @@ struct ComparePrioritizedTask {
 
 void SetExecutorName(size_t idx) {
   std::string thread_name = "OLPSDKPOOL_" + std::to_string(idx);
-  SetCurrentThreadName(thread_name);
+  olp::utils::Thread::SetCurrentThreadName(thread_name);
   OLP_SDK_LOG_INFO_F(kLogTag, "Starting thread '%s'", thread_name.c_str());
 }
 
@@ -97,7 +78,7 @@ class ThreadPoolTaskScheduler::QueueImpl {
 };
 
 ThreadPoolTaskScheduler::ThreadPoolTaskScheduler(size_t thread_count)
-    : queue_{std::make_unique<QueueImpl>()} {
+    :queue_{std::make_unique<QueueImpl>()} {
   thread_pool_.reserve(thread_count);
 
   for (size_t idx = 0; idx < thread_count; ++idx) {

--- a/olp-cpp-sdk-core/src/utils/Thread.cpp
+++ b/olp-cpp-sdk-core/src/utils/Thread.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "olp/core/utils/WarningWorkarounds.h"
+#include "olp/core/utils/Thread.h"
+#include "olp/core/porting/platform.h"
+#if defined(PORTING_PLATFORM_MAC)
+#include <pthread.h>
+#elif defined(PORTING_PLATFORM_ANDROID) || defined(PORTING_PLATFORM_LINUX) || defined(PORTING_PLATFORM_QNX)
+#include <pthread.h>
+#endif
+
+#include <cstring>
+namespace olp {
+namespace utils {
+
+void Thread::SetCurrentThreadName(const std::string& thread_name) {
+  // Currently only supported for pthread users
+  OLP_SDK_CORE_UNUSED(thread_name);
+
+#if defined(PORTING_PLATFORM_MAC)
+  // Note that in Mac based systems the pthread_setname_np takes 1 argument
+  // only.
+  pthread_setname_np(thread_name.c_str());
+#elif defined(PORTING_PLATFORM_ANDROID) || defined(PORTING_PLATFORM_LINUX) || defined(PORTING_PLATFORM_QNX)
+  // QNX allows 100 but Linux only 16 so select min value and apply for both.
+  // If maximum length is exceeded on some systems, e.g. Linux, the name is not
+  // set at all. So better truncate it to have at least the minimum set.
+  constexpr size_t kMaxThreadNameLength = 16u;
+  std::string truncated_name = thread_name.substr(0, kMaxThreadNameLength - 1);
+  pthread_setname_np(pthread_self(), truncated_name.c_str());
+#endif
+}
+
+}  // namespace utils
+}  // namespace olp


### PR DESCRIPTION
1. for some reason, olp doesn't get the sdk macro properly, so the olp pool threads don't show proper thread name on android.  In this commit platform macro is used instead of sdk macro.
2. thread name is also added to disk cache thread for compacting db.