### PR TITLE
Add missing thread names

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -142,6 +142,7 @@ set(OLP_SDK_UTILS_HEADERS
     ./include/olp/core/utils/Credentials.h
     ./include/olp/core/utils/Dir.h
     ./include/olp/core/utils/LruCache.h
+    ./include/olp/core/utils/Thread.h
     ./include/olp/core/utils/Url.h
     ./include/olp/core/utils/WarningWorkarounds.h
 )
@@ -351,6 +352,7 @@ set(OLP_SDK_UTILS_SOURCES
     ./src/utils/BoostExceptionHandle.cpp
     ./src/utils/Credentials.cpp
     ./src/utils/Dir.cpp
+    ./src/utils/Thread.cpp
     ./src/utils/Url.cpp
 )
 

--- a/olp-cpp-sdk-core/include/olp/core/utils/Thread.h
+++ b/olp-cpp-sdk-core/include/olp/core/utils/Thread.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+#include <olp/core/CoreApi.h>
+#include <string>
+
+namespace olp {
+namespace utils {
+
+/** @brief Manages threads.
+ */
+class CORE_API Thread {
+ public:
+  /**
+   * @brief Set the name of current thread.
+   *
+   * @param name The new name of thread.
+   *
+   */
+  static void SetCurrentThreadName(const std::string& name);
+};
+
+}  // namespace utils
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/cache/DiskCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.cpp
@@ -36,11 +36,13 @@
 #include "olp/core/logging/Log.h"
 #include "olp/core/porting/make_unique.h"
 #include "olp/core/utils/Dir.h"
+#include "olp/core/utils/Thread.h"
 
 namespace olp {
 namespace cache {
 
 namespace {
+constexpr auto kThreadNameCompactDb = "CompactDB";
 constexpr auto kLogTag = "DiskCache";
 constexpr auto kLevelDbLostFolder = "lost";
 constexpr auto kMaxL0Files = 4;
@@ -432,6 +434,7 @@ DiskCache::OperationOutcome<> DiskCache::ApplyBatch(
       }
 
       compaction_thread_ = std::thread([this]() {
+        olp::utils::Thread::SetCurrentThreadName(kThreadNameCompactDb);
         OLP_SDK_LOG_INFO(kLogTag, "Compacting database started");
         database_->CompactRange(nullptr, nullptr);
         compacting_ = false;

--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
@@ -27,6 +27,7 @@
 #include <cstring>
 #include <memory>
 #include <utility>
+#include "olp/core/utils/Thread.h"
 
 #if defined(HAVE_SIGNAL_H)
 #include <signal.h>
@@ -53,6 +54,7 @@ namespace http {
 namespace {
 
 const char* kLogTag = "CURL";
+const char* kCurlThreadName = "OLPSDKCURL";
 
 #if defined(OLP_SDK_ENABLE_ANDROID_CURL) && !defined(ANDROID_HOST)
 const auto kCurlAndroidCaBundleFolder = "/system/etc/security/cacerts";
@@ -1095,6 +1097,8 @@ int NetworkCurl::GetHandleIndex(CURL* handle) {
 }
 
 void NetworkCurl::Run() {
+  olp::utils::Thread::SetCurrentThreadName(kCurlThreadName);
+
   {
     std::lock_guard<std::mutex> lock(event_mutex_);
     state_ = WorkerState::STARTED;

--- a/olp-cpp-sdk-core/src/utils/Thread.cpp
+++ b/olp-cpp-sdk-core/src/utils/Thread.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "olp/core/utils/Thread.h"
+#include "olp/core/porting/platform.h"
+#include "olp/core/utils/WarningWorkarounds.h"
+#if defined(PORTING_PLATFORM_MAC)
+#include <pthread.h>
+#elif defined(PORTING_PLATFORM_ANDROID) || defined(PORTING_PLATFORM_LINUX) || \
+    defined(PORTING_PLATFORM_QNX)
+#include <pthread.h>
+#endif
+
+#include <cstring>
+namespace olp {
+namespace utils {
+
+void Thread::SetCurrentThreadName(const std::string& thread_name) {
+  // Currently only supported for pthread users
+  OLP_SDK_CORE_UNUSED(thread_name);
+
+#if defined(PORTING_PLATFORM_MAC)
+  // Note that in Mac based systems the pthread_setname_np takes 1 argument
+  // only.
+  pthread_setname_np(thread_name.c_str());
+#elif defined(PORTING_PLATFORM_ANDROID) || defined(PORTING_PLATFORM_LINUX) || \
+    defined(PORTING_PLATFORM_QNX)
+  // QNX allows 100 but Linux only 16 so select min value and apply for both.
+  // If maximum length is exceeded on some systems, e.g. Linux, the name is not
+  // set at all. So better truncate it to have at least the minimum set.
+  constexpr size_t kMaxThreadNameLength = 16u;
+  std::string truncated_name = thread_name.substr(0, kMaxThreadNameLength - 1);
+  pthread_setname_np(pthread_self(), truncated_name.c_str());
+#endif
+}
+
+}  // namespace utils
+}  // namespace olp


### PR DESCRIPTION
Extract Thread helper into separate
file, and use it to name spawned
threads.

Relates-To: HERESDK-3466