### PR TITLE
Boost update on CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The table below lists the dependencies of the Data SDK.
 |:---------------------|:--------------------|
 | Libcurl              | 7.52.1              |
 | OpenSSL              | 1.1.1w              |
-| Boost (headers only) | 1.72.0              |
+| Boost (headers only) | 1.82.0              |
 | LevelDB              | 1.21                |
 | Snappy               | 1.1.7               |
 | RapidJSON            | latest              |

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -52,7 +52,7 @@ set(OLP_SDK_CPP_RAPIDJSON_URL "https://github.com/Tencent/rapidjson.git")
 set(OLP_SDK_CPP_RAPIDJSON_TAG "master")
 
 set(OLP_SDK_CPP_BOOST_URL "https://github.com/boostorg/boost.git")
-set(OLP_SDK_CPP_BOOST_TAG "boost-1.72.0")
+set(OLP_SDK_CPP_BOOST_TAG "boost-1.82.0")
 
 set(OLP_SDK_CPP_LMDB_URL "https://github.com/LMDB/lmdb.git")
 set(OLP_SDK_CPP_LMDB_TAG "LMDB_0.9.29")

--- a/external/boost/CMakeLists.txt.boost.in
+++ b/external/boost/CMakeLists.txt.boost.in
@@ -30,6 +30,7 @@ ExternalProject_Add(boost-download
                         libs/container_hash
                         libs/core
                         libs/detail
+                        libs/describe
                         libs/format
                         libs/function_types
                         libs/headers
@@ -38,6 +39,7 @@ ExternalProject_Add(boost-download
                         libs/iterator
                         libs/move
                         libs/mpl
+                        libs/mp11
                         libs/numeric/conversion
                         libs/optional
                         libs/predef

--- a/scripts/macos/psv/azure_macos_build_psv.sh
+++ b/scripts/macos/psv/azure_macos_build_psv.sh
@@ -21,7 +21,6 @@
 mkdir -p build
 cd build
 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-    -DCMAKE_CXX_FLAGS="-Wno-deprecated-builtins -Wno-deprecated-declarations -Wno-deprecated-copy" \
     -DOLP_SDK_BUILD_EXAMPLES=ON \
     -DBUILD_SHARED_LIBS=ON \
     -DOLP_SDK_ENABLE_TESTING=NO \


### PR DESCRIPTION
Update boost dependency.
Use newer boost v 1.82.0
Remove workaround in compilation.

Relates-To: DATASDK-52

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>