### PR TITLE
Force CMake 3.5 for Snappy

### DIFF
--- a/external/leveldb/CMakeLists.txt.leveldb.in
+++ b/external/leveldb/CMakeLists.txt.leveldb.in
@@ -27,6 +27,7 @@ ExternalProject_Add(snappy
   GIT_SHALLOW       1
   INSTALL_DIR       "@EXTERNAL_BINARY_INSTALL_DIR@"
   CMAKE_ARGS        @COMMON_PLATFORM_FLAGS@
+                    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
                     -DCMAKE_BUILD_TYPE=@CMAKE_BUILD_TYPE@
                     -DCMAKE_INSTALL_LIBDIR=lib
                     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>


### PR DESCRIPTION
CMake 4.0 doesn't support cases when required version is too low

Relates-To: MINOR