### PR TITLE
Allow CancellationContext in hashes

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/CancellationContext.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/CancellationContext.h
@@ -83,6 +83,7 @@ class CORE_API CancellationContext {
  private:
   /// A helper for unordered containers.
   friend struct CancellationContextHash;
+  friend struct CancellationContextEquality;
 
   /**
    * @brief An implementation used to shared the `CancellationContext` instance.
@@ -124,6 +125,22 @@ struct CORE_API CancellationContextHash {
    * @return The hash for the `CancellationContext` instance.
    */
   size_t operator()(const CancellationContext& context) const;
+};
+
+/**
+ * @brief A helper for unordered containers for equality comparison
+ */
+struct CORE_API CancellationContextEquality {
+  /**
+   * @brief Checks equality for two `CancellationContext` instances.
+   *
+   * @param lhs The first `CancellationContext` instance.
+   * @param rhs The second `CancellationContext` instance.
+   *
+   * @return True if both refer to the same implementation; false otherwise.
+   */
+  bool operator()(const CancellationContext& lhs,
+                  const CancellationContext& rhs) const;
 };
 
 }  // namespace client

--- a/olp-cpp-sdk-core/include/olp/core/client/CancellationContext.inl
+++ b/olp-cpp-sdk-core/include/olp/core/client/CancellationContext.inl
@@ -79,5 +79,10 @@ inline size_t CancellationContextHash::operator()(
       context.impl_);
 }
 
+inline bool CancellationContextEquality::operator()(
+    const CancellationContext& lhs, const CancellationContext& rhs) const {
+  return lhs.impl_ == rhs.impl_;
+}
+
 }  // namespace client
 }  // namespace olp


### PR DESCRIPTION
A hash needs a hashing function and a way to determin equality. Since we don't want to add a comparison operator, let's add another helper so we can store CancellationContext in std::unordered_set and friends.

Relates-To: MINOR