### PR TITLE
Increase parallel connection limit for iOS

### DIFF
--- a/olp-cpp-sdk-core/src/http/ios/OLPHttpClient.mm
+++ b/olp-cpp-sdk-core/src/http/ios/OLPHttpClient.mm
@@ -31,6 +31,7 @@
 
 namespace {
 constexpr auto kLogTag = "OLPHttpClient";
+constexpr auto kMaximumConnectionPerHost = 32;
 
 using SessionId = std::uint64_t;
 static SessionId sessionIdCounter_ = std::numeric_limits<SessionId>::min() + 1;
@@ -672,6 +673,8 @@ class EnterBackgroundSubscriberImpl
   } else {
     config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
   }
+
+  config.HTTPMaximumConnectionsPerHost = kMaximumConnectionPerHost;
 
   if (proxyDict) {
     config.connectionProxyDictionary = proxyDict;


### PR DESCRIPTION
Default number of parallel connection per host
is 6 for hardware iOS device. This limits the
speed of network stages of map download
and map update.
Increase this limit to 32 connections.

Relates-To: HERESDK-5947