### PR TITLE
Add path tiling utils

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -23,14 +23,14 @@ find_package(RapidJSON 1.1.0 REQUIRED)
 find_package(Boost REQUIRED)
 find_package(Threads REQUIRED)
 
-if(OLP_SDK_ENABLE_DEFAULT_CACHE)
+if (OLP_SDK_ENABLE_DEFAULT_CACHE)
     find_package(Snappy REQUIRED)
     find_package(leveldb REQUIRED)
-endif()
+endif ()
 
-if(OLP_SDK_ENABLE_DEFAULT_CACHE_LMDB)
+if (OLP_SDK_ENABLE_DEFAULT_CACHE_LMDB)
     find_package(lmdb REQUIRED)
-endif()
+endif ()
 
 configure_file(./include/olp/core/Config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/olp/core/Config.h)
 
@@ -39,293 +39,295 @@ include(cmake/CompileChecks.cmake)
 
 porting_do_checks()
 
-if(OLP_SDK_ENABLE_OFFLINE_MODE OR IOS OR (WIN32 AND NOT MINGW))
+if (OLP_SDK_ENABLE_OFFLINE_MODE OR IOS OR (WIN32 AND NOT MINGW))
     set(NETWORK_NO_CURL ON)
-elseif(ANDROID)
-    if(OLP_SDK_ENABLE_ANDROID_CURL)
+elseif (ANDROID)
+    if (OLP_SDK_ENABLE_ANDROID_CURL)
         set(NETWORK_NO_CURL OFF)
         find_package(CURL 7.52.0 REQUIRED)
-    else()
+    else ()
         find_package(Java REQUIRED)
         set(NETWORK_NO_CURL ON)
-    endif()
-else()
+    endif ()
+else ()
     set(NETWORK_NO_CURL OFF)
     find_package(CURL 7.52.0 REQUIRED)
