### PR TITLE
Github Actions updates

### DIFF
--- a/.github/workflows/psv_pipelines.yml
+++ b/.github/workflows/psv_pipelines.yml
@@ -91,18 +91,18 @@ jobs:
         run: gcc --version && ./scripts/linux/psv/build_psv.sh
         shell: bash
 
-  psv-linux-22-04-gcc13-build-no-cache:
-    name: PSV.Linux.22.04.gcc13.OLP_SDK_ENABLE_DEFAULT_CACHE=OFF
-    runs-on: ubuntu-22.04
+  psv-linux-latest-gcc14-build-no-cache:
+    name: PSV.Linux.latest.gcc14.OLP_SDK_ENABLE_DEFAULT_CACHE=OFF
+    runs-on: ubuntu-latest
     env:
       BUILD_TYPE: RelWithDebInfo
-      CC: gcc-13
-      CXX: g++-13
+      CC: gcc-14
+      CXX: g++-14
     steps:
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Install Ubuntu dependencies
-      run: sudo rm /etc/apt/sources.list.d/microsoft-prod.list && sudo add-apt-repository ppa:ubuntu-toolchain-r/test && sudo apt-get update && sudo apt-get install -y libboost-all-dev libssl-dev libcurl4-openssl-dev gcc-13 g++-13 --no-install-recommends
+      run: sudo rm /etc/apt/sources.list.d/microsoft-prod.list && sudo add-apt-repository ppa:ubuntu-toolchain-r/test && sudo apt-get update && sudo apt-get install -y libboost-all-dev libssl-dev libcurl4-openssl-dev gcc-14 g++-14 --no-install-recommends
       shell: bash
     - name: Compile project without cache
       run: ./scripts/linux/psv/build_psv_no_cache.sh
@@ -194,7 +194,7 @@ jobs:
       shell: bash
 
   psv-macos-15-arm64-xcode-16-build:
-    name: PSV.MacOS13.Xcode16
+    name: PSV.MacOS15.Xcode16
     runs-on: macos-15
     steps:
     - name: Check out repository
@@ -226,7 +226,7 @@ jobs:
           USE_LATEST_XCODE: 0
 
   psv-ios-os15-arm64-xcode-16-build:
-    name: PSV.iOS.MacOS13.Xcode16
+    name: PSV.iOS.MacOS15.Xcode16
     runs-on: macOS-15
     steps:
     - name: Check out repository
@@ -245,12 +245,12 @@ jobs:
         run: scripts/ios/azure_ios_build_psv.sh
         shell: bash
 
-  psv-win-16-vc2019-build:
-    name: PSV.Win.VC2019
-    runs-on: windows-2019
+  psv-win-17-vc2022-build:
+    name: PSV.Win.VC2022
+    runs-on: windows-2022
     env:
       BUILD_TYPE: RelWithDebInfo
-      GENERATOR: "Visual Studio 16 2019"
+      GENERATOR: "Visual Studio 17 2022"
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
- switch gcc13 to gcc14 on Ubuntu
- add job which is testing latest gcc in non-blocking
status using: continue-on-error: true
- when job become stable above flag to be removed on CI
- update windows from deprecated 2019 to 2022
- minor job naming update

Relates-To: OCMAM-532

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>