### PR TITLE
Fix a crash in DiskCache::Size method

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DiskCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DiskCache.cpp
@@ -541,6 +541,10 @@ leveldb::Options DiskCache::CreateOpenOptions(const StorageSettings& settings,
 }
 
 uint64_t DiskCache::Size() const {
+  if (!database_) {
+    OLP_SDK_LOG_ERROR(kLogTag, "Size: Database is not initialized");
+    return 0;
+  }
   uint64_t result{0u};
   leveldb::Range range{"0", "z"};
   database_->GetApproximateSizes(&range, 1, &result);


### PR DESCRIPTION
The crash happened on a call to Size method on a closed cache.

Relates-To: OCMAM-106