### PR TITLE
Update Apple CI jobs, skip boost compile warning

### DIFF
--- a/.github/workflows/psv_pipelines.yml
+++ b/.github/workflows/psv_pipelines.yml
@@ -176,45 +176,75 @@ jobs:
       run: scripts/android/build.sh
       shell: bash
 
-  psv-macos-12-xcode-14-build:
-    name: PSV.MacOS12.Xcode14
-    runs-on: macOS-12
+  psv-macos-13-x86_64-xcode-15-build:
+    name: PSV.MacOS13.Xcode15.x86_64
+    runs-on: macOS-13
     steps:
     - name: Check out repository
       uses: actions/checkout@v4
-    - name: MacOS Build
+    - name: MacOS Build Xcode15
       run: scripts/macos/psv/azure_macos_build_psv.sh
       shell: bash
 
-  psv-ios-xcode-14-build:
-    name: PSV.iOS.MacOS12.Xcode14
-    runs-on: macOS-12
+  psv-macos-13-xcode-15-build:
+    name: PSV.MacOS13.Xcode15
+    runs-on: macos-13-xlarge
     steps:
     - name: Check out repository
       uses: actions/checkout@v4
-    - name: iOS Xcode 14 Build
-      run: scripts/ios/azure_ios_build_psv.sh
+    - name: MacOS Build Xcode15
+      run: scripts/macos/psv/azure_macos_build_psv.sh
       shell: bash
 
-  psv-ios-xcode-13-build:
-    name: PSV.iOS.MacOS12.Xcode13
-    runs-on: macOS-12
+  psv-macos-14-xcode-15-build:
+    name: PSV.MacOS14.Xcode15
+    runs-on: macos-14
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-      - name: iOS Xcode 13 Build
-        run: scripts/ios/azure_ios_build_psv.sh
-        shell: bash
-        env:
-          USE_LATEST_XCODE: 0
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: MacOS Build Xcode15
+      run: scripts/macos/psv/azure_macos_build_psv.sh
+      shell: bash
 
-  psv-ios-os13-xcode-15-build:
+  psv-macos-15-arm64-xcode-16-build:
+    name: PSV.MacOS13.Xcode16
+    runs-on: macos-15
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: MacOS Build Xcode16
+      run: scripts/macos/psv/azure_macos_build_psv.sh
+      shell: bash
+
+  psv-ios-xcode-15-build:
     name: PSV.iOS.MacOS13.Xcode15
     runs-on: macOS-13
     steps:
     - name: Check out repository
       uses: actions/checkout@v4
     - name: iOS Xcode 15 Build
+      run: scripts/ios/azure_ios_build_psv.sh
+      shell: bash
+
+  psv-ios-xcode-14-build:
+    name: PSV.iOS.MacOS13.Xcode14
+    runs-on: macOS-13
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: iOS Xcode 14.3 Build
+        run: scripts/ios/azure_ios_build_psv.sh
+        shell: bash
+        env:
+          USE_LATEST_XCODE: 0
+
+  psv-ios-os15-xcode-16-build:
+    name: PSV.iOS.MacOS13.Xcode16
+    runs-on: macOS-15
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: iOS Xcode 16 Build
       run: scripts/ios/azure_ios_build_psv.sh
       shell: bash
 

--- a/scripts/ios/azure_ios_build_psv.sh
+++ b/scripts/ios/azure_ios_build_psv.sh
@@ -26,7 +26,7 @@ if [[ ${USE_LATEST_XCODE} == 0 ]]; then
   # Due to some bug which is cmake cannot detect compiler while called
   # from cmake itself when project is compiled with XCode 12.4 we must
   # switch to old XCode as a workaround.
-  sudo xcode-select -s /Applications/Xcode_13.1.app
+  sudo xcode-select -s /Applications/Xcode_14.3.app
 fi
 
 mkdir -p build && cd build

--- a/scripts/macos/psv/azure_macos_build_psv.sh
+++ b/scripts/macos/psv/azure_macos_build_psv.sh
@@ -21,6 +21,7 @@
 mkdir -p build
 cd build
 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+    -DCMAKE_CXX_FLAGS="-Wno-deprecated-builtins -Wno-deprecated-declarations -Wno-deprecated-copy" \
     -DOLP_SDK_BUILD_EXAMPLES=ON \
     -DBUILD_SHARED_LIBS=ON \
     -DOLP_SDK_ENABLE_TESTING=NO \


### PR DESCRIPTION
According to updates on images: macos-12 deprecation we should use macos-13 and Xcode 14.3 as the lowest versions in CI validation.
Also, add х86_64 macos-13 image with job separately, while other images 
are by default on ARM.
Additional compiler options are related boost internal warnings 
on newer xcodes.
Add more MacOS jobs to cover more combinations: MacOS-Xcode.

Relates-TO: DATASDK-47