-endif()
+endif ()
 
 set(Network_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
-if(OLP_SDK_ENABLE_OFFLINE_MODE)
+if (OLP_SDK_ENABLE_OFFLINE_MODE)
     include(cmake/offline.cmake)
-else()
+else ()
     include(cmake/curl.cmake)
     include(cmake/winhttp.cmake)
     include(cmake/android.cmake)
     include(cmake/ios.cmake)
-endif()
+endif ()
 
 set(OLP_SDK_CACHE_HEADERS
-    ./include/olp/core/cache/CacheSettings.h
-    ./include/olp/core/cache/DefaultCache.h
-    ./include/olp/core/cache/KeyGenerator.h
-    ./include/olp/core/cache/KeyValueCache.h
+        ./include/olp/core/cache/CacheSettings.h
+        ./include/olp/core/cache/DefaultCache.h
+        ./include/olp/core/cache/KeyGenerator.h
+        ./include/olp/core/cache/KeyValueCache.h
 )
 
 set(OLP_SDK_CLIENT_HEADERS
-    ./include/olp/core/client/ApiError.h
-    ./include/olp/core/client/ApiLookupClient.h
-    ./include/olp/core/client/ApiNoResult.h
-    ./include/olp/core/client/ApiResponse.h
-    ./include/olp/core/client/BackdownStrategy.h
-    ./include/olp/core/client/CancellationContext.h
-    ./include/olp/core/client/CancellationContext.inl
-    ./include/olp/core/client/CancellationToken.h
-    ./include/olp/core/client/Condition.h
-    ./include/olp/core/client/DefaultLookupEndpointProvider.h
-    ./include/olp/core/client/ErrorCode.h
-    ./include/olp/core/client/FetchOptions.h
-    ./include/olp/core/client/HRN.h
-    ./include/olp/core/client/HttpResponse.h
-    ./include/olp/core/client/OauthToken.h
-    ./include/olp/core/client/OlpClient.h
-    ./include/olp/core/client/OlpClientFactory.h
-    ./include/olp/core/client/OlpClientSettings.h
-    ./include/olp/core/client/OlpClientSettingsFactory.h
-    ./include/olp/core/client/PendingRequests.h
-    ./include/olp/core/client/RetrySettings.h
-    ./include/olp/core/client/TaskContext.h
+        ./include/olp/core/client/ApiError.h
+        ./include/olp/core/client/ApiLookupClient.h
+        ./include/olp/core/client/ApiNoResult.h
+        ./include/olp/core/client/ApiResponse.h
+        ./include/olp/core/client/BackdownStrategy.h
+        ./include/olp/core/client/CancellationContext.h
+        ./include/olp/core/client/CancellationContext.inl
+        ./include/olp/core/client/CancellationToken.h
+        ./include/olp/core/client/Condition.h
+        ./include/olp/core/client/DefaultLookupEndpointProvider.h
+        ./include/olp/core/client/ErrorCode.h
+        ./include/olp/core/client/FetchOptions.h
+        ./include/olp/core/client/HRN.h
+        ./include/olp/core/client/HttpResponse.h
+        ./include/olp/core/client/OauthToken.h
+        ./include/olp/core/client/OlpClient.h
+        ./include/olp/core/client/OlpClientFactory.h
+        ./include/olp/core/client/OlpClientSettings.h
+        ./include/olp/core/client/OlpClientSettingsFactory.h
+        ./include/olp/core/client/PendingRequests.h
+        ./include/olp/core/client/RetrySettings.h
+        ./include/olp/core/client/TaskContext.h
 )
 
 set(OLP_SDK_GENERATED_HEADERS
-    ./include/olp/core/generated/parser/JsonParser.h
-    ./include/olp/core/generated/parser/ParserWrapper.h
-    ./include/olp/core/generated/serializer/SerializerWrapper.h
+        ./include/olp/core/generated/parser/JsonParser.h
+        ./include/olp/core/generated/parser/ParserWrapper.h
+        ./include/olp/core/generated/serializer/SerializerWrapper.h
 )
 
 set(OLP_SDK_HTTP_HEADERS
-    ./include/olp/core/http/adapters/HarCaptureAdapter.h
-    ./include/olp/core/http/CertificateSettings.h
-    ./include/olp/core/http/HttpStatusCode.h
-    ./include/olp/core/http/Network.h
-    ./include/olp/core/http/HttpStatusCode.h
-    ./include/olp/core/http/NetworkConstants.h
-    ./include/olp/core/http/NetworkInitializationSettings.h
-    ./include/olp/core/http/NetworkProxySettings.h
-    ./include/olp/core/http/NetworkRequest.h
-    ./include/olp/core/http/NetworkResponse.h
-    ./include/olp/core/http/NetworkSettings.h
-    ./include/olp/core/http/NetworkTypes.h
-    ./include/olp/core/http/NetworkUtils.h
+        ./include/olp/core/http/adapters/HarCaptureAdapter.h
+        ./include/olp/core/http/CertificateSettings.h
+        ./include/olp/core/http/HttpStatusCode.h
+        ./include/olp/core/http/Network.h
+        ./include/olp/core/http/HttpStatusCode.h
+        ./include/olp/core/http/NetworkConstants.h
+        ./include/olp/core/http/NetworkInitializationSettings.h
+        ./include/olp/core/http/NetworkProxySettings.h
+        ./include/olp/core/http/NetworkRequest.h
+        ./include/olp/core/http/NetworkResponse.h
+        ./include/olp/core/http/NetworkSettings.h
+        ./include/olp/core/http/NetworkTypes.h
+        ./include/olp/core/http/NetworkUtils.h
 )
 
 set(OLP_SDK_MODEL_HEADERS
-    ./include/olp/core/client/model/Api.h
+        ./include/olp/core/client/model/Api.h
 )
 
 set(OLP_SDK_PLATFORM_HEADERS
-    ./include/olp/core/context/Context.h
+        ./include/olp/core/context/Context.h
 )
 
 set(OLP_SDK_PORTING_HEADERS
-    ./include/olp/core/porting/deprecated.h
-    ./include/olp/core/porting/export.h
-    ./include/olp/core/porting/make_unique.h
-    ./include/olp/core/porting/platform.h
-    ./include/olp/core/porting/shared_mutex.h
-    ./include/olp/core/porting/try_emplace.h
-    ./include/olp/core/porting/warning_disable.h
+        ./include/olp/core/porting/deprecated.h
+        ./include/olp/core/porting/export.h
+        ./include/olp/core/porting/make_unique.h
+        ./include/olp/core/porting/platform.h
+        ./include/olp/core/porting/shared_mutex.h
+        ./include/olp/core/porting/try_emplace.h
+        ./include/olp/core/porting/warning_disable.h
 )
 
 set(OLP_SDK_UTILS_HEADERS
-    ./include/olp/core/utils/Base64.h
-    ./include/olp/core/utils/Config.h
-    ./include/olp/core/utils/Credentials.h
-    ./include/olp/core/utils/Dir.h
-    ./include/olp/core/utils/LruCache.h
-    ./include/olp/core/utils/Thread.h
-    ./include/olp/core/utils/Url.h
-    ./include/olp/core/utils/WarningWorkarounds.h
+        ./include/olp/core/utils/Base64.h
+        ./include/olp/core/utils/Config.h
+        ./include/olp/core/utils/Credentials.h
+        ./include/olp/core/utils/Dir.h
+        ./include/olp/core/utils/LruCache.h
+        ./include/olp/core/utils/Thread.h
+        ./include/olp/core/utils/Url.h
+        ./include/olp/core/utils/WarningWorkarounds.h
 )
 
 set(OLP_SDK_LOGGING_HEADERS
-    ./include/olp/core/logging/Appender.h
-    ./include/olp/core/logging/Configuration.h
-    ./include/olp/core/logging/ConsoleAppender.h
-    ./include/olp/core/logging/DebugAppender.h
-    ./include/olp/core/logging/FileAppender.h
-    ./include/olp/core/logging/FilterGroup.h
-    ./include/olp/core/logging/Format.h
-    ./include/olp/core/logging/Level.h
-    ./include/olp/core/logging/Log.h
-    ./include/olp/core/logging/LogContext.h
-    ./include/olp/core/logging/LogMessage.h
-    ./include/olp/core/logging/MessageFormatter.h
+        ./include/olp/core/logging/Appender.h
+        ./include/olp/core/logging/Configuration.h
+        ./include/olp/core/logging/ConsoleAppender.h
+        ./include/olp/core/logging/DebugAppender.h
+        ./include/olp/core/logging/FileAppender.h
+        ./include/olp/core/logging/FilterGroup.h
+        ./include/olp/core/logging/Format.h
+        ./include/olp/core/logging/Level.h
+        ./include/olp/core/logging/Log.h
+        ./include/olp/core/logging/LogContext.h
+        ./include/olp/core/logging/LogMessage.h
+        ./include/olp/core/logging/MessageFormatter.h
 )
 
 set(OLP_SDK_THREAD_HEADERS
-    ./include/olp/core/thread/Atomic.h
-    ./include/olp/core/thread/Continuation.h
-    ./include/olp/core/thread/Continuation.inl
-    ./include/olp/core/thread/ExecutionContext.h
-    ./include/olp/core/thread/SyncQueue.h
-    ./include/olp/core/thread/SyncQueue.inl
-    ./include/olp/core/thread/TaskContinuation.h
-    ./include/olp/core/thread/TaskContinuation.inl
-    ./include/olp/core/thread/TaskScheduler.h
-    ./include/olp/core/thread/ThreadPoolTaskScheduler.h
-    ./include/olp/core/thread/TypeHelpers.h
+        ./include/olp/core/thread/Atomic.h
+        ./include/olp/core/thread/Continuation.h
+        ./include/olp/core/thread/Continuation.inl
+        ./include/olp/core/thread/ExecutionContext.h
+        ./include/olp/core/thread/SyncQueue.h
+        ./include/olp/core/thread/SyncQueue.inl
+        ./include/olp/core/thread/TaskContinuation.h
+        ./include/olp/core/thread/TaskContinuation.inl
+        ./include/olp/core/thread/TaskScheduler.h
+        ./include/olp/core/thread/ThreadPoolTaskScheduler.h
+        ./include/olp/core/thread/TypeHelpers.h
 )
 
 set(OLP_SDK_GEOCOORDINATES_HEADERS
-    ./include/olp/core/geo/coordinates/GeoCoordinates.h
-    ./include/olp/core/geo/coordinates/GeoCoordinates3d.h
-    ./include/olp/core/geo/coordinates/GeoPoint.h
-    ./include/olp/core/geo/coordinates/GeoRectangle.h
+        ./include/olp/core/geo/coordinates/GeoCoordinates.h
+        ./include/olp/core/geo/coordinates/GeoCoordinates3d.h
+        ./include/olp/core/geo/coordinates/GeoPoint.h
+        ./include/olp/core/geo/coordinates/GeoRectangle.h
 )
 
 set(OLP_SDP_GEOPROJECTION_HEADERS
-    ./include/olp/core/geo/projection/EarthConstants.h
-    ./include/olp/core/geo/projection/EquirectangularProjection.h
-    ./include/olp/core/geo/projection/IdentityProjection.h
-    ./include/olp/core/geo/projection/IProjection.h
-    ./include/olp/core/geo/projection/SphereProjection.h
-    ./include/olp/core/geo/projection/WebMercatorProjection.h
+        ./include/olp/core/geo/projection/EarthConstants.h
+        ./include/olp/core/geo/projection/EquirectangularProjection.h
+        ./include/olp/core/geo/projection/IdentityProjection.h
+        ./include/olp/core/geo/projection/IProjection.h
+        ./include/olp/core/geo/projection/SphereProjection.h
+        ./include/olp/core/geo/projection/WebMercatorProjection.h
 )
 
 set(OLP_SDK_GEOTILING_HEADERS
-    ./include/olp/core/geo/tiling/HalfQuadTreeSubdivisionScheme.h
-    ./include/olp/core/geo/tiling/ISubdivisionScheme.h
-    ./include/olp/core/geo/tiling/ITilingScheme.h
-    ./include/olp/core/geo/tiling/QuadTreeSubdivisionScheme.h
-    ./include/olp/core/geo/tiling/SubTiles.h
-    ./include/olp/core/geo/tiling/TileKey.h
-    ./include/olp/core/geo/tiling/TileKeyUtils.h
-    ./include/olp/core/geo/tiling/TileTreeTraverse.h
-    ./include/olp/core/geo/tiling/TilingScheme.h
-    ./include/olp/core/geo/tiling/TilingSchemeRegistry.h
+        ./include/olp/core/geo/tiling/HalfQuadTreeSubdivisionScheme.h
+        ./include/olp/core/geo/tiling/ISubdivisionScheme.h
+        ./include/olp/core/geo/tiling/ITilingScheme.h
+        ./include/olp/core/geo/tiling/PathTiling.h
+        ./include/olp/core/geo/tiling/QuadTreeSubdivisionScheme.h
+        ./include/olp/core/geo/tiling/SubTiles.h
+        ./include/olp/core/geo/tiling/TileKey.h
+        ./include/olp/core/geo/tiling/TileKeyUtils.h
+        ./include/olp/core/geo/tiling/TileTreeTraverse.h
+        ./include/olp/core/geo/tiling/TilingScheme.h
+        ./include/olp/core/geo/tiling/TilingSchemeRegistry.h
 )
 
 set(OLP_SDK_GEOTYPE_HEADER
-    ./include/olp/core/geo/Types.h
+        ./include/olp/core/geo/Types.h
 )
 
 set(OLP_SDK_CONFIG_HEADER
-    ${CMAKE_CURRENT_BINARY_DIR}/include/olp/core/Config.h
+        ${CMAKE_CURRENT_BINARY_DIR}/include/olp/core/Config.h
 )
 
 set(OLP_SDK_MATH_HEADERS
-    ./include/olp/core/math/AlignedBox.h
-    ./include/olp/core/math/Math.h
-    ./include/olp/core/math/Size.h
-    ./include/olp/core/math/Types.h
-    ./include/olp/core/math/Vector.h
+        ./include/olp/core/math/AlignedBox.h
+        ./include/olp/core/math/Math.h
+        ./include/olp/core/math/Size.h
+        ./include/olp/core/math/Types.h
+        ./include/olp/core/math/Vector.h
 )
 
 set(OLP_SDK_COREAPI_HEADERS
-    ./include/olp/core/CoreApi.h
+        ./include/olp/core/CoreApi.h
 )
 
 set(OLP_SDK_GEO_SOURCES
-    ./src/geo/coordinates/GeoCoordinates.cpp
-    ./src/geo/coordinates/GeoCoordinates3d.cpp
-    ./src/geo/coordinates/GeoRectangle.cpp
-    ./src/geo/projection/EquirectangularProjection.cpp
-    ./src/geo/projection/IdentityProjection.cpp
-    ./src/geo/projection/SphereProjection.cpp
-    ./src/geo/projection/WebMercatorProjection.cpp
-    ./src/geo/tiling/HalfQuadTreeSubdivisionScheme.cpp
-    ./src/geo/tiling/QuadTreeSubdivisionScheme.cpp
-    ./src/geo/tiling/TileKey.cpp
-    ./src/geo/tiling/TileKeyUtils.cpp
-    ./src/geo/tiling/TileTreeTraverse.cpp
+        ./src/geo/coordinates/GeoCoordinates.cpp
+        ./src/geo/coordinates/GeoCoordinates3d.cpp
+        ./src/geo/coordinates/GeoRectangle.cpp
+        ./src/geo/projection/EquirectangularProjection.cpp
+        ./src/geo/projection/IdentityProjection.cpp
+        ./src/geo/projection/SphereProjection.cpp
+        ./src/geo/projection/WebMercatorProjection.cpp
+        ./src/geo/tiling/HalfQuadTreeSubdivisionScheme.cpp
+        ./src/geo/tiling/PathTiling.cpp
+        ./src/geo/tiling/QuadTreeSubdivisionScheme.cpp
+        ./src/geo/tiling/TileKey.cpp
+        ./src/geo/tiling/TileKeyUtils.cpp
+        ./src/geo/tiling/TileTreeTraverse.cpp
 )
 
 set(OLP_SDK_CACHE_SOURCES
-    ./src/cache/DefaultCache.cpp
-    ./src/cache/DefaultCacheImpl.cpp
-    ./src/cache/DefaultCacheImpl.h
-    ./src/cache/DiskCache.cpp
-    ./src/cache/DiskCache.h
-    ./src/cache/DiskCacheEnv.cpp
-    ./src/cache/DiskCacheEnv.h
-    ./src/cache/DiskCacheSizeLimitEnv.cpp
-    ./src/cache/DiskCacheSizeLimitEnv.h
-    ./src/cache/DiskCacheSizeLimitWritableFile.cpp
-    ./src/cache/DiskCacheSizeLimitWritableFile.h
-    ./src/cache/KeyGenerator.cpp
-    ./src/cache/ProtectedKeyList.cpp
-    ./src/cache/ProtectedKeyList.h
-    ./src/cache/InMemoryCache.cpp
-    ./src/cache/InMemoryCache.h
-    ./src/cache/ReadOnlyEnv.cpp
-    ./src/cache/ReadOnlyEnv.h
+        ./src/cache/DefaultCache.cpp
+        ./src/cache/DefaultCacheImpl.cpp
+        ./src/cache/DefaultCacheImpl.h
+        ./src/cache/DiskCache.cpp
+        ./src/cache/DiskCache.h
+        ./src/cache/DiskCacheEnv.cpp
+        ./src/cache/DiskCacheEnv.h
+        ./src/cache/DiskCacheSizeLimitEnv.cpp
+        ./src/cache/DiskCacheSizeLimitEnv.h
+        ./src/cache/DiskCacheSizeLimitWritableFile.cpp
+        ./src/cache/DiskCacheSizeLimitWritableFile.h
+        ./src/cache/KeyGenerator.cpp
+        ./src/cache/ProtectedKeyList.cpp
+        ./src/cache/ProtectedKeyList.h
+        ./src/cache/InMemoryCache.cpp
+        ./src/cache/InMemoryCache.h
+        ./src/cache/ReadOnlyEnv.cpp
+        ./src/cache/ReadOnlyEnv.h
 )
 
 set(OLP_SDK_CLIENT_SOURCES
-    ./src/client/api/PlatformApi.cpp
-    ./src/client/api/PlatformApi.h
-    ./src/client/api/ResourcesApi.cpp
-    ./src/client/api/ResourcesApi.h
-    ./src/client/parser/ApiParser.cpp
-    ./src/client/parser/ApiParser.h
-    ./src/client/repository/ApiCacheRepository.cpp
-    ./src/client/repository/ApiCacheRepository.h
-    ./src/client/ApiLookupClient.cpp
-    ./src/client/ApiLookupClientImpl.cpp
-    ./src/client/ApiLookupClientImpl.h
-    ./src/client/CancellationToken.cpp
-    ./src/client/DefaultLookupEndpointProvider.cpp
-    ./src/client/HRN.cpp
-    ./src/client/OauthToken.cpp
-    ./src/client/OlpClient.cpp
-    ./src/client/OlpClientFactory.cpp
-    ./src/client/OlpClientSettingsFactory.cpp
-    ./src/client/PendingRequests.cpp
-    ./src/client/PendingUrlRequests.h
-    ./src/client/PendingUrlRequests.cpp
-    ./src/client/RetrySettings.cpp
-    ./src/client/Tokenizer.h
+        ./src/client/api/PlatformApi.cpp
+        ./src/client/api/PlatformApi.h
+        ./src/client/api/ResourcesApi.cpp
+        ./src/client/api/ResourcesApi.h
+        ./src/client/parser/ApiParser.cpp
+        ./src/client/parser/ApiParser.h
+        ./src/client/repository/ApiCacheRepository.cpp
+        ./src/client/repository/ApiCacheRepository.h
+        ./src/client/ApiLookupClient.cpp
+        ./src/client/ApiLookupClientImpl.cpp
+        ./src/client/ApiLookupClientImpl.h
+        ./src/client/CancellationToken.cpp
+        ./src/client/DefaultLookupEndpointProvider.cpp
+        ./src/client/HRN.cpp
+        ./src/client/OauthToken.cpp
+        ./src/client/OlpClient.cpp
+        ./src/client/OlpClientFactory.cpp
+        ./src/client/OlpClientSettingsFactory.cpp
+        ./src/client/PendingRequests.cpp
+        ./src/client/PendingUrlRequests.h
+        ./src/client/PendingUrlRequests.cpp
+        ./src/client/RetrySettings.cpp
+        ./src/client/Tokenizer.h
 )
 
 set(OLP_SDK_HTTP_SOURCES
-    ./src/http/adapters/HarCaptureAdapter.cpp
-    ./src/http/DefaultNetwork.cpp
-    ./src/http/DefaultNetwork.h
-    ./src/http/Network.cpp
-    ./src/http/NetworkProxySettings.cpp
-    ./src/http/NetworkRequest.cpp
-    ./src/http/NetworkResponse.cpp
-    ./src/http/NetworkSettings.cpp
-    ./src/http/NetworkTypes.cpp
-    ./src/http/NetworkUtils.cpp
+        ./src/http/adapters/HarCaptureAdapter.cpp
+        ./src/http/DefaultNetwork.cpp
+        ./src/http/DefaultNetwork.h
+        ./src/http/Network.cpp
+        ./src/http/NetworkProxySettings.cpp
+        ./src/http/NetworkRequest.cpp
+        ./src/http/NetworkResponse.cpp
+        ./src/http/NetworkSettings.cpp
+        ./src/http/NetworkTypes.cpp
+        ./src/http/NetworkUtils.cpp
 )
 
 set(OLP_SDK_PLATFORM_SOURCES
-    ./src/context/Context.cpp
-    ./src/context/ContextInternal.cpp
-    ./src/context/ContextInternal.h
+        ./src/context/Context.cpp
+        ./src/context/ContextInternal.cpp
+        ./src/context/ContextInternal.h
 )
 
 if (NOT OLP_SDK_ENABLE_OFFLINE_MODE)
     if (ANDROID)
         # http network Android implementation:
         set(OLP_SDK_HTTP_ANDROID_SOURCES
-            ./src/http/android/NetworkAndroid.h
-            ./src/http/android/NetworkAndroid.cpp
-            ./src/http/android/utils/JNIThreadBinder.h
-            ./src/http/android/utils/JNIScopedLocalReference.h
+                ./src/http/android/NetworkAndroid.h
+                ./src/http/android/NetworkAndroid.cpp
+                ./src/http/android/utils/JNIThreadBinder.h
+                ./src/http/android/utils/JNIScopedLocalReference.h
         )
 
         set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_ANDROID_SOURCES})
         set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_HAS_ANDROID)
