### PR TITLE
Decrease allocations in QuadTreeIndex

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/BlobDataWriter.h
+++ b/olp-cpp-sdk-dataservice-read/src/BlobDataWriter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ class BlobDataWriter {
 };
 
 template <>
-bool BlobDataWriter::Write<std::string>(const std::string& value) {
+inline bool BlobDataWriter::Write<std::string>(const std::string& value) {
   if (write_offset_ + value.size() + 1 > data_.size()) {
     return false;
   }

--- a/olp-cpp-sdk-dataservice-read/src/ReleaseDependencyResolver.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ReleaseDependencyResolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 HERE Europe B.V.
+ * Copyright (C) 2020-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ ReleaseDependencyResolver::CheckProtectedTilesInQuad(
   // check if quad tree has other protected keys, if not, add quad key to
   // release from protected list, othervise add all protected keys left
   // for this quad to map
-  auto index_data = cached_tree.GetIndexData();
+  auto index_data = cached_tree.GetIndexData(QuadTreeIndex::DataHandle);
   TilesDataKeysType protected_keys;
   for (const auto& ind : index_data) {
     const auto tile_data_key = cache::KeyGenerator::CreateDataHandleKey(

--- a/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/VersionedLayerClientImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 HERE Europe B.V.
+ * Copyright (C) 2019-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -743,7 +743,7 @@ client::ApiNoResponse VersionedLayerClientImpl::DeleteFromCache(
     return result;
   }
 
-  auto index_data = cached_tree.GetIndexData();
+  auto index_data = cached_tree.GetIndexData(QuadTreeIndex::DataHandle);
   for (const auto& ind : index_data) {
     if (ind.tile_key != tile &&
         data_cache_repository.IsCached(layer_id_, ind.data_handle)) {

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 HERE Europe B.V.
+ * Copyright (C) 2019-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ constexpr std::int32_t kMaxQuadTreeIndexDepth = 4;
 
 SubQuadsResult FlattenTree(const QuadTreeIndex& tree) {
   SubQuadsResult result;
-  auto index_data = tree.GetIndexData();
+  auto index_data = tree.GetIndexData(QuadTreeIndex::DataHandle);
   for (auto& data : index_data) {
     const auto it = result.lower_bound(data.tile_key);
     if (it == result.end() || result.key_comp()(data.tile_key, it->first)) {
@@ -455,11 +455,12 @@ PrefetchTilesRepository::DownloadVersionedQuadTree(
       default_additional_fields, billing_tag_, context);
 
   if (quad_tree.GetStatus() != olp::http::HttpStatusCode::OK) {
-    OLP_SDK_LOG_WARNING_F(kLogTag,
-                          "GetSubQuads failed(%s, %" PRId64 ", %" PRId32
-                          "), status_code='%d'",
-                          tile_key.c_str(), version, depth, quad_tree.GetStatus());
-    return {client::ApiError(quad_tree.GetStatus(), quad_tree.GetResponseAsString()),
+    OLP_SDK_LOG_WARNING_F(
+        kLogTag,
+        "GetSubQuads failed(%s, %" PRId64 ", %" PRId32 "), status_code='%d'",
+        tile_key.c_str(), version, depth, quad_tree.GetStatus());
+    return {client::ApiError(quad_tree.GetStatus(),
+                             quad_tree.GetResponseAsString()),
             quad_tree.GetNetworkStatistics()};
   }
 


### PR DESCRIPTION
Added a `fields` parameter to GetIndexData method.
Change GetIndexData method to skip string fields which are not needed.

Relates-To: DATASDK-64