### PR TITLE
Add getter for OlpClientSettings

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClient.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClient.h
@@ -108,6 +108,13 @@ class CORE_API OlpClient {
   void SetSettings(const OlpClientSettings& settings);
 
   /**
+   * @brief Getter function to retrieve client settings.
+   *
+   * @return The client settings
+   */
+  const OlpClientSettings& GetSettings() const;
+
+  /**
    * @brief Executes the HTTP request through the network stack.
    *
    * @param path The path that is appended to the base URL.

--- a/olp-cpp-sdk-core/src/client/OlpClient.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClient.cpp
@@ -467,6 +467,7 @@ class OlpClient::OlpClientImpl {
 
   ParametersType& GetMutableDefaultHeaders();
   void SetSettings(const OlpClientSettings& settings);
+  const OlpClientSettings& GetSettings() const { return settings_; }
 
   CancellationToken CallApi(const std::string& path, const std::string& method,
                             const ParametersType& query_params,
@@ -854,6 +855,10 @@ OlpClient::ParametersType& OlpClient::GetMutableDefaultHeaders() {
 
 void OlpClient::SetSettings(const OlpClientSettings& settings) {
   impl_->SetSettings(settings);
+}
+
+const OlpClientSettings& OlpClient::GetSettings() const {
+  return impl_->GetSettings();
 }
 
 CancellationToken OlpClient::CallApi(


### PR DESCRIPTION
Required for extensions that take an OlpClient instance to do some additional work.

Relates-To: MINOR