### PR TITLE
Background subscriber to check current value

### DIFF
--- a/olp-cpp-sdk-core/src/http/ios/OLPHttpClient.mm
+++ b/olp-cpp-sdk-core/src/http/ios/OLPHttpClient.mm
@@ -42,14 +42,14 @@ class EnterBackgroundSubscriberImpl
       : http_client_(http_client) {}
 
   void OnEnterBackground() override {
-    if (http_client_) {
+    if (http_client_ && !http_client_.inBackground) {
       http_client_.inBackground = true;
       [http_client_ restartCurrentTasks];
     }
   }
 
   void OnExitBackground() override {
-    if (http_client_) {
+    if (http_client_ && http_client_.inBackground) {
       http_client_.inBackground = false;
     }
   }

--- a/olp-cpp-sdk-core/src/http/ios/OLPHttpTask.mm
+++ b/olp-cpp-sdk-core/src/http/ios/OLPHttpTask.mm
@@ -73,6 +73,7 @@ constexpr auto kLogTag = "OLPHttpTask";
     _headersSizeReceived = 0;
     _headersSizeSent = 0;
     _contentLength = 0;
+    _backgroundMode = false;
   }
   return self;
 }


### PR DESCRIPTION
To prevent triggering handlers several times in a row. Currently
this should not harm the app because NSURLSessionDownloadTask tasks
are skipped in restartCurrentTasks.

Testing on iOS-13 simulator it was possible to get two same states
in a row using notifications. Maybe a simulator issue or iOS-13 case
which is the first where background mode delegates are in the Scene
delegate instead of Application delegate.

Relates-To: DATASDK-39