-    endif()
+    endif ()
 
     if (UNIX AND (NOT ANDROID OR OLP_SDK_ENABLE_ANDROID_CURL))
         set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_CURL_SOURCES})
 
         set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_HAS_CURL)
-    endif()
+    endif ()
 
     if (IOS)
         set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_IOS_SOURCES})
@@ -333,257 +335,257 @@ if (NOT OLP_SDK_ENABLE_OFFLINE_MODE)
         set(OLP_SDK_PLATFORM_SOURCES ${OLP_SDK_PLATFORM_SOURCES} ${OLP_SDK_PLATFORM_IOS_SOURCES})
 
         set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_HAS_IOS)
-    endif()
+    endif ()
 
     if (WIN32)
         if (MINGW)
             set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_CURL_SOURCES})
             set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_HAS_CURL)
-        else()
+        else ()
             set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_WIN_SOURCES})
             set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_HAS_WINHTTP)
-        endif()
-    endif()
-else()
+        endif ()
+    endif ()
+else ()
     set(OLP_SDK_HTTP_SOURCES ${OLP_SDK_HTTP_SOURCES} ${OLP_SDK_HTTP_OFFLINE_SOURCES})
     set(OLP_SDK_DEFAULT_NETWORK_DEFINITION OLP_SDK_NETWORK_OFFLINE)
