### PR TITLE
Enable SAX parser to handle compressedDataSize

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsSaxHandler.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsSaxHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 HERE Europe B.V.
+ * Copyright (C) 2023-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,11 +79,13 @@ bool PartitionsSaxHandler::String(const char* str, unsigned int length, bool) {
     case State::kParsingIgnoreAttribute:
       break;
 
-    case State::kWaitForRootObject:     // Not expected
-    case State::kWaitForNextPartition:  // Not expected
-    case State::kWaitForRootObjectEnd:  // Not expected
-    case State::kParsingVersion:        // Version is not a string
-    case State::kParsingDataSize:       // DataSize is not a string
+    case State::kWaitForRootObject:          // Not expected
+    case State::kWaitForNextPartition:       // Not expected
+    case State::kWaitForRootObjectEnd:       // Not expected
+    case State::kParsingVersion:             // Version is not a string
+    case State::kParsingDataSize:            // DataSize is not a string
+    case State::kParsingCompressedDataSize:  // CompressedDataSize is not a
+                                             // string
     default:
       return false;
   }
@@ -98,6 +100,8 @@ bool PartitionsSaxHandler::Uint(unsigned int value) {
     partition_.SetVersion(value);
   } else if (state_ == State::kParsingDataSize) {
     partition_.SetDataSize(value);
+  } else if (state_ == State::kParsingCompressedDataSize) {
+    partition_.SetCompressedDataSize(value);
   } else {
     return false;
   }
@@ -162,6 +166,8 @@ PartitionsSaxHandler::State PartitionsSaxHandler::ProcessNextAttribute(
       return State::kParsingChecksum;
     case HashStringToInt("dataSize"):
       return State::kParsingDataSize;
+    case HashStringToInt("compressedDataSize"):
+      return State::kParsingCompressedDataSize;
     case HashStringToInt("version"):
       return State::kParsingVersion;
     case HashStringToInt("crc"):

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsSaxHandler.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsSaxHandler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 HERE Europe B.V.
+ * Copyright (C) 2023-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,6 +70,7 @@ class PartitionsSaxHandler
     kParsingDataHandle,
     kParsingChecksum,
     kParsingDataSize,
+    kParsingCompressedDataSize,
     kParsingCrc,
     kParsingIgnoreAttribute,
 

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsSaxHandlerTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsSaxHandlerTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 HERE Europe B.V.
+ * Copyright (C) 2023-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ const char* kDataHandle = "dataHandle";
 const char* kPartition = "partition";
 const char* kChecksum = "checksum";
 const char* kDataSize = "dataSize";
+const char* kCompressedDataSize = "compressedDataSize";
 const char* kVersion = "version";
 const char* kCrc = "crc";
 
@@ -65,6 +66,8 @@ TEST(PartitionsSaxHandlerTest, NormalFlow) {
   ASSERT_TRUE(handler.String(kChecksumValue, len(kChecksumValue), true));
   ASSERT_TRUE(handler.String(kDataSize, len(kDataSize), true));
   ASSERT_TRUE(handler.Uint(150));
+  ASSERT_TRUE(handler.String(kCompressedDataSize, len(kCompressedDataSize), true));
+  ASSERT_TRUE(handler.Uint(100));
   ASSERT_TRUE(handler.String(kVersion, len(kVersion), true));
   ASSERT_TRUE(handler.Uint(6));
   ASSERT_TRUE(handler.String(kCrc, len(kCrc), true));
@@ -80,6 +83,7 @@ TEST(PartitionsSaxHandlerTest, NormalFlow) {
             std::string(kChecksumValue));
   EXPECT_EQ(parsed_partition.GetCrc().get_value_or(""), std::string(kCrcValue));
   EXPECT_EQ(parsed_partition.GetDataSize().get_value_or(0), 150);
+  EXPECT_EQ(parsed_partition.GetCompressedDataSize().get_value_or(0), 100);
   EXPECT_EQ(parsed_partition.GetVersion().get_value_or(0), 6);
 }
 


### PR DESCRIPTION
Parser was not expecting compressedDataSize field and failed to parse the JSON.

Relates-To: OCMAM-223