### PR TITLE
Always require OpenSSL

### DIFF
--- a/olp-cpp-sdk-core/cmake/curl.cmake
+++ b/olp-cpp-sdk-core/cmake/curl.cmake
@@ -33,20 +33,13 @@ if(CURL_FOUND AND NOT NETWORK_NO_CURL)
     endif()
 
     if(NOT OPENSSL_FOUND)
-        if(ANDROID AND OLP_SDK_ENABLE_ANDROID_CURL)
-            find_package(OpenSSL REQUIRED)
-        else()
-            find_package(OpenSSL)
-        endif()
+        # Enforcing OpenSSL to make sure that it is available
+        find_package(OpenSSL REQUIRED)
     endif()
 
-    if(OPENSSL_FOUND)
-        add_definitions(-DOLP_SDK_NETWORK_HAS_OPENSSL)
-
-        if(ANDROID AND OLP_SDK_ENABLE_ANDROID_CURL)
-            include_directories(${OPENSSL_INCLUDE_DIR})
-            set(OLP_SDK_NETWORK_CURL_LIBRARIES ${OLP_SDK_NETWORK_CURL_LIBRARIES} ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
-        endif()
+    if(OPENSSL_FOUND AND ANDROID AND OLP_SDK_ENABLE_ANDROID_CURL)
+        include_directories(${OPENSSL_INCLUDE_DIR})
+        set(OLP_SDK_NETWORK_CURL_LIBRARIES ${OLP_SDK_NETWORK_CURL_LIBRARIES} ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
     endif()
 
     option(OLP_SDK_ENABLE_CURL_VERBOSE "Enable support for CURL_VERBOSE environment variable to set libcurl to verbose mode" OFF)

--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
@@ -34,7 +34,6 @@
 #include <boost/optional.hpp>
 
 #if defined(OLP_SDK_ENABLE_ANDROID_CURL) && !defined(ANDROID_HOST)
-#ifdef OLP_SDK_NETWORK_HAS_OPENSSL
 #include <openssl/ossl_typ.h>
 
 #ifdef OPENSSL_NO_MD5
@@ -46,7 +45,6 @@
 // certificate as it won't be able to locate one. We need to add our custom
 // lookup method that uses MD5. Old SHA1 lookup will be left as is.
 #define OLP_SDK_USE_MD5_CERT_LOOKUP
-#endif
 #endif
 
 // CURLOPT_CAINFO_BLOB has become available only in curl-7.77
@@ -386,12 +384,6 @@ class NetworkCurl : public olp::http::Network,
 
   /// UNIX Pipe used to notify sleeping worker thread during select() call.
   int pipe_[2]{};
-
-#ifdef OLP_SDK_NETWORK_HAS_OPENSSL
-  /// Mutexes that are used by OpenSSL to synchronize during concurrent
-  /// network transfer.
-  std::unique_ptr<std::mutex[]> ssl_mutexes_{};
-#endif
 
   /// Stores value if `curl_global_init()` was successful on construction.
   bool curl_initialized_;

--- a/scripts/linux/nv/cppcheck_and_upload_sonar.sh
+++ b/scripts/linux/nv/cppcheck_and_upload_sonar.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (C) 2019-2021 HERE Europe B.V.
+# Copyright (C) 2019-2024 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,7 +36,6 @@ cppcheck \
     -DHAVE_SIGNAL_H \
     -DIGNORE_SIGPIPE \
     -DOLP_SDK_NETWORK_HAS_CURL \
-    -DOLP_SDK_NETWORK_HAS_OPENSSL \
     -DOLP_SDK_NETWORK_HAS_PIPE=1 \
     -DOLP_SDK_NETWORK_HAS_UNISTD_H=1 \
     -DOLP_SDK_PLATFORM_NAME=\"Linux\" \


### PR DESCRIPTION
OpenSSL now required, and should be always present
hence `OLP_SDK_NETWORK_HAS_OPENSSL` could be removed

Relates-To: HERESUP-1440