### PR TITLE
Do not propagate -Werror from leveldb

### DIFF
--- a/external/leveldb/CMakeLists-leveldb.txt
+++ b/external/leveldb/CMakeLists-leveldb.txt
@@ -247,7 +247,10 @@ endif(BUILD_SHARED_LIBS)
 if(HAVE_CLANG_THREAD_SAFETY)
   target_compile_options(leveldb
     PUBLIC
-      -Werror -Wthread-safety)
+      -Wthread-safety
+    PRIVATE
+      -Werror
+  )
 endif(HAVE_CLANG_THREAD_SAFETY)
 
 if(HAVE_CRC32C)


### PR DESCRIPTION
Setting -Werror as PUBLIC flag means that all targets that link to leveldb will stop compiling on the first warning. An intermediate library must never propagate that flag to parent projects.

Relates-To: MINOR