-endif()
+endif ()
 
 set(OLP_SDK_UTILS_SOURCES
-    ./src/utils/Base64.cpp
-    ./src/utils/BoostExceptionHandle.cpp
-    ./src/utils/Credentials.cpp
-    ./src/utils/Dir.cpp
-    ./src/utils/Thread.cpp
-    ./src/utils/Url.cpp
+        ./src/utils/Base64.cpp
+        ./src/utils/BoostExceptionHandle.cpp
+        ./src/utils/Credentials.cpp
+        ./src/utils/Dir.cpp
+        ./src/utils/Thread.cpp
+        ./src/utils/Url.cpp
 )
 
 set(OLP_SDK_LOGGING_SOURCES
-    ./src/logging/Configuration.cpp
-    ./src/logging/ConsoleAppender.cpp
-    ./src/logging/DebugAppender.cpp
-    ./src/logging/FileAppender.cpp
-    ./src/logging/FilterGroup.cpp
-    ./src/logging/Format.cpp
-    ./src/logging/Log.cpp
-    ./src/logging/LogContext.cpp
-    ./src/logging/MessageFormatter.cpp
-    ./src/logging/ThreadId.cpp
-    ./src/logging/ThreadId.h
+        ./src/logging/Configuration.cpp
+        ./src/logging/ConsoleAppender.cpp
+        ./src/logging/DebugAppender.cpp
+        ./src/logging/FileAppender.cpp
+        ./src/logging/FilterGroup.cpp
+        ./src/logging/Format.cpp
+        ./src/logging/Log.cpp
+        ./src/logging/LogContext.cpp
+        ./src/logging/MessageFormatter.cpp
+        ./src/logging/ThreadId.cpp
+        ./src/logging/ThreadId.h
 )
 
 set(OLP_SDK_THREAD_SOURCES
-    ./src/thread/Continuation.cpp
-    ./src/thread/ExecutionContext.cpp
-    ./src/thread/PriorityQueueExtended.h
-    ./src/thread/ThreadPoolTaskScheduler.cpp
+        ./src/thread/Continuation.cpp
+        ./src/thread/ExecutionContext.cpp
+        ./src/thread/PriorityQueueExtended.h
+        ./src/thread/ThreadPoolTaskScheduler.cpp
 )
 
 set(OLP_SDK_CORE_HEADERS
-    ${OLP_SDK_CACHE_HEADERS}
-    ${OLP_SDK_CLIENT_HEADERS}
-    ${OLP_SDK_GENERATED_HEADERS}
-    ${OLP_SDK_HTTP_HEADERS}
-    ${OLP_SDK_MODEL_HEADERS}
-    ${OLP_SDK_PLATFORM_HEADERS}
-    ${OLP_SDK_PORTING_HEADERS}
-    ${OLP_SDK_UTILS_HEADERS}
-    ${OLP_SDK_LOGGING_HEADERS}
-    ${OLP_SDK_THREAD_HEADERS}
-    ${OLP_SDK_MATH_HEADERS}
-    ${OLP_SDK_GEOCOORDINATES_HEADERS}
-    ${OLP_SDP_GEOPROJECTION_HEADERS}
-    ${OLP_SDK_GEOTILING_HEADERS}
-    ${OLP_SDK_COREAPI_HEADERS}
-    ${OLP_SDK_GEOTYPE_HEADER}
-    ${OLP_SDK_CONFIG_HEADER}
+        ${OLP_SDK_CACHE_HEADERS}
+        ${OLP_SDK_CLIENT_HEADERS}
+        ${OLP_SDK_GENERATED_HEADERS}
+        ${OLP_SDK_HTTP_HEADERS}
+        ${OLP_SDK_MODEL_HEADERS}
+        ${OLP_SDK_PLATFORM_HEADERS}
+        ${OLP_SDK_PORTING_HEADERS}
+        ${OLP_SDK_UTILS_HEADERS}
+        ${OLP_SDK_LOGGING_HEADERS}
+        ${OLP_SDK_THREAD_HEADERS}
+        ${OLP_SDK_MATH_HEADERS}
+        ${OLP_SDK_GEOCOORDINATES_HEADERS}
+        ${OLP_SDP_GEOPROJECTION_HEADERS}
+        ${OLP_SDK_GEOTILING_HEADERS}
+        ${OLP_SDK_COREAPI_HEADERS}
+        ${OLP_SDK_GEOTYPE_HEADER}
+        ${OLP_SDK_CONFIG_HEADER}
 )
 
 set(OLP_SDK_CORE_SOURCES
-    ${OLP_SDK_CLIENT_SOURCES}
-    ${OLP_SDK_HTTP_SOURCES}
-    ${OLP_SDK_PLATFORM_SOURCES}
-    ${OLP_SDK_UTILS_SOURCES}
-    ${OLP_SDK_LOGGING_SOURCES}
-    ${OLP_SDK_THREAD_SOURCES}
-    ${OLP_SDK_GEO_SOURCES}
+        ${OLP_SDK_CLIENT_SOURCES}
+        ${OLP_SDK_HTTP_SOURCES}
+        ${OLP_SDK_PLATFORM_SOURCES}
+        ${OLP_SDK_UTILS_SOURCES}
+        ${OLP_SDK_LOGGING_SOURCES}
+        ${OLP_SDK_THREAD_SOURCES}
+        ${OLP_SDK_GEO_SOURCES}
 )
 
-if(OLP_SDK_ENABLE_DEFAULT_CACHE)
+if (OLP_SDK_ENABLE_DEFAULT_CACHE)
     set(OLP_SDK_CORE_SOURCES ${OLP_SDK_CORE_SOURCES} ${OLP_SDK_CACHE_SOURCES})
