### PR TITLE
Release v1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## v1.21.0 (25/10/2024)
+
+**Common**
+* Removed deprecated `olp::client::OlpClient::SetSettings(...)` method.  Use `olp::client::OlpClient` constructor instead.
+* Removed deprecated `olp::client::HttpResponse::status` field. Use `HttpResponse::GetStatus()` method instead.
+* Removed deprecated `olp::client::HttpResponse::response` field. Use `HttpResponse::GetRawResponse()` method instead.
+* Removed deprecated `olp::client::HttpResponse::headers` field. Use `HttpResponse::GetHeaders()` method instead.
+
+**olp-cpp-sdk-core**
+* Added `olp::client::HttpResponse::GetResponseAsBytes` convenience method to get the response body as a vector of unsigned chars.
+* Added `olp::client::HttpResponse::GetResponseAsString` convenience method to get the response body content as a string.
+* Added `olp::client::HttpResponse::GetRawResponse` convenience method to get reference to the response object.
+* Added `olp::client::OlpClient::GetSettings()` method.
+* Removed deprecated `olp::http::CreateDefaultNetwork(size_t)` function. Use `olp::http::CreateDefaultNetwork(NetworkInitializationSettings)` instead.
+* Removed deprecated `olp::http::NetworkSettings::GetRetries()` method.
+* Removed deprecated `olp::http::NetworkSettings::WithRetries()` method.
+* Removed deprecated `olp::http::NetworkSettings::GetConnectionTimeout()` method. Use `NetworkSettings::GetConnectionTimeoutDuration()` instead.
+* Removed deprecated `olp::http::NetworkSettings::WithConnectionTimeout(int)` method. Use `NetworkSettings::WithConnectionTimeout(std::chrono::milliseconds)` instead.
+* Removed deprecated `olp::http::NetworkSettings::GetTransferTimeout()` method. Use `NetworkSettings::GetTransferTimeoutDuration()` instead.
+* Removed deprecated `olp::http::NetworkSettings::WithTransferTimeout(int)` method. Use `NetworkSettings::WithTransferTimeout(std::chrono::milliseconds)` instead.
+* Removed deprecated `olp::utils::Dir::exists(const std::string&)` method. Use `Dir::Exists(...)` instead.
+* Removed deprecated `olp::utils::Dir::remove(const std::string&)` method. Use `Dir::Remove(...)` instead.
+* Removed deprecated `olp::utils::Dir::create(const std::string&)` method. Use `Dir::Create(...)` instead.
+* Changed cURL network implementation requirements. OpenSSL is mandatory now.
+* Fixed asynchronous access to the list of cancelled tasks in the iOS background mode.
+* Fixed deleting cancelled invalid download tasks in the iOS background mode.
+* Fixed crashes in `olp::cache::DiskCache::Size()` method that happened when it's called on closed cache.
+* Fixed `olp::math::AlignedBox` template compilation in certain environments.
+* Improved error handling on iOS. `NSURLErrorSecureConnectionFailed`, `NSURLErrorCannotFindHost`, `NSURLErrorDNSLookupFailed` and `NSURLErrorResourceUnavailable` are retriable now.
+* Improved the iOS background download mode change. No additional actions performed when requested mode is already active.
+* Improved cURL certificates configuration. Now, every field can be set up independently.
+
 ## v1.20.1 (13/08/2024)
 
 **Common**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 cmake_minimum_required(VERSION 3.9)
 
 # Build the sdk targets
-project(olp-cpp-sdk VERSION 1.20.1)
+project(olp-cpp-sdk VERSION 1.21.0)
 
 # Add preprocessor definitions for the SDK version and platform name
 add_definitions(-DOLP_SDK_VERSION_STRING=\"${olp-cpp-sdk_VERSION}\")

--- a/olp-cpp-sdk-authentication/CMakeLists.txt
+++ b/olp-cpp-sdk-authentication/CMakeLists.txt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-project(olp-cpp-sdk-authentication VERSION 1.20.1)
+project(olp-cpp-sdk-authentication VERSION 1.21.0)
 set(DESCRIPTION "C++ API library for accessing HERE Account authentication service")
 
 file(GLOB_RECURSE AUTHENTICATION_INC "include/*.h*")

--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -16,7 +16,7 @@
 # License-Filename: LICENSE
 
 
-project(olp-cpp-sdk-core VERSION 1.20.1)
+project(olp-cpp-sdk-core VERSION 1.21.0)
 set(DESCRIPTION "Core network and utility library for the HERE OLP SDK C++")
 
 find_package(RapidJSON 1.1.0 REQUIRED)

--- a/olp-cpp-sdk-dataservice-read/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/CMakeLists.txt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-project(olp-cpp-sdk-dataservice-read VERSION 1.20.1)
+project(olp-cpp-sdk-dataservice-read VERSION 1.21.0)
 set(DESCRIPTION "C++ API library for reading OLP data")
 
 file(GLOB_RECURSE INC "include/*.h*")

--- a/olp-cpp-sdk-dataservice-write/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-write/CMakeLists.txt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-project(olp-cpp-sdk-dataservice-write VERSION 1.20.1)
+project(olp-cpp-sdk-dataservice-write VERSION 1.21.0)
 set(DESCRIPTION "C++ API library for writing data to OLP")
 
 set(OLP_SDK_DATASERVICE_WRITE_API_HEADERS


### PR DESCRIPTION
Update CHANGELOG.md and CMakeLists.txt files for the v1.21.0 release.

Relates-To: DATASDK-48