### PR TITLE
Fix the data race in NetworkCurl

### DIFF
--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.h
@@ -239,10 +239,11 @@ class NetworkCurl : public Network,
 
   /**
    * @brief Allocate new handle RequestHandle.
+   * @note Must be protected by event_mutex_
    *
    * @return Pointer to the allocated RequestHandle.
    */
-  RequestHandle* InitRequestHandle();
+  RequestHandle* InitRequestHandleUnsafe();
 
   /**
    * @brief Reset the handle after network request is done.


### PR DESCRIPTION
Fixed the RequestHandle initialization; it has to be protected with a mutex
Fixed the condition in cancel event handling to avoid canceling wrong requests

Relates-To: DATASDK-69