### PR TITLE
Remove deprecated `OlpClient` functions

### DIFF
--- a/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.cpp
@@ -275,9 +275,7 @@ client::OlpClient CreateOlpClient(
     settings.retry_settings.max_attempts = 0;
   }
 
-  client::OlpClient client;
-  client.SetBaseUrl(auth_settings.token_endpoint_url);
-  client.SetSettings(std::move(settings));
+  client::OlpClient client(settings, auth_settings.token_endpoint_url);
   return client;
 }
 

--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClient.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,21 +91,6 @@ class CORE_API OlpClient {
    * @return The default headers.
    */
   ParametersType& GetMutableDefaultHeaders();
-
-  /**
-   * @brief Sets the client settings.
-   *
-   * @note Handle with care and do not change while requests are ongoing.
-   * Ideally the settings would not change during the lifecycle of this
-   * instance.
-   *
-   * @param settings The client settings.
-   *
-   * @deprecated This method will be removed by 05.2021. Please use the
-   * constructor instead. The settings should not change during the lifetime of
-   * the instance.
-   */
-  void SetSettings(const OlpClientSettings& settings);
 
   /**
    * @brief Getter function to retrieve client settings.

--- a/olp-cpp-sdk-core/src/client/OlpClient.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClient.cpp
@@ -466,7 +466,6 @@ class OlpClient::OlpClientImpl {
   std::string GetBaseUrl() const;
 
   ParametersType& GetMutableDefaultHeaders();
-  void SetSettings(const OlpClientSettings& settings);
   const OlpClientSettings& GetSettings() const { return settings_; }
 
   CancellationToken CallApi(const std::string& path, const std::string& method,
@@ -525,11 +524,6 @@ std::string OlpClient::OlpClientImpl::GetBaseUrl() const {
 OlpClient::ParametersType&
 OlpClient::OlpClientImpl::GetMutableDefaultHeaders() {
   return default_headers_;
-}
-
-void OlpClient::OlpClientImpl::SetSettings(const OlpClientSettings& settings) {
-  // I would not expect that settings change during lifetime of the instance.
-  settings_ = settings;
 }
 
 boost::optional<client::ApiError> OlpClient::OlpClientImpl::AddBearer(
@@ -851,10 +845,6 @@ std::string OlpClient::GetBaseUrl() const { return impl_->GetBaseUrl(); }
 
 OlpClient::ParametersType& OlpClient::GetMutableDefaultHeaders() {
   return impl_->GetMutableDefaultHeaders();
-}
-
-void OlpClient::SetSettings(const OlpClientSettings& settings) {
-  impl_->SetSettings(settings);
 }
 
 const OlpClientSettings& OlpClient::GetSettings() const {

--- a/olp-cpp-sdk-core/src/client/OlpClientFactory.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClientFactory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@ namespace client {
 
 std::shared_ptr<OlpClient> OlpClientFactory::Create(
     const OlpClientSettings& settings) {
-  auto olp_client = std::make_shared<OlpClient>();
-  olp_client->SetSettings(settings);
+  const auto kEmptyBaseUrl = std::string();
+  auto olp_client = std::make_shared<OlpClient>(settings, kEmptyBaseUrl);
   return olp_client;
 }
 

--- a/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,9 +77,7 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApi(
       OLP_SDK_LOG_DEBUG_F(kLogTag, "LookupApi(%s/%s) found in cache, hrn='%s'",
                           service.c_str(), service_version.c_str(),
                           hrn.c_str());
-      client::OlpClient client;
-      client.SetSettings(std::move(settings));
-      client.SetBaseUrl(*url);
+      client::OlpClient client(settings, *url);
       return client;
     } else if (options == CacheOnly) {
       return {{client::ErrorCode::NotFound,
@@ -92,10 +90,7 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApi(
                      service.c_str(), service_version.c_str(), hrn.c_str());
 
   const auto& base_url = GetDatastoreServerUrl(catalog.GetPartition());
-  client::OlpClient client;
-  client.SetBaseUrl(base_url);
-  // Do not move settings, we still need them later on!
-  client.SetSettings(settings);
+  client::OlpClient client(settings, base_url);
   PlatformApi::ApisResponse api_response;
 
   if (service == "config") {
@@ -142,9 +137,7 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApi(
                       service.c_str(), service_version.c_str(), hrn.c_str(),
                       service_url.c_str());
 
-  client::OlpClient service_client;
-  service_client.SetBaseUrl(service_url);
-  service_client.SetSettings(settings);
+  client::OlpClient service_client(settings, service_url);
   return service_client;
 }
 }  // namespace read

--- a/olp-cpp-sdk-dataservice-read/src/StreamLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/StreamLayerClientImpl.cpp
@@ -133,11 +133,8 @@ client::CancellationToken StreamLayerClientImpl::Subscribe(
 
       client_context_ = std::make_unique<StreamLayerClientContext>(
           subscripton_id, subscription_mode, correlation_id,
-          std::make_shared<client::OlpClient>());
-
-      client_context_->client->SetBaseUrl(
-          subscription.GetResult().GetNodeBaseURL());
-      client_context_->client->SetSettings(settings_);
+          std::make_shared<client::OlpClient>(
+              settings_, subscription.GetResult().GetNodeBaseURL()));
     }
 
     OLP_SDK_LOG_INFO_F(kLogTag,

--- a/olp-cpp-sdk-dataservice-write/src/ApiClientLookup.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/ApiClientLookup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,9 +152,7 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApiClient(
       auto base_url = boost::any_cast<std::string>(url);
       OLP_SDK_LOG_INFO_F(kLogTag, "LookupApiClient(%s, %s) -> from cache",
                          service.c_str(), service_version.c_str());
-      client::OlpClient client;
-      client.SetSettings(settings);
-      client.SetBaseUrl(base_url);
+      client::OlpClient client(settings, base_url);
       return ApiClientResponse{client};
     }
   }
@@ -174,9 +172,7 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApiClient(
   }
 
   ApisResponse api_response;
-  client::OlpClient input_client;
-  input_client.SetBaseUrl(base_url);
-  input_client.SetSettings(settings);
+  client::OlpClient input_client(settings, base_url);
 
   if (service == "config") {
     OLP_SDK_LOG_INFO_F(kLogTag, "LookupApiClient(%s/%s): %s - config service",
@@ -219,9 +215,6 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApiClient(
         service_version.c_str(), catalog.GetPartition().c_str());
   }
 
-  client::OlpClient output_client;
-  output_client.SetBaseUrl(output_base_url);
-
   if (cache) {
     constexpr time_t kExpiryTimeInSecs = 3600;
     if (cache->Put(cache_key, output_base_url,
@@ -234,7 +227,7 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApiClient(
     }
   }
 
-  output_client.SetSettings(settings);
+  client::OlpClient output_client(settings, output_base_url);
   return ApiClientResponse{std::move(output_client)};
 }
 


### PR DESCRIPTION
Constructor should be used instead

Relates-To: OCMAM-212