-endif()
+endif ()
 
 add_library(${PROJECT_NAME} ${OLP_SDK_CORE_SOURCES} ${OLP_SDK_CORE_HEADERS})
 
 if (IOS AND OLP_SDK_ENABLE_IOS_BACKGROUND_DOWNLOAD)
     target_compile_definitions(${PROJECT_NAME}
-        PUBLIC OLP_SDK_NETWORK_IOS_BACKGROUND_DOWNLOAD)
-endif()
+            PUBLIC OLP_SDK_NETWORK_IOS_BACKGROUND_DOWNLOAD)
+endif ()
 
 if (OLP_SDK_DISABLE_DEBUG_LOGGING)
     target_compile_definitions(${PROJECT_NAME}
-        PUBLIC LOGGING_DISABLE_DEBUG_LEVEL)
-endif()
+            PUBLIC LOGGING_DISABLE_DEBUG_LEVEL)
+endif ()
 
 if (OLP_SDK_DISABLE_LOCATION_LOGGING)
     target_compile_definitions(${PROJECT_NAME}
-        PUBLIC LOGGING_DISABLE_LOCATION)
-endif()
+            PUBLIC LOGGING_DISABLE_LOCATION)
+endif ()
 
 target_compile_definitions(${PROJECT_NAME}
-    PRIVATE ${OLP_SDK_DEFAULT_NETWORK_DEFINITION})
+        PRIVATE ${OLP_SDK_DEFAULT_NETWORK_DEFINITION})
 
 if (OLP_SDK_NO_EXCEPTION AND NOT OLP_SDK_BOOST_THROW_EXCEPTION_EXTERNAL)
     target_compile_definitions(${PROJECT_NAME}
-        PRIVATE OLP_SDK_BOOST_THROW_EXCEPTION=1)
-endif()
+            PRIVATE OLP_SDK_BOOST_THROW_EXCEPTION=1)
+endif ()
 
 target_include_directories(${PROJECT_NAME} PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
-    $<BUILD_INTERFACE:${Boost_INCLUDE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+        $<BUILD_INTERFACE:${Boost_INCLUDE_DIR}>
 
-    $<BUILD_INTERFACE:${RapidJSON_INCLUDE_DIRS}/..>
+        $<BUILD_INTERFACE:${RapidJSON_INCLUDE_DIRS}/..>
 
-    $<INSTALL_INTERFACE:include>)
+        $<INSTALL_INTERFACE:include>)
 
 if (ANDROID)
     set(ADDITIONAL_LIBRARIES log)
-else()
+else ()
     set(ADDITIONAL_LIBRARIES)
-endif()
+endif ()
 
 if (HAVE_PTHREAD_SETNAME_NP)
     add_definitions(-DOLP_SDK_HAVE_PTHREAD_SETNAME_NP)
-endif()
+endif ()
 
 target_link_libraries(${PROJECT_NAME}
-    PUBLIC
+        PUBLIC
         ${ADDITIONAL_LIBRARIES}
         ${OLP_SDK_NETWORK_CURL_LIBRARIES}
         ${NETWORK_WINHTTP_LIBRARIES}
         ${CMAKE_THREAD_LIBS_INIT}
 )
 
-if(OLP_SDK_ENABLE_DEFAULT_CACHE)
+if (OLP_SDK_ENABLE_DEFAULT_CACHE)
     include(CheckCXXSymbolExists)
     check_cxx_symbol_exists(fdatasync "unistd.h" HAVE_FDATASYNC)
     check_cxx_symbol_exists(F_FULLFSYNC "fcntl.h" HAVE_FULLFSYNC)
     check_cxx_symbol_exists(O_CLOEXEC "fcntl.h" HAVE_O_CLOEXEC)
 
     target_include_directories(${PROJECT_NAME}
-        PUBLIC
-        $<BUILD_INTERFACE:${leveldb_INCLUDE_DIR}>
+            PUBLIC
+            $<BUILD_INTERFACE:${leveldb_INCLUDE_DIR}>
     )
     target_link_libraries(${PROJECT_NAME}
-        PRIVATE
-        leveldb::leveldb
+            PRIVATE
+            leveldb::leveldb
     )
 
-    if(HAVE_FDATASYNC)
+    if (HAVE_FDATASYNC)
         target_compile_definitions(${PROJECT_NAME}
-            PRIVATE
-            HAVE_FDATASYNC)
-    endif()
+                PRIVATE
+                HAVE_FDATASYNC)
+    endif ()
 
-    if(HAVE_FULLFSYNC)
+    if (HAVE_FULLFSYNC)
         target_compile_definitions(${PROJECT_NAME}
-            PRIVATE
-            HAVE_FULLFSYNC)
-    endif()
+                PRIVATE
+                HAVE_FULLFSYNC)
+    endif ()
 
-    if(HAVE_O_CLOEXEC)
+    if (HAVE_O_CLOEXEC)
         target_compile_definitions(${PROJECT_NAME}
-            PRIVATE
-            HAVE_O_CLOEXEC)
-    endif()
-endif()
+                PRIVATE
+                HAVE_O_CLOEXEC)
+    endif ()
+endif ()
 
-if(OLP_SDK_ENABLE_DEFAULT_CACHE_LMDB)
+if (OLP_SDK_ENABLE_DEFAULT_CACHE_LMDB)
     target_include_directories(${PROJECT_NAME}
-        PRIVATE
+            PRIVATE
             $<BUILD_INTERFACE:${lmdb_INCLUDE_DIR}>
     )
     target_link_libraries(${PROJECT_NAME}
-        PRIVATE
+            PRIVATE
             lmdb::lmdb
     )
-endif()
+endif ()
 
-if(IOS)
+if (IOS)
     if (CMAKE_GENERATOR MATCHES "Xcode")
-        set_target_properties (
+        set_target_properties(
                 ${PROJECT_NAME}
                 PROPERTIES
                 XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES
         )
-    else()
+    else ()
         target_compile_options(${PROJECT_NAME} PRIVATE "-fobjc-arc")
-    endif()
+    endif ()
 
     find_library(OLP_SDK_CORE_FOUNDATION_FRAMEWORK CoreFoundation)
     find_library(OLP_SDK_SECURITY_FRAMEWORK Security)
     find_library(OLP_SDK_CFNETWORK_FRAMEWORK CFNetwork)
 
     target_link_libraries(${PROJECT_NAME} PRIVATE ${OLP_SDK_CORE_FOUNDATION_FRAMEWORK}
-                                                  ${OLP_SDK_SECURITY_FRAMEWORK}
-                                                  ${OLP_SDK_CFNETWORK_FRAMEWORK})
-elseif(ANDROID AND NOT OLP_SDK_ENABLE_ANDROID_CURL AND NOT OLP_SDK_ENABLE_OFFLINE_MODE)
+            ${OLP_SDK_SECURITY_FRAMEWORK}
+            ${OLP_SDK_CFNETWORK_FRAMEWORK})
+elseif (ANDROID AND NOT OLP_SDK_ENABLE_ANDROID_CURL AND NOT OLP_SDK_ENABLE_OFFLINE_MODE)
     # Make sure that OlpHttpClient.jar is built before olp-cpp-sdk-core
     add_dependencies(${PROJECT_NAME} ${OLP_SDK_ANDROID_HTTP_CLIENT_JAR})
-endif()
+endif ()
 
-if(CURL_FOUND AND NOT MINGW)
+if (CURL_FOUND AND NOT MINGW)
     include(CheckIncludeFile)
     check_include_file(signal.h HAVE_SIGNAL_H)
