### PR TITLE
Remove deprecated `NetworkSettings` functions

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkSettings.h
@@ -38,33 +38,6 @@ namespace http {
 class CORE_API NetworkSettings final {
  public:
   /**
-   * @brief Gets the maximum number of retries for the HTTP request.
-   *
-   * @return The maximum number of retries for the HTTP request.
-   */
-  OLP_SDK_DEPRECATED("Will be removed by 04.2024")
-  std::size_t GetRetries() const;
-
-  /**
-   * @brief Sets the maximum number of retries for the HTTP request.
-   *
-   * @param[in] retries The maximum number of retries for HTTP request.
-   *
-   * @return A reference to *this.
-   */
-  OLP_SDK_DEPRECATED("Will be removed by 04.2024")
-  NetworkSettings& WithRetries(std::size_t retries);
-
-  /**
-   * @brief Gets the connection timeout in seconds.
-   *
-   * @return The connection timeout in seconds.
-   */
-  OLP_SDK_DEPRECATED(
-      "Will be removed by 04.2024, use GetConnectionTimeoutDuration() instead")
-  int GetConnectionTimeout() const;
-
-  /**
    * @brief Gets the connection timeout.
    *
    * @return The connection timeout.
@@ -79,18 +52,6 @@ class CORE_API NetworkSettings final {
    */
   std::chrono::milliseconds GetBackgroundConnectionTimeoutDuration() const;
 #endif  // OLP_SDK_NETWORK_IOS_BACKGROUND_DOWNLOAD
-
-  /**
-   * @brief Sets the connection timeout in seconds.
-   *
-   * @param[in] timeout The connection timeout in seconds.
-   *
-   * @return A reference to *this.
-   */
-  OLP_SDK_DEPRECATED(
-      "Will be removed by 04.2024, use "
-      "WithConnectionTimeout(std::chrono::milliseconds) instead")
-  NetworkSettings& WithConnectionTimeout(int timeout);
 
   /**
    * @brief Sets the connection timeout.
@@ -114,32 +75,11 @@ class CORE_API NetworkSettings final {
 #endif  // OLP_SDK_NETWORK_IOS_BACKGROUND_DOWNLOAD
 
   /**
-   * @brief Gets the transfer timeout in seconds.
-   *
-   * @return The transfer timeout in seconds.
-   */
-  OLP_SDK_DEPRECATED(
-      "Will be removed by 04.2024, use GetTransferTimeoutDuration() instead")
-  int GetTransferTimeout() const;
-
-  /**
    * @brief Gets the transfer timeout.
    *
    * @return The transfer timeout.
    */
   std::chrono::milliseconds GetTransferTimeoutDuration() const;
-
-  /**
-   * @brief Sets the transfer timeout in seconds.
-   *
-   * @param[in] timeout The transfer timeout in seconds.
-   *
-   * @return A reference to *this.
-   */
-  OLP_SDK_DEPRECATED(
-      "Will be removed by 04.2024, use "
-      "WithTransferTimeout(std::chrono::milliseconds) instead")
-  NetworkSettings& WithTransferTimeout(int timeout);
 
   /**
    * @brief Gets max lifetime (since creation) allowed for reusing a connection.
@@ -203,8 +143,6 @@ class CORE_API NetworkSettings final {
   NetworkSettings& WithDNSServers(std::vector<std::string> dns_servers);
 
  private:
-  /// The maximum number of retries for the HTTP request.
-  std::size_t retries_{3};
   /// The connection timeout.
   std::chrono::milliseconds connection_timeout_ = std::chrono::seconds(60);
 #ifdef OLP_SDK_NETWORK_IOS_BACKGROUND_DOWNLOAD

--- a/olp-cpp-sdk-core/src/http/NetworkSettings.cpp
+++ b/olp-cpp-sdk-core/src/http/NetworkSettings.cpp
@@ -22,14 +22,6 @@
 namespace olp {
 namespace http {
 
-std::size_t NetworkSettings::GetRetries() const { return retries_; }
-
-int NetworkSettings::GetConnectionTimeout() const {
-  return static_cast<int>(std::chrono::duration_cast<std::chrono::seconds>(
-                              GetConnectionTimeoutDuration())
-                              .count());
-}
-
 std::chrono::milliseconds NetworkSettings::GetConnectionTimeoutDuration()
     const {
   return connection_timeout_;
@@ -41,12 +33,6 @@ NetworkSettings::GetBackgroundConnectionTimeoutDuration() const {
   return background_connection_timeout_;
 }
 #endif  // OLP_SDK_NETWORK_IOS_BACKGROUND_DOWNLOAD
-
-int NetworkSettings::GetTransferTimeout() const {
-  return static_cast<int>(std::chrono::duration_cast<std::chrono::seconds>(
-                              GetTransferTimeoutDuration())
-                              .count());
-}
 
 std::chrono::milliseconds NetworkSettings::GetTransferTimeoutDuration() const {
   return transfer_timeout_;
@@ -64,15 +50,6 @@ const std::vector<std::string>& NetworkSettings::GetDNSServers() const {
   return dns_servers_;
 }
 
-NetworkSettings& NetworkSettings::WithRetries(std::size_t retries) {
-  retries_ = retries;
-  return *this;
-}
-
-NetworkSettings& NetworkSettings::WithConnectionTimeout(int timeout) {
-  return WithConnectionTimeout(std::chrono::seconds(timeout));
-}
-
 NetworkSettings& NetworkSettings::WithConnectionTimeout(
     std::chrono::milliseconds timeout) {
   connection_timeout_ = timeout;
@@ -86,10 +63,6 @@ NetworkSettings& NetworkSettings::WithBackgroundConnectionTimeout(
   return *this;
 }
 #endif  // OLP_SDK_NETWORK_IOS_BACKGROUND_DOWNLOAD
-
-NetworkSettings& NetworkSettings::WithTransferTimeout(int timeout) {
-  return WithTransferTimeout(std::chrono::seconds(timeout));
-}
 
 NetworkSettings& NetworkSettings::WithTransferTimeout(
     std::chrono::milliseconds timeout) {

--- a/olp-cpp-sdk-core/tests/http/NetworkSettingsTest.cpp
+++ b/olp-cpp-sdk-core/tests/http/NetworkSettingsTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 HERE Europe B.V.
+ * Copyright (C) 2023-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,50 +20,25 @@
 #include <gtest/gtest.h>
 
 #include <olp/core/http/NetworkSettings.h>
-#include <olp/core/porting/warning_disable.h>
-
-PORTING_PUSH_WARNINGS()
-PORTING_CLANG_GCC_DISABLE_WARNING("-Wdeprecated-declarations")
 
 namespace {
 
 TEST(NetworkSettingsTest, TimeoutDefaults) {
   const auto settings = olp::http::NetworkSettings();
-  EXPECT_EQ(settings.GetConnectionTimeout(), 60);
   EXPECT_EQ(settings.GetConnectionTimeoutDuration(), std::chrono::seconds(60));
-  EXPECT_EQ(settings.GetTransferTimeout(), 30);
   EXPECT_EQ(settings.GetTransferTimeoutDuration(), std::chrono::seconds(30));
-}
-
-TEST(NetworkSettingsTest, WithConnectionTimeoutDeprecated) {
-  const auto settings = olp::http::NetworkSettings().WithConnectionTimeout(15);
-  EXPECT_EQ(settings.GetConnectionTimeout(), 15);
-  EXPECT_EQ(settings.GetConnectionTimeoutDuration(), std::chrono::seconds(15));
 }
 
 TEST(NetworkSettingsTest, WithConnectionTimeout) {
   const auto settings = olp::http::NetworkSettings().WithConnectionTimeout(
       std::chrono::seconds(15));
-  EXPECT_EQ(settings.GetConnectionTimeout(), 15);
   EXPECT_EQ(settings.GetConnectionTimeoutDuration(), std::chrono::seconds(15));
-}
-
-TEST(NetworkSettingsTest, WithTransferTimeoutDeprecated) {
-  const auto settings = olp::http::NetworkSettings().WithTransferTimeout(15);
-  EXPECT_EQ(settings.GetTransferTimeout(), 15);
-  EXPECT_EQ(settings.GetTransferTimeoutDuration(), std::chrono::seconds(15));
 }
 
 TEST(NetworkSettingsTest, WithTransferTimeout) {
   const auto settings = olp::http::NetworkSettings().WithTransferTimeout(
       std::chrono::seconds(15));
-  EXPECT_EQ(settings.GetTransferTimeout(), 15);
   EXPECT_EQ(settings.GetTransferTimeoutDuration(), std::chrono::seconds(15));
-}
-
-TEST(NetworkSettingsTest, WithRetriesDeprecated) {
-  const auto settings = olp::http::NetworkSettings().WithRetries(5);
-  EXPECT_EQ(settings.GetRetries(), 5);
 }
 
 TEST(NetworkSettingsTest, WithMaxConnectionLifetimeDefault) {
@@ -84,5 +59,3 @@ TEST(NetworkSettingsTest, WithDNSServers) {
 }
 
 }  // namespace
-
-PORTING_POP_WARNINGS()


### PR DESCRIPTION
Deprecated ones were used only in tests

Relates-To: OCMAM-212