### PR TITLE
Skip internal keys' lookup in LRU for the DefaultCache.

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -881,7 +881,7 @@ OperationOutcomeEmpty DefaultCacheImpl::GetFromDiskCache(
 
     if (expiry > 0 || protected_keys_.IsProtected(key)) {
       // Entry didn't expire yet, we can still use it
-      if (!PromoteKeyLru(key)) {
+      if (!IsInternalKey(key) && !PromoteKeyLru(key)) {
         // If not found in LRU or not protected no need to look in disk cache
         // either.
         OLP_SDK_LOG_DEBUG_F(kLogTag,

--- a/olp-cpp-sdk-core/tests/cache/DefaultCacheImplTest.cpp
+++ b/olp-cpp-sdk-core/tests/cache/DefaultCacheImplTest.cpp
@@ -998,7 +998,6 @@ TEST_F(DefaultCacheImplTest, InternalKeysBypassLru) {
     const auto data_string{"this is key's data"};
     cache::CacheSettings settings;
     settings.disk_path_mutable = cache_path_;
-    settings.max_disk_storage = 2u * 1024u * 1024u;
     {
       settings.eviction_policy = cache::EvictionPolicy::kNone;
       DefaultCacheImplHelper cache(settings);

--- a/olp-cpp-sdk-core/tests/cache/DefaultCacheImplTest.cpp
+++ b/olp-cpp-sdk-core/tests/cache/DefaultCacheImplTest.cpp
@@ -995,29 +995,34 @@ TEST_F(DefaultCacheImplTest, InternalKeysBypassLru) {
     SCOPED_TRACE("Protect and release keys, which suppose to be evicted");
 
     const auto internal_key{"internal::protected::protected_data"};
+    const auto data_string{"this is key's data"};
     cache::CacheSettings settings;
     settings.disk_path_mutable = cache_path_;
     settings.max_disk_storage = 2u * 1024u * 1024u;
     {
+      settings.eviction_policy = cache::EvictionPolicy::kNone;
       DefaultCacheImplHelper cache(settings);
       ASSERT_EQ(olp::cache::DefaultCache::Success, cache.Open());
       cache.Clear();
-      const std::string key{"somekey"};
-      std::string data_string{"this is key's data"};
 
       constexpr auto expiry = 2;
-      EXPECT_TRUE(cache.Put(key, data_string,
+      EXPECT_TRUE(cache.Put(internal_key, data_string,
                             [data_string]() { return data_string; }, expiry));
-      ASSERT_TRUE(cache.Protect({key}));
     }
 
     settings.disk_path_mutable = cache_path_;
     settings.disk_path_protected.reset();
+    settings.eviction_policy = cache::EvictionPolicy::kLeastRecentlyUsed;
 
     DefaultCacheImplHelper cache(settings);
     ASSERT_EQ(olp::cache::DefaultCache::Success, cache.Open());
     // no keys was evicted
-    EXPECT_TRUE(cache.Get(internal_key));
+    auto stored_dats = cache.Get(internal_key);
+    ASSERT_TRUE(stored_dats);
+    std::string stored_string(
+        reinterpret_cast<const char*>(stored_dats->data()),
+        stored_dats->size());
+    EXPECT_EQ(stored_string, data_string);
     cache.Clear();
   }
 }

--- a/olp-cpp-sdk-core/tests/cache/DefaultCacheImplTest.cpp
+++ b/olp-cpp-sdk-core/tests/cache/DefaultCacheImplTest.cpp
@@ -1015,13 +1015,15 @@ TEST_F(DefaultCacheImplTest, InternalKeysBypassLru) {
 
     DefaultCacheImplHelper cache(settings);
     ASSERT_EQ(olp::cache::DefaultCache::Success, cache.Open());
-    // no keys was evicted
+
     auto stored_dats = cache.Get(internal_key);
     ASSERT_TRUE(stored_dats);
+
     std::string stored_string(
         reinterpret_cast<const char*>(stored_dats->data()),
         stored_dats->size());
     EXPECT_EQ(stored_string, data_string);
+
     cache.Clear();
   }
 }


### PR DESCRIPTION
Currently, for mutable cache, the key should be in the protected list or LRU to be read. Internal keys are pretty important and should have priority to be read without additional restrictions.

Relates-to: DATASDK-71