-    if(HAVE_SIGNAL_H)
+    if (HAVE_SIGNAL_H)
         target_compile_definitions(${PROJECT_NAME}
-            PRIVATE HAVE_SIGNAL_H IGNORE_SIGPIPE)
-    endif()
-endif()
+                PRIVATE HAVE_SIGNAL_H IGNORE_SIGPIPE)
+    endif ()
+endif ()
 
 option(NETWORK_SSL_VERIFY_OVERRIDE
-    "Enable support for NETWORK_SSL_VERIFY environment variable to override SSL certificate verification" OFF)
-if(NETWORK_SSL_VERIFY_OVERRIDE)
+        "Enable support for NETWORK_SSL_VERIFY environment variable to override SSL certificate verification" OFF)
+if (NETWORK_SSL_VERIFY_OVERRIDE)
     target_compile_definitions(${PROJECT_NAME}
-        PRIVATE NETWORK_SSL_VERIFY_OVERRIDE)
-endif()
+            PRIVATE NETWORK_SSL_VERIFY_OVERRIDE)
+endif ()
 
 target_compile_definitions(${PROJECT_NAME}
-    PRIVATE THREAD_LIBRARY)
-if(BUILD_SHARED_LIBS)
+        PRIVATE THREAD_LIBRARY)
+if (BUILD_SHARED_LIBS)
     target_compile_definitions(${PROJECT_NAME}
-        PRIVATE THREAD_LIBRARY_DYNAMIC)
-endif()
+            PRIVATE THREAD_LIBRARY_DYNAMIC)
+endif ()
 
 target_compile_definitions(${PROJECT_NAME}
-    PRIVATE CORE_LIBRARY)
-if(BUILD_SHARED_LIBS)
+        PRIVATE CORE_LIBRARY)
+if (BUILD_SHARED_LIBS)
     target_compile_definitions(${PROJECT_NAME}
-        PUBLIC CORE_SHARED_LIBRARY)
-endif()
+            PUBLIC CORE_SHARED_LIBRARY)
+endif ()
 
 # install component
