### PR TITLE
OLPHttpTask to lock toIgnoreResponse before usage

### DIFF
--- a/olp-cpp-sdk-core/src/http/ios/OLPHttpTask.mm
+++ b/olp-cpp-sdk-core/src/http/ios/OLPHttpTask.mm
@@ -98,7 +98,9 @@ constexpr auto kLogTag = "OLPHttpTask";
   }
 
   if (_dataTask) {
-    _httpClient.toIgnoreResponse[_dataTask.taskDescription] = _dataTask;
+    @synchronized(_httpClient.toIgnoreResponse) {
+      _httpClient.toIgnoreResponse[_dataTask.taskDescription] = _dataTask;
+    }
     [_dataTask cancel];
     _dataTask = nil;
   }


### PR DESCRIPTION
It is 'synchronized' in the didCompleteWithError callback so it's better to add 'synchronized' in the restarting as well

Relates-To: DATASDK-45