### PR TITLE
Add project scope to the settings

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/Settings.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/Settings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,6 +104,11 @@ struct AUTHENTICATION_API Settings {
    * treated.
    */
   client::RetrySettings retry_settings;
+
+  /**
+   * @brief (Optional) The scope to be assigned to an access token requests.
+   */
+  boost::optional<std::string> scope;
 };
 
 }  // namespace authentication

--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenResult.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenResult.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <boost/optional.hpp>
 #include <chrono>
 #include <ctime>
 #include <string>
@@ -43,16 +44,20 @@ class AUTHENTICATION_API TokenResult {
    * @param access_token The access token issued by the authorization server.
    * @param expiry_time The Epoch time when the token expires, or -1 if
    * the token is invalid.
+   * @param scope The scope assigned to the access token.
    */
-  TokenResult(std::string access_token, time_t expiry_time);
+  TokenResult(std::string access_token, time_t expiry_time,
+              boost::optional<std::string> scope);
 
   /**
    * @brief Creates the `TokenResult` instance.
    *
    * @param access_token The access token issued by the authorization server.
    * @param expires_in The expiry time of the access token.
+   * @param scop The scope assigned to the access token.
    */
-  TokenResult(std::string access_token, std::chrono::seconds expires_in);
+  TokenResult(std::string access_token, std::chrono::seconds expires_in,
+              boost::optional<std::string> scope);
   /**
    * @brief Creates the default `TokenResult` instance.
    */
@@ -81,10 +86,19 @@ class AUTHENTICATION_API TokenResult {
    */
   std::chrono::seconds GetExpiresIn() const;
 
+  /**
+   * @brief Gets the scope that is assigned to the access token.
+   *
+   * @return The optional string that contains the scope assigned to the access
+   * token.
+   */
+  const boost::optional<std::string>& GetScope() const;
+
  private:
   std::string access_token_;
   time_t expiry_time_{};
   std::chrono::seconds expires_in_{};
+  boost::optional<std::string> scope_;
 };
 
 }  // namespace authentication

--- a/olp-cpp-sdk-authentication/src/TokenEndpointImpl.h
+++ b/olp-cpp-sdk-authentication/src/TokenEndpointImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 HERE Europe B.V.
+ * Copyright (C) 2021-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@
  */
 
 #pragma once
+
+#include <boost/optional.hpp>
+#include <string>
 
 #include <olp/authentication/AuthenticationClient.h>
 #include <olp/authentication/AuthenticationCredentials.h>
@@ -87,6 +90,7 @@ class TokenEndpointImpl {
                                   client::CancellationContext& context) const;
 
   const AuthenticationCredentials credentials_;
+  const boost::optional<std::string> scope_;
   const AuthenticationSettings settings_;
   AuthenticationClient auth_client_;
 };

--- a/olp-cpp-sdk-authentication/src/TokenResult.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenResult.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,16 +21,22 @@
 
 namespace olp {
 namespace authentication {
-TokenResult::TokenResult(std::string access_token, time_t expiry_time)
-    : access_token_(std::move(access_token)), expiry_time_(expiry_time) {
+TokenResult::TokenResult(std::string access_token, time_t expiry_time,
+                         boost::optional<std::string> scope)
+    : access_token_(std::move(access_token)),
+      expiry_time_(expiry_time),
+      scope_(std::move(scope)) {
   const auto now = std::time(nullptr);
   expires_in_ =
       std::chrono::seconds(expiry_time_ > now ? (expiry_time_ - now) : 0);
 }
 
 TokenResult::TokenResult(std::string access_token,
-                         std::chrono::seconds expires_in)
-    : access_token_(std::move(access_token)), expires_in_(expires_in) {
+                         std::chrono::seconds expires_in,
+                         boost::optional<std::string> scope)
+    : access_token_(std::move(access_token)),
+      expires_in_(expires_in),
+      scope_(std::move(scope)) {
   expiry_time_ = std::time(nullptr) + expires_in_.count();
 }
 
@@ -39,6 +45,10 @@ const std::string& TokenResult::GetAccessToken() const { return access_token_; }
 time_t TokenResult::GetExpiryTime() const { return expiry_time_; }
 
 std::chrono::seconds TokenResult::GetExpiresIn() const { return expires_in_; }
+
+const boost::optional<std::string>& TokenResult::GetScope() const {
+  return scope_;
+}
 
 }  // namespace authentication
 }  // namespace olp

--- a/tests/common/matchers/NetworkUrlMatchers.h
+++ b/tests/common/matchers/NetworkUrlMatchers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,6 +91,13 @@ MATCHER_P(BodyEq, expected_body, "") {
              ? std::equal(expected_body_str.begin(), expected_body_str.end(),
                           arg.GetBody()->begin())
              : expected_body_str.empty();
+}
+
+MATCHER_P(BodyContains, expected_substring, "") {
+  const std::string sstr(expected_substring);
+  const auto& body = arg.GetBody();
+  return std::search(body->cbegin(), body->cend(), sstr.cbegin(),
+                     sstr.cend()) != body->cend();
 }
 
 MATCHER_P(HeadersContain, expected_header, "") {

--- a/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-authentication/AuthenticationClientTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 HERE Europe B.V.
+ * Copyright (C) 2019-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -410,7 +410,10 @@ TEST_F(AuthenticationClientTest, SignInClientUseWrongLocalTime) {
 TEST_F(AuthenticationClientTest, SignInClientScope) {
   ExpectTimestampRequest(*network_);
 
-  EXPECT_CALL(*network_, Send(IsPostRequest(kRequestAuth), _, _, _, _))
+  EXPECT_CALL(*network_,
+              Send(testing::AllOf(IsPostRequest(kRequestAuth),
+                                  BodyContains("\"scope\":\"scope\"")),
+                   _, _, _, _))
       .WillOnce(ReturnHttpResponse(GetResponse(http::HttpStatusCode::OK),
                                    kResponseWithScope));
 


### PR DESCRIPTION
It is attached to the token request and can be used on server side in the authentication process.

Relates-To: DATASDK-8