-install (FILES ${OLP_SDK_HTTP_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/http)
-install (FILES ${OLP_SDK_MODEL_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/model)
-install (FILES ${OLP_SDK_PLATFORM_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/platform)
-install (FILES ${OLP_SDK_PORTING_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/porting)
-install (FILES ${OLP_SDK_UTILS_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/utils)
-install (FILES ${OLP_SDK_THREAD_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/thread)
-install (FILES ${OLP_SDK_CACHE_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/cache)
-install (FILES ${OLP_SDK_CLIENT_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/client)
-install (FILES ${OLP_SDK_MATH_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/math)
-install (FILES ${OLP_SDK_GEOCOORDINATES_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/geo/coordinates)
-install (FILES ${OLP_SDP_GEOPROJECTION_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/geo/projection)
-install (FILES ${OLP_SDK_GEOTILING_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/geo/tiling)
-install (FILES ${OLP_SDK_LOGGING_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/logging)
-install (FILES ${OLP_SDK_COREAPI_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core)
-install (FILES ${OLP_SDK_GEOTYPE_HEADER} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/geo)
-install (FILES ${OLP_SDK_CONFIG_HEADER} DESTINATION ${INCLUDE_DIRECTORY}/olp/core)
+install(FILES ${OLP_SDK_HTTP_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/http)
+install(FILES ${OLP_SDK_MODEL_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/model)
+install(FILES ${OLP_SDK_PLATFORM_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/platform)
+install(FILES ${OLP_SDK_PORTING_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/porting)
+install(FILES ${OLP_SDK_UTILS_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/utils)
+install(FILES ${OLP_SDK_THREAD_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/thread)
+install(FILES ${OLP_SDK_CACHE_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/cache)
+install(FILES ${OLP_SDK_CLIENT_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/client)
+install(FILES ${OLP_SDK_MATH_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/math)
+install(FILES ${OLP_SDK_GEOCOORDINATES_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/geo/coordinates)
+install(FILES ${OLP_SDP_GEOPROJECTION_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/geo/projection)
+install(FILES ${OLP_SDK_GEOTILING_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/geo/tiling)
+install(FILES ${OLP_SDK_LOGGING_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/logging)
+install(FILES ${OLP_SDK_COREAPI_HEADERS} DESTINATION ${INCLUDE_DIRECTORY}/olp/core)
+install(FILES ${OLP_SDK_GEOTYPE_HEADER} DESTINATION ${INCLUDE_DIRECTORY}/olp/core/geo)
+install(FILES ${OLP_SDK_CONFIG_HEADER} DESTINATION ${INCLUDE_DIRECTORY}/olp/core)
 
 export_config()
 
-if(OLP_SDK_ENABLE_TESTING)
+if (OLP_SDK_ENABLE_TESTING)
     add_subdirectory(tests)
-endif()
+endif ()

--- a/olp-cpp-sdk-core/include/olp/core/geo/tiling/PathTiling.h
+++ b/olp-cpp-sdk-core/include/olp/core/geo/tiling/PathTiling.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <memory>
+#include <tuple>
+
+#include <olp/core/geo/coordinates/GeoCoordinates.h>
+#include <olp/core/geo/tiling/TileKey.h>
+
+#include <boost/optional/optional.hpp>
+#include <vector>
+
+namespace olp {
+namespace geo {
+
+class GeoSegmentsGeneratorBase {
+ public:
+  using Segment = std::tuple<GeoCoordinates, GeoCoordinates>;
+
+  virtual ~GeoSegmentsGeneratorBase() = default;
+
+  virtual boost::optional<Segment> Next() = 0;
+};
+
+template <typename InputIterator>
+class GeoSegmentsGenerator final : public GeoSegmentsGeneratorBase {
+ public:
+  GeoSegmentsGenerator(InputIterator begin, InputIterator end)
+      : pos_(begin), end_(end) {}
+
+  ~GeoSegmentsGenerator() override = default;
+
+  boost::optional<Segment> Next() override {
+    if (pos_ == end_) {
+      return boost::none;
+    }
+    const auto start = static_cast<GeoCoordinates>(*pos_);
+    std::advance(pos_, 1);
+    if (pos_ == end_) {
+      return boost::none;
+    }
+    const auto end = static_cast<GeoCoordinates>(*pos_);
+    return std::make_tuple(start, end);
+  }
+
+ private:
+  InputIterator pos_;
+  InputIterator end_;
+};
+
+template <typename InputIterator>
+std::shared_ptr<GeoSegmentsGeneratorBase> MakeGeoSegmentsGenerator(
+    InputIterator begin, InputIterator end) {
+  return std::make_shared<GeoSegmentsGenerator<InputIterator>>(begin, end);
+}
+
+class PathTilingGenerator {
+ public:
+  PathTilingGenerator(
+      std::shared_ptr<GeoSegmentsGeneratorBase> segments_generator,
+      std::shared_ptr<ITilingScheme> tiling_scheme, uint32_t tile_level,
+      uint32_t area_offset);
+
+  boost::optional<TileKey> Next();
+
+ private:
+  class PathTilingGeneratorImpl;
+  std::shared_ptr<PathTilingGeneratorImpl> impl_;
+};
+
+}  // namespace geo
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/geo/tiling/PathTiling.cpp
+++ b/olp-cpp-sdk-core/src/geo/tiling/PathTiling.cpp
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/core/geo/tiling/PathTiling.h>
+
+#include <unordered_set>
+
+#include <olp/core/geo/tiling/TileKey.h>
+#include <olp/core/geo/tiling/TileKeyUtils.h>
+
+#include <deque>
+
+#include "olp/core/geo/tiling/ISubdivisionScheme.h"
+#include "olp/core/geo/tiling/ITilingScheme.h"
+
+namespace olp {
+namespace geo {
+namespace {
+class BresenhamLineGenerator {
+ public:
+  BresenhamLineGenerator(const int x0, const int y0, const int x1, const int y1,
+                         const bool slope_reversed, const int radius)
+      : x_end_(x1),
+        is_slope_reversed_(slope_reversed),
+        radius_(radius),
+        delta_x_(x1 - x0),
+        delta_y_(std::abs(y1 - y0)),
+        y_step_(y0 > y1 ? -1 : 1),
+        x_(x0),
+        y_(y0),
+        error_(0),
+        a_(-radius_),
+        b_(-radius_) {}
+
+  bool Next(int& out_x, int& out_y) {
+    if (x_ > x_end_) {
+      return false;
+    }
+
+    out_x = x_ + a_;
+    out_y = y_ + b_;
+
+    if (is_slope_reversed_)
+      std::swap(out_x, out_y);
+
+    if (++b_ > radius_) {
+      b_ = -radius_;
+      if (++a_ > radius_) {
+        a_ = -radius_;
+
+        error_ += delta_y_;
+        if (2 * error_ >= delta_x_) {
+          y_ += y_step_;
+          error_ -= delta_x_;
+        }
+
+        ++x_;
+      }
+    }
+
+    return true;
+  }
+
+ private:
+  int x_end_;
+  bool is_slope_reversed_;
+  int radius_;
+  int delta_x_;
+  int delta_y_;
+  int y_step_;
+  int x_;
+  int y_;
+  int error_;
+  int a_;
+  int b_;
+};
+
+boost::optional<BresenhamLineGenerator> MakeBresenhamLineGenerator(
+    boost::optional<GeoSegmentsGeneratorBase::Segment> segment,
+    const int radius, const ITilingScheme& tiling_scheme,
+    const uint32_t tile_level) {
+  if (!segment) {
+    return boost::none;
+  }
+
+  const auto segment_start = olp::geo::TileKeyUtils::GeoCoordinatesToTileKey(
+      tiling_scheme, std::get<0>(*segment), tile_level);
+  const auto segment_end = olp::geo::TileKeyUtils::GeoCoordinatesToTileKey(
+      tiling_scheme, std::get<1>(*segment), tile_level);
+
+  int x0 = segment_start.Column();
+  int y0 = segment_start.Row();
+  int x1 = segment_end.Column();
+  int y1 = segment_end.Row();
+
+  const bool reversed_slope = std::abs(y1 - y0) > std::abs(x1 - x0);
+  if (reversed_slope) {
+    std::swap(x0, y0);
+    std::swap(x1, y1);
+  }
+  if (x0 > x1) {
+    std::swap(x0, x1);
+    std::swap(y0, y1);
+  }
+
+  return BresenhamLineGenerator(x0, y0, x1, y1, reversed_slope, radius);
+}
+
+}  // namespace
+
+// GeoPath -> GeoPairs -> TilePairs -> LineAlgorithm -> Expanding around
+
+class PathTilingGenerator::PathTilingGeneratorImpl {
+ public:
+  PathTilingGeneratorImpl(
+      std::shared_ptr<GeoSegmentsGeneratorBase> segments_generator,
+      std::shared_ptr<ITilingScheme> tiling_scheme, uint32_t tile_level,
+      uint32_t area_offset)
+      : segments_generator_(std::move(segments_generator)),
+        tiling_scheme_(std::move(tiling_scheme)),
+        tile_level_(tile_level),
+        area_offset_(area_offset),
+        bresenham_line_generator_(InitNextGenerator()) {}
+
+  boost::optional<TileKey> Next() {
+    if (!bresenham_line_generator_) {
+      return boost::none;
+    }
+
+    int x = 0, y = 0;
+    while (bresenham_line_generator_->Next(x, y)) {
+      const auto& sub_division_scheme = tiling_scheme_->GetSubdivisionScheme();
+      WrapAround(x, y, sub_division_scheme.GetLevelSize(tile_level_));
+
+      const auto tile = TileKey::FromRowColumnLevel(y, x, tile_level_);
+      const auto quad_key = tile.ToQuadKey64();
+
+      if (visited_tiles_hashes_.count(quad_key) != 0) {
+        continue;
+      }
+      // Remove excess tiles from queue
+      if (visited_tiles_hashes_queue_.size() >
+          area_offset_ * area_offset_ * 5) {
+        visited_tiles_hashes_.erase(visited_tiles_hashes_queue_.front());
+        visited_tiles_hashes_queue_.pop_front();
+      }
+
+      visited_tiles_hashes_.insert(quad_key);
+      return tile;
+    }
+
+    bresenham_line_generator_ = InitNextGenerator();
+
+    return Next();
+  }
+
+ private:
+  boost::optional<BresenhamLineGenerator> InitNextGenerator() const {
+    return MakeBresenhamLineGenerator(segments_generator_->Next(), area_offset_,
+                                      *tiling_scheme_, tile_level_);
+  }
+
+  static void WrapAround(int& x, int& y, const math::Size2u& dimensions) {
+    if (x < 0) {
+      x = x % dimensions.Width() + dimensions.Width();
+    } else if (x >= dimensions.Width()) {
+      x = x % dimensions.Width();
+    }
+
+    if (y < 0) {
+      y = y % dimensions.Height() + dimensions.Height();
+    } else if (y >= dimensions.Height()) {
+      y = y % dimensions.Height();
+    }
+  }
+
+  std::shared_ptr<GeoSegmentsGeneratorBase> segments_generator_;
+  std::shared_ptr<ITilingScheme> tiling_scheme_;
+  const uint32_t tile_level_;
+  const uint32_t area_offset_;
+
+  boost::optional<BresenhamLineGenerator> bresenham_line_generator_;
+
+  std::unordered_set<uint64_t> visited_tiles_hashes_;
+  std::deque<uint64_t> visited_tiles_hashes_queue_;
+};
+
+PathTilingGenerator::PathTilingGenerator(
+    std::shared_ptr<GeoSegmentsGeneratorBase> segments_generator,
+    std::shared_ptr<ITilingScheme> tiling_scheme, uint32_t tile_level,
+    uint32_t area_offset)
+    : impl_(std::make_shared<PathTilingGeneratorImpl>(
+          std::move(segments_generator), std::move(tiling_scheme), tile_level,
+          area_offset)) {}
+
+boost::optional<TileKey> PathTilingGenerator::Next() { return impl_->Next(); }
+
+}  // namespace geo
+}  // namespace olp

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -16,61 +16,62 @@
 # License-Filename: LICENSE
 
 set(OLP_CPP_SDK_CORE_TESTS_SOURCES
-    ./cache/DefaultCacheImplTest.cpp
-    ./cache/DefaultCacheTest.cpp
-    ./cache/Helpers.cpp
-    ./cache/Helpers.h
-    ./cache/InMemoryCacheTest.cpp
-    ./cache/KeyGeneratorTest.cpp
-    ./cache/ProtectedKeyListTest.cpp
+        ./cache/DefaultCacheImplTest.cpp
+        ./cache/DefaultCacheTest.cpp
+        ./cache/Helpers.cpp
+        ./cache/Helpers.h
+        ./cache/InMemoryCacheTest.cpp
+        ./cache/KeyGeneratorTest.cpp
+        ./cache/ProtectedKeyListTest.cpp
 
-    ./client/ApiLookupClientImplTest.cpp
-    ./client/ApiResponseTest.cpp
-    ./client/BackdownStrategyTest.cpp
-    ./client/CancellationContextTest.cpp
-    ./client/ConditionTest.cpp
-    ./client/DefaultLookupEndpointProviderTest.cpp
-    ./client/HRNTest.cpp
-    ./client/OlpClientSettingsFactoryTest.cpp
-    ./client/OlpClientTest.cpp
-    ./client/PendingUrlRequestsTest.cpp
-    ./client/TaskContextTest.cpp
+        ./client/ApiLookupClientImplTest.cpp
+        ./client/ApiResponseTest.cpp
+        ./client/BackdownStrategyTest.cpp
+        ./client/CancellationContextTest.cpp
+        ./client/ConditionTest.cpp
+        ./client/DefaultLookupEndpointProviderTest.cpp
+        ./client/HRNTest.cpp
+        ./client/OlpClientSettingsFactoryTest.cpp
+        ./client/OlpClientTest.cpp
+        ./client/PendingUrlRequestsTest.cpp
+        ./client/TaskContextTest.cpp
 
-    ./context/ContextTest.cpp
+        ./context/ContextTest.cpp
 
-    ./geo/coordinates/GeoCoordinates3dTest.cpp
-    ./geo/coordinates/GeoCoordinatesTest.cpp
-    ./geo/coordinates/GeoPointTest.cpp
-    ./geo/coordinates/GeoRectangleTest.cpp
-    ./geo/projection/EquirectangularProjectionTest.cpp
-    ./geo/projection/IdentityProjectionTest.cpp
-    ./geo/projection/SphereProjectionTest.cpp
-    ./geo/projection/WebMercatorProjectionTest.cpp
-    ./geo/tiling/SubdivisionSchemeTest.cpp
-    ./geo/tiling/SubTilesTest.cpp
-    ./geo/tiling/TileKeyTest.cpp
-    ./geo/tiling/TileKeyUtilsTest.cpp
+        ./geo/coordinates/GeoCoordinates3dTest.cpp
+        ./geo/coordinates/GeoCoordinatesTest.cpp
+        ./geo/coordinates/GeoPointTest.cpp
+        ./geo/coordinates/GeoRectangleTest.cpp
+        ./geo/projection/EquirectangularProjectionTest.cpp
+        ./geo/projection/IdentityProjectionTest.cpp
+        ./geo/projection/SphereProjectionTest.cpp
+        ./geo/projection/WebMercatorProjectionTest.cpp
+        ./geo/tiling/PathTilingTest.cpp
+        ./geo/tiling/SubdivisionSchemeTest.cpp
+        ./geo/tiling/SubTilesTest.cpp
+        ./geo/tiling/TileKeyTest.cpp
+        ./geo/tiling/TileKeyUtilsTest.cpp
 
-    ./logging/ConfigurationTest.cpp
-    ./logging/DisabledLoggingTest.cpp
-    ./logging/FileAppenderTest.cpp
-    ./logging/FilterGroupTest.cpp
-    ./logging/FormatTest.cpp
-    ./logging/LogTest.cpp
-    ./logging/MessageFormatterTest.cpp
-    ./logging/MockAppender.cpp
+        ./logging/ConfigurationTest.cpp
+        ./logging/DisabledLoggingTest.cpp
+        ./logging/FileAppenderTest.cpp
+        ./logging/FilterGroupTest.cpp
+        ./logging/FormatTest.cpp
+        ./logging/LogTest.cpp
+        ./logging/MessageFormatterTest.cpp
+        ./logging/MockAppender.cpp
 
-    ./thread/ContinuationTest.cpp
-    ./thread/ExecutionContextTest.cpp
-    ./thread/PriorityQueueExtendedTest.cpp
-    ./thread/SyncQueueTest.cpp
-    ./thread/TaskContinuationTest.cpp
-    ./thread/ThreadPoolTaskSchedulerTest.cpp
+        ./thread/ContinuationTest.cpp
+        ./thread/ExecutionContextTest.cpp
+        ./thread/PriorityQueueExtendedTest.cpp
+        ./thread/SyncQueueTest.cpp
+        ./thread/TaskContinuationTest.cpp
+        ./thread/ThreadPoolTaskSchedulerTest.cpp
 
-    ./http/NetworkSettingsTest.cpp
-    ./http/NetworkUtils.cpp
+        ./http/NetworkSettingsTest.cpp
+        ./http/NetworkUtils.cpp
 
-    ./utils/UtilsTest.cpp
+        ./utils/UtilsTest.cpp
 )
 
 if (ANDROID OR IOS)
@@ -78,7 +79,7 @@ if (ANDROID OR IOS)
 
     add_library(${OLP_SDK_CORE_TESTS_LIB} ${OLP_CPP_SDK_CORE_TESTS_SOURCES})
     target_link_libraries(${OLP_SDK_CORE_TESTS_LIB}
-        PRIVATE
+            PRIVATE
             custom-params
             gmock
             gtest
@@ -89,29 +90,29 @@ if (ANDROID OR IOS)
     # Some tests include private headers of core. This should be fixed in tests,
     # only then here.
     target_include_directories(${OLP_SDK_CORE_TESTS_LIB}
-        PRIVATE
+            PRIVATE
             ../src/cache
             ../src/client
     )
     if (ANDROID)
         include(${CMAKE_SOURCE_DIR}/cmake/android/gen_android_test.cmake)
         gen_android_test_runner(olp-cpp-sdk-core-tests
-            ${OLP_SDK_CORE_TESTS_LIB})
+                ${OLP_SDK_CORE_TESTS_LIB})
         add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/android
-            ${CMAKE_CURRENT_BINARY_DIR}/android)
+                ${CMAKE_CURRENT_BINARY_DIR}/android)
 
-    else()
+    else ()
         include(${CMAKE_SOURCE_DIR}/cmake/ios/gen_ios_test.cmake)
         gen_ios_test_runner(olp-cpp-sdk-core-tests ${OLP_SDK_CORE_TESTS_LIB})
         add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/ios
-            ${CMAKE_CURRENT_BINARY_DIR}/ios)
+                ${CMAKE_CURRENT_BINARY_DIR}/ios)
 
-    endif()
+    endif ()
 
-else()
+else ()
     add_executable(olp-cpp-sdk-core-tests ${OLP_CPP_SDK_CORE_TESTS_SOURCES})
     target_link_libraries(olp-cpp-sdk-core-tests
-        PRIVATE
+            PRIVATE
             custom-params
             gmock
             gtest
@@ -122,8 +123,8 @@ else()
     # Some tests include private headers of core. This should be fixed in tests,
     # only then here.
     target_include_directories(olp-cpp-sdk-core-tests
-    PRIVATE
-        ../src/cache
+            PRIVATE
+            ../src/cache
     )
 
-endif()
+endif ()

--- a/olp-cpp-sdk-core/tests/geo/tiling/PathTilingTest.cpp
+++ b/olp-cpp-sdk-core/tests/geo/tiling/PathTilingTest.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <olp/core/geo/tiling/PathTiling.h>
+
+#include "olp/core/geo/tiling/TilingSchemeRegistry.h"
+
+namespace olp {
+namespace geo {
+
+const auto kBerlin1 = GeoCoordinates::FromDegrees(52.514176, 13.339062);
+const auto kBerlin2 = GeoCoordinates::FromDegrees(52.517029, 13.387142);
+const auto kBerlin3 = GeoCoordinates::FromDegrees(52.490536, 13.397480);
+
+TEST(PathTilingTest, GeoSegmentsGenerator) {
+  std::vector<GeoCoordinates> coordinates{
+      kBerlin1,
+      kBerlin2,
+      kBerlin3,
+  };
+  auto generator =
+      MakeGeoSegmentsGenerator(coordinates.begin(), coordinates.end());
+  ASSERT_TRUE(generator->Next() == std::make_tuple(kBerlin1, kBerlin2));
+  ASSERT_TRUE(generator->Next() == std::make_tuple(kBerlin2, kBerlin3));
+  EXPECT_FALSE(generator->Next());
+}
+
+TEST(PathTilingTest, Path) {
+  std::vector<GeoCoordinates> coordinates{
+      kBerlin1,
+      kBerlin2,
+      kBerlin3,
+  };
+
+  auto generator =
+      MakeGeoSegmentsGenerator(coordinates.begin(), coordinates.end());
+  auto tiling_scheme = std::make_shared<HalfQuadTreeIdentityTilingScheme>();
+  auto path_generator = PathTilingGenerator(generator, tiling_scheme, 16, 1);
+  std::vector<uint64_t> tile_keys;
+
+  for (auto tile = path_generator.Next(); tile; tile = path_generator.Next()) {
+    tile_keys.push_back(tile->ToQuadKey64());
+  }
+
+  EXPECT_THAT(tile_keys,
+              testing::ElementsAre(
+                  6046300013, 6046300015, 6046300101, 6046300024, 6046300026,
+                  6046300112, 6046300025, 6046300027, 6046300113, 6046300028,
+                  6046300030, 6046300116, 6046300029, 6046300031, 6046300117,
+                  6046310952, 6046310954, 6046311040, 6046310953, 6046310955,
+                  6046311041, 6046311042, 6046311043, 6046310958, 6046311044,
+                  6046311046, 6046310959, 6046311045, 6046311047, 6046310970,
+                  6046311056, 6046311058, 6046310971, 6046311057, 6046311059,
+                  6046310974, 6046311060, 6046311062, 6046310937, 6046310940,
+                  6046310941, 6046310939, 6046310942, 6046310943, 6046310961,
+                  6046310964, 6046310965, 6046310963, 6046310966, 6046310967,
+                  6046310969, 6046310972, 6046310973, 6046310962, 6046310968));
+}
+
+}  // namespace geo
+}  // namespace olp


### PR DESCRIPTION
Add PathTilingGenerator class, used to generate tiles along the path. PathTilingGenerator is designed as a generator to enable long route traversal without keeping the list of tile keys.
To map the geo line to tile keys, a Bresenham algorith is used.

Relates-To: OCMAM-461