### PR TITLE
Change the VersionedLayerClient code

### DIFF
--- a/external/boost/CMakeLists.txt.boost.in
+++ b/external/boost/CMakeLists.txt.boost.in
@@ -60,7 +60,7 @@ ExternalProject_Add(boost-download
     BUILD_IN_SOURCE     1
     UPDATE_COMMAND      ""
     CONFIGURE_COMMAND   @BOOTSTRAP_CMD@
-    BUILD_COMMAND       @B2_CMD@ headers
+    BUILD_COMMAND       "@B2_CMD@" headers
     INSTALL_COMMAND     ""
     TEST_COMMAND        ""
 )

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,9 +94,9 @@ QueryApi::PartitionsExtendedResponse QueryApi::GetPartitionsbyId(
                       layer_id.c_str(), http_response.status);
 
   if (http_response.status != olp::http::HttpStatusCode::OK) {
-    return PartitionsExtendedResponse(
+    return {
         client::ApiError(http_response.status, http_response.response.str()),
-        http_response.GetNetworkStatistics());
+        http_response.GetNetworkStatistics()};
   }
   using PartitionsResponse =
       client::ApiResponse<model::Partitions, client::ApiError>;
@@ -104,28 +104,28 @@ QueryApi::PartitionsExtendedResponse QueryApi::GetPartitionsbyId(
   auto partitions_response =
       parser::parse_result<PartitionsResponse>(http_response.response);
 
-  if (!partitions_response.IsSuccessful()) {
-    return PartitionsExtendedResponse(partitions_response.GetError(),
-                                      http_response.GetNetworkStatistics());
+  if (!partitions_response) {
+    return {partitions_response.GetError(),
+            http_response.GetNetworkStatistics()};
   }
 
-  return PartitionsExtendedResponse(partitions_response.MoveResult(),
-                                    http_response.GetNetworkStatistics());
+  return {partitions_response.MoveResult(),
+          http_response.GetNetworkStatistics()};
 }
 
 olp::client::HttpResponse QueryApi::QuadTreeIndex(
     const client::OlpClient& client, const std::string& layer_id,
     const std::string& quad_key, boost::optional<int64_t> version,
-    int32_t depth, boost::optional<std::vector<std::string>> additional_fields,
+    int32_t depth, const std::vector<std::string>& additional_fields,
     boost::optional<std::string> billing_tag,
     client::CancellationContext context) {
   std::multimap<std::string, std::string> header_params;
   header_params.emplace("Accept", "application/json");
 
   std::multimap<std::string, std::string> query_params;
-  if (additional_fields) {
+  if (!additional_fields.empty()) {
     query_params.emplace("additionalFields",
-                         ConcatStringArray(*additional_fields, ","));
+                         ConcatStringArray(additional_fields, ","));
   }
   if (billing_tag) {
     query_params.emplace("billingTag", *billing_tag);

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,8 +112,7 @@ class QueryApi {
   static olp::client::HttpResponse QuadTreeIndex(
       const client::OlpClient& client, const std::string& layer_id,
       const std::string& quad_key, boost::optional<int64_t> version,
-      int32_t depth,
-      boost::optional<std::vector<std::string>> additional_fields,
+      int32_t depth, const std::vector<std::string>& additional_fields,
       boost::optional<std::string> billing_tag,
       client::CancellationContext context);
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -56,7 +56,7 @@ DataResponse DataRepository::GetVersionedTile(
     client::CancellationContext context) {
   PartitionsRepository repository(catalog_, layer_id, settings_, lookup_client_,
                                   storage_);
-  auto response = repository.GetTile(request, version, context);
+  auto response = repository.GetTile(request, version, context, {});
 
   auto network_statistics = response.GetPayload();
 
@@ -66,7 +66,7 @@ DataResponse DataRepository::GetVersionedTile(
         "GetVersionedDataTile partition request failed, hrn='%s', key='%s'",
         catalog_.ToCatalogHRNString().c_str(),
         request.CreateKey(layer_id).c_str());
-    return DataResponse(response.GetError(), network_statistics);
+    return {response.GetError(), network_statistics};
   }
 
   // Get the data using a data handle for requested tile
@@ -79,9 +79,9 @@ DataResponse DataRepository::GetVersionedTile(
   network_statistics += data_response.GetPayload();
 
   if (data_response) {
-    return DataResponse(data_response.MoveResult(), network_statistics);
+    return {data_response.MoveResult(), network_statistics};
   } else {
-    return DataResponse(data_response.GetError(), network_statistics);
+    return {data_response.GetError(), network_statistics};
   }
 }
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,12 +56,12 @@ class PartitionsRepository {
  public:
   PartitionsRepository(client::HRN catalog, std::string layer,
                        client::OlpClientSettings settings,
-                       client::ApiLookupClient client,
+                       const client::ApiLookupClient& client,
                        NamedMutexStorage storage = NamedMutexStorage());
 
   PartitionsResponse GetVolatilePartitions(
       const read::PartitionsRequest& request,
-      client::CancellationContext context);
+      const client::CancellationContext& context);
 
   QueryApi::PartitionsExtendedResponse GetVersionedPartitionsExtendedResponse(
       const read::PartitionsRequest& request, std::int64_t version,
@@ -74,33 +74,31 @@ class PartitionsRepository {
   static model::Partition PartitionFromSubQuad(const model::SubQuad& sub_quad,
                                                const std::string& partition);
 
-  PartitionResponse GetAggregatedTile(TileRequest request,
-                                      boost::optional<int64_t> version,
-                                      client::CancellationContext context);
+  PartitionResponse GetAggregatedTile(
+      TileRequest request, boost::optional<int64_t> version,
+      const client::CancellationContext& context);
 
   PartitionResponse GetTile(const TileRequest& request,
                             boost::optional<int64_t> version,
                             client::CancellationContext context,
-                            boost::optional<std::vector<std::string>>
-                                additional_fields = boost::none);
+                            const std::vector<std::string>& required_fields);
 
   client::ApiNoResponse ParsePartitionsStream(
-      std::shared_ptr<AsyncJsonStream> async_stream,
-      PartitionsStreamCallback partition_callback,
+      const std::shared_ptr<AsyncJsonStream>& async_stream,
+      const PartitionsStreamCallback& partition_callback,
       client::CancellationContext context);
 
-  void StreamPartitions(std::shared_ptr<AsyncJsonStream> async_stream,
+  void StreamPartitions(const std::shared_ptr<AsyncJsonStream>& async_stream,
                         std::int64_t version,
                         const std::vector<std::string>& additional_fields,
                         boost::optional<std::string> billing_tag,
-                        client::CancellationContext context);
+                        const client::CancellationContext& context);
 
  private:
   QuadTreeIndexResponse GetQuadTreeIndexForTile(
       const TileRequest& request, boost::optional<int64_t> version,
       client::CancellationContext context,
-      boost::optional<std::vector<std::string>> additional_fields =
-          boost::none);
+      const std::vector<std::string>& required_fields);
 
   QueryApi::PartitionsExtendedResponse GetPartitionsExtendedResponse(
       const read::PartitionsRequest& request,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -54,7 +54,7 @@ using SubTilesResponse = ExtendedApiResponse<SubTilesResult, client::ApiError,
 class PrefetchTilesRepository {
  public:
   PrefetchTilesRepository(
-      client::HRN catalog, const std::string& layer_id,
+      client::HRN catalog, std::string layer_id,
       client::OlpClientSettings settings, client::ApiLookupClient client,
       boost::optional<std::string> billing_tag = boost::none,
       NamedMutexStorage mutex_storage = NamedMutexStorage());
@@ -134,20 +134,22 @@ class PrefetchTilesRepository {
                                         std::int64_t version,
                                         client::CancellationContext context);
 
-  SubQuadsResponse GetVolatileSubQuads(geo::TileKey tile, int32_t depth,
-                                       client::CancellationContext context);
+  SubQuadsResponse GetVolatileSubQuads(
+      geo::TileKey tile, int32_t depth,
+      const client::CancellationContext& context);
 
  protected:
-  static void SplitSubtree(RootTilesForRequest& root_tiles_depth,
-                           RootTilesForRequest::iterator subtree_to_split,
-                           const geo::TileKey& tile_key, std::uint32_t min);
+  static void SplitSubtree(
+      RootTilesForRequest& root_tiles_depth,
+      const RootTilesForRequest::iterator& subtree_to_split,
+      const geo::TileKey& tile_key, std::uint32_t min);
 
   using QuadTreeResponse = ExtendedApiResponse<QuadTreeIndex, client::ApiError,
                                                client::NetworkStatistics>;
 
   QuadTreeResponse DownloadVersionedQuadTree(
       geo::TileKey tile, int32_t depth, std::int64_t version,
-      client::CancellationContext context);
+      const client::CancellationContext& context);
 
  private:
   const client::HRN catalog_;

--- a/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
@@ -31,6 +31,7 @@
 #include <olp/core/client/OlpClientFactory.h>
 #include <olp/core/client/OlpClientSettings.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
+#include <olp/core/utils/Url.h>
 #include <olp/dataservice/read/DataRequest.h>
 #include <olp/dataservice/read/TileRequest.h>
 #include <repositories/DataRepository.h>
@@ -57,11 +58,18 @@ constexpr auto kUrlResponse403 =
 
 constexpr auto kUrlBlobDataHandle = R"(4eed6ed1-0d32-43b9-ae79-043cb4256432)";
 
-constexpr auto kUrlQueryTreeIndex =
-    R"(https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/testlayer/versions/4/quadkeys/23064/depths/4)";
+const auto kUrlQueryTreeIndex =
+    R"(https://sab.query.data.api.platform.here.com/query/v1/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/testlayer/versions/4/quadkeys/23064/depths/4?additionalFields=)" +
+    olp::utils::Url::Encode(R"(checksum,crc,dataSize,compressedDataSize)");
 
 constexpr auto kSubQuads =
-    R"jsonString({"subQuads": [{"subQuadKey":"115","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1"},{"subQuadKey":"463","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1"}],"parentQuads": []})jsonString";
+    R"jsonString(
+      {
+        "subQuads": [
+          {"subQuadKey":"115","version":4,"dataHandle":"95c5c703-e00e-4c38-841e-e419367474f1","checksum":"xxx","compressedDataSize":10,"dataSize":15,"crc":"aaa"},
+          {"subQuadKey":"463","version":4,"dataHandle":"e83b397a-2be5-45a8-b7fb-ad4cb3ea13b1","checksum":"xxx","compressedDataSize":10,"dataSize":15,"crc":"aaa"}],
+        "parentQuads": []
+      })jsonString";
 
 namespace {
 

--- a/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientImplTest.cpp
@@ -1365,8 +1365,6 @@ TEST(VersionedLayerClientTest, QuadTreeIndex) {
 
   auto quad_path = generator.VersionedQuadTree("92259", kCatalogVersion, depth);
   ASSERT_FALSE(quad_path.empty());
-  quad_path +=
-      "?additionalFields=" + olp::utils::Url::Encode("checksum,crc,dataSize");
 
   const auto tile_key = olp::geo::TileKey::FromHereTile(kHereTile);
   auto client = std::make_shared<read::VersionedLayerClientImpl>(

--- a/tests/common/PlatformUrlsGenerator.cpp
+++ b/tests/common/PlatformUrlsGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 HERE Europe B.V.
+ * Copyright (C) 2020-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <utility>
 
+#include <olp/core/utils/Url.h>
 #include <olp/dataservice/read/model/Partitions.h>
 #include <olp/dataservice/read/model/VersionResponse.h>
 #include "ApiDefaultResponses.h"
@@ -85,8 +86,11 @@ std::string PlatformUrlsGenerator::LatestVersion() {
 std::string PlatformUrlsGenerator::VersionedQuadTree(const std::string& quadkey,
                                                      uint64_t version,
                                                      uint64_t depth) {
-  auto path = "/layers/" + layer_ + "/versions/" + std::to_string(version) +
-              "/quadkeys/" + quadkey + "/depths/" + std::to_string(depth);
+  auto path =
+      "/layers/" + layer_ + "/versions/" + std::to_string(version) +
+      "/quadkeys/" + quadkey + "/depths/" + std::to_string(depth) +
+      "?additionalFields=" +
+      olp::utils::Url::Encode("checksum,crc,dataSize,compressedDataSize");
   return FullPath("query", path);
 }
 

--- a/tests/common/ReadDefaultResponses.h
+++ b/tests/common/ReadDefaultResponses.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,10 @@ namespace mockserver {
 struct TileMetadata {
   std::string data_handle;
   boost::optional<int32_t> version;
+  std::string crc;
+  std::string checksum;
+  int32_t data_size{0};
+  int32_t compressed_data_size{0};
 };
 
 class ReadDefaultResponses {
@@ -85,16 +89,13 @@ class QuadTreeBuilder {
   explicit QuadTreeBuilder(olp::geo::TileKey root_tile,
                            boost::optional<int32_t> base_version);
 
-  QuadTreeBuilder& WithParent(olp::geo::TileKey parent, std::string datahandle,
+  QuadTreeBuilder& WithParent(olp::geo::TileKey parent, std::string data_handle,
                               boost::optional<int32_t> version = boost::none);
   QuadTreeBuilder& FillParents();
 
   // tile is represented as a normal tilekey
   QuadTreeBuilder& WithSubQuad(olp::geo::TileKey tile, std::string datahandle,
                                boost::optional<int32_t> version = boost::none);
-
-  // valid depth 0..4
-  QuadTreeBuilder& FillSubquads(uint32_t depth);
 
   std::string BuildJson() const;
 

--- a/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/ApiTest.cpp
@@ -329,8 +329,8 @@ TEST_F(ApiTest, QuadTreeIndex) {
 
   auto start_time = std::chrono::high_resolution_clock::now();
   auto index_response = olp::dataservice::read::QueryApi::QuadTreeIndex(
-      query_client, layer_id, quad_key, version, depth, boost::none,
-      boost::none, olp::client::CancellationContext{});
+      query_client, layer_id, quad_key, version, depth, {}, boost::none,
+      olp::client::CancellationContext{});
   auto end = std::chrono::high_resolution_clock::now();
 
   std::chrono::duration<double> time = end - start_time;

--- a/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/HttpResponses.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@
 
 #pragma once
 
-#define URL_CONFIG                                                        \
+#include "olp/core/utils/Url.h"
+
+#define URL_CONFIG                                                         \
   R"(https://config.data.api.platform.sit.here.com/config/v1/catalogs/)" + \
       GetTestCatalog()
 
@@ -111,7 +113,8 @@
 #define URL_SEEK_STREAM \
   R"(https://some.stream.url/stream/v2/catalogs/hrn:here:data::olp-here-test:hereos-internal-test-v2/layers/testlayer/seek?mode=serial&subscriptionId=subscribe_id_12345)"
 
-#define CONFIG_BASE_URL "https://config.data.api.platform.sit.here.com/config/v1"
+#define CONFIG_BASE_URL \
+  "https://config.data.api.platform.sit.here.com/config/v1"
 
 #define HTTP_RESPONSE_LOOKUP_CONFIG                                                    \
   R"jsonString([{"api":"config","version":"v1","baseURL":")jsonString" CONFIG_BASE_URL \
@@ -189,22 +192,22 @@
       GetTestCatalog()
 
 #define URL_QUADKEYS_23618364 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/23618364/depths/4)"
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/23618364/depths/4?additionalFields=checksum%2Ccrc%2CdataSize%2CcompressedDataSize)"
 
 #define URL_QUADKEYS_1476147 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/1476147/depths/4)"
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/1476147/depths/4?additionalFields=checksum%2Ccrc%2CdataSize%2CcompressedDataSize)"
 
 #define URL_QUADKEYS_5904591 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/5904591/depths/4)"
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/5904591/depths/4?additionalFields=checksum%2Ccrc%2CdataSize%2CcompressedDataSize)"
 
 #define URL_QUADKEYS_369036 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/369036/depths/4)"
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/369036/depths/4?additionalFields=checksum%2Ccrc%2CdataSize%2CcompressedDataSize)"
 
 #define URL_QUADKEYS_92259 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/92259/depths/4)"
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/versions/4/quadkeys/92259/depths/4?additionalFields=checksum%2Ccrc%2CdataSize%2CcompressedDataSize)"
 
 #define URL_QUADKEYS_AGGREGATE_92259 \
-  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/testlayer/versions/108/quadkeys/92259/depths/4)"
+  R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/testlayer/versions/108/quadkeys/92259/depths/4?additionalFields=checksum%2Ccrc%2CdataSize%2CcompressedDataSize)"
 
 #define URL_QUADKEYS_VOLATILE_23618364 \
   R"(https://query.data.api.platform.here.com/query/v1/catalogs/hereos-internal-test-v2/layers/hype-test-prefetch/quadkeys/23618364/depths/4)"


### PR DESCRIPTION
Change the clint to perform query requests with default additional fields.
Fix the boost configuration error on Windows.
Fix various clang-tidy warnings.

Relates-To: OCMAM-179