### PR TITLE
Fix VersionedLayerClientProtectTest test

### DIFF
--- a/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientProtectTest.cpp
+++ b/tests/functional/olp-cpp-sdk-dataservice-read/VersionedLayerClientProtectTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ class VersionedLayerClientProtectTest : public ::testing::Test {
     cache_settings.eviction_policy =
         olp::cache::EvictionPolicy::kLeastRecentlyUsed;
     cache_settings.max_disk_storage =
-        46484u / 0.85;  // eviction trashold is (0.8500000238F)
+        55000u / 0.85;  // eviction threshold is (0.8500000238F)
     settings_->cache =
         olp::client::OlpClientSettingsFactory::CreateDefaultCache(
             cache_settings);

--- a/tests/functional/utils/MockServerHelper.cpp
+++ b/tests/functional/utils/MockServerHelper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,12 +80,14 @@ void MockServerHelper::MockGetResponse(const std::string& layer,
 void MockServerHelper::MockGetResponse(const std::string& layer,
                                        olp::geo::TileKey tile, int64_t version,
                                        const std::string& tree) {
-  mock_server_client_.MockResponse("GET",
-                                   "/query/v1/catalogs/" + catalog_ +
-                                       "/layers/" + layer + "/versions/" +
-                                       std::to_string(version) + "/quadkeys/" +
-                                       tile.ToHereTile() + "/depths/4",
-                                   tree);
+  mock_server_client_.MockResponse(
+      "GET",
+      "/query/v1/catalogs/" + catalog_ + "/layers/" + layer + "/versions/" +
+          std::to_string(version) + "/quadkeys/" + tile.ToHereTile() +
+          "/depths/4",
+      tree, olp::http::HttpStatusCode::OK, false, boost::none,
+      std::vector<Expectation::QueryStringParameter>{
+          {"additionalFields", {"checksum,crc,dataSize,compressedDataSize"}}});
 }
 
 bool MockServerHelper::Verify() {

--- a/tests/utils/mock-server-client/Client.h
+++ b/tests/utils/mock-server-client/Client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,12 +45,13 @@ class Client {
  public:
   explicit Client(olp::client::OlpClientSettings settings);
 
-  void MockResponse(const std::string& method_matcher,
-                    const std::string& path_matcher,
-                    const std::string& response_body,
-                    int https_status = olp::http::HttpStatusCode::OK,
-                    bool unlimited = false,
-                    boost::optional<int32_t> delay_ms = boost::none);
+  void MockResponse(
+      const std::string& method_matcher, const std::string& path_matcher,
+      const std::string& response_body,
+      int https_status = olp::http::HttpStatusCode::OK, bool unlimited = false,
+      boost::optional<int32_t> delay_ms = boost::none,
+      boost::optional<std::vector<Expectation::QueryStringParameter>>
+          query_params = boost::none);
 
   void MockBinaryResponse(const std::string& method_matcher,
                           const std::string& path_matcher,
@@ -77,14 +78,16 @@ inline Client::Client(olp::client::OlpClientSettings settings) {
   http_client_->SetBaseUrl(kBaseUrl);
 }
 
-inline void Client::MockResponse(const std::string& method_matcher,
-                                 const std::string& path_matcher,
-                                 const std::string& response_body,
-                                 int https_status, bool unlimited,
-                                 boost::optional<int32_t> delay_ms) {
+inline void Client::MockResponse(
+    const std::string& method_matcher, const std::string& path_matcher,
+    const std::string& response_body, int https_status, bool unlimited,
+    boost::optional<int32_t> delay_ms,
+    boost::optional<std::vector<Expectation::QueryStringParameter>>
+        query_params) {
   auto expectation = Expectation{};
   expectation.request.path = path_matcher;
   expectation.request.method = method_matcher;
+  expectation.request.query_string_parameters = std::move(query_params);
 
   boost::optional<Expectation::ResponseAction> action =
       Expectation::ResponseAction{};

--- a/tests/utils/mock-server-client/Expectation.h
+++ b/tests/utils/mock-server-client/Expectation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,15 @@
 namespace mockserver {
 
 struct Expectation {
+  struct QueryStringParameter {
+    std::string name;
+    std::vector<std::string> values;
+  };
   struct RequestMatcher {
     boost::optional<std::string> path = boost::none;
     boost::optional<std::string> method = boost::none;
+    boost::optional<std::vector<QueryStringParameter>> query_string_parameters =
+        boost::none;
   };
 
   struct ResponseDelay {
@@ -64,6 +70,9 @@ struct Expectation {
 
 void to_json(const Expectation& x, rapidjson::Value& value,
              rapidjson::Document::AllocatorType& allocator);
+void to_json(const Expectation::QueryStringParameter& x,
+             rapidjson::Value& value,
+             rapidjson::Document::AllocatorType& allocator);
 void to_json(const Expectation::RequestMatcher& x, rapidjson::Value& value,
              rapidjson::Document::AllocatorType& allocator);
 void to_json(const Expectation::BinaryResponse& x, rapidjson::Value& value,
@@ -90,12 +99,22 @@ inline void to_json(const Expectation& x, rapidjson::Value& value,
   }
 }
 
+inline void to_json(const Expectation::QueryStringParameter& x,
+                    rapidjson::Value& value,
+                    rapidjson::Document::AllocatorType& allocator) {
+  value.SetObject();
+  serialize("name", x.name, value, allocator);
+  serialize("values", x.values, value, allocator);
+}
+
 inline void to_json(const Expectation::RequestMatcher& x,
                     rapidjson::Value& value,
                     rapidjson::Document::AllocatorType& allocator) {
   value.SetObject();
   serialize("path", x.path, value, allocator);
   serialize("method", x.method, value, allocator);
+  serialize("queryStringParameters", x.query_string_parameters, value,
+            allocator);
 }
 
 inline void to_json(const Expectation::BinaryResponse& x,


### PR DESCRIPTION
Mock server required support for additional fields, and cache size should be tuned to accommodate increased data size

Relates-To: DATASDK-38