### PR TITLE
Custom body to be sent to URL from Credentials

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
@@ -83,6 +83,13 @@ class AUTHENTICATION_API AuthenticationClient {
      * than the default expiration time supported by the access token endpoint.
      */
     std::chrono::seconds expires_in{0};
+
+    /**
+     * @brief (Optional) Custom body to be passed, if authentication service
+     * requires it. Fully overrides default body and resets the request content
+     * type.
+     */
+    boost::optional<std::string> custom_body{boost::none};
   };
 
   /**

--- a/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.h
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.h
@@ -68,6 +68,8 @@ class AuthenticationClientImpl {
   using SignInUserCacheType =
       thread::Atomic<utils::LruCache<std::string, SignInUserResult>>;
 
+  static constexpr auto kApplicationJson = "application/json";
+
   explicit AuthenticationClientImpl(AuthenticationSettings settings);
   virtual ~AuthenticationClientImpl();
 
@@ -162,7 +164,8 @@ class AuthenticationClientImpl {
       const client::OlpClient& client, const std::string& endpoint,
       client::CancellationContext context,
       const AuthenticationCredentials& credentials,
-      client::OlpClient::RequestBodyType body, std::time_t timestamp);
+      client::OlpClient::RequestBodyType body, std::time_t timestamp,
+      const std::string& content_type = kApplicationJson);
 
   SignInResult ParseAuthResponse(int status, std::stringstream& auth_response);
 

--- a/olp-cpp-sdk-core/include/olp/core/utils/Url.h
+++ b/olp-cpp-sdk-core/include/olp/core/utils/Url.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include <olp/core/CoreApi.h>
+#include <boost/optional.hpp>
 
 namespace olp {
 namespace utils {
@@ -65,6 +66,22 @@ class CORE_API Url {
   static std::string Construct(
       const std::string& base, const std::string& path,
       const std::multimap<std::string, std::string>& query_params);
+
+  /**
+   * @brief Represents the host part and rest of full URL.
+   */
+  using HostAndRest = std::pair<std::string, std::string>;
+
+  /**
+   * @brief Separates full URL to the host part the rest. Helps to split URL
+   * from credentials to parts passed to the OlpClient and NetworkRequest.
+   *
+   * @param url Full URL.
+   *
+   * @return An optional pair representing host part and the rest of URL.
+   * Returns boost::none when url cannot be split.
+   */
+  static boost::optional<HostAndRest> ParseHostAndRest(const std::string& url);
 };
 
 }  // namespace utils

--- a/olp-cpp-sdk-core/src/utils/Url.cpp
+++ b/olp-cpp-sdk-core/src/utils/Url.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdio>
+#include <regex>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -122,6 +123,21 @@ std::string Url::Construct(
   }
 
   return url_ss.str();
+}
+
+boost::optional<Url::HostAndRest> Url::ParseHostAndRest(
+    const std::string& url) {
+  const auto host_and_rest_regex =
+      R"(^(.*:\/\/[A-Za-z0-9\-\.]+(:[0-9]+)?)(.*)$)";
+  std::regex regex{host_and_rest_regex};
+  std::smatch match;
+  if (!std::regex_search(url, match, regex) || match.size() != 4) {
+    return boost::none;
+  }
+
+  const auto host = std::string{match[1]};
+  const auto rest = std::string{match[3]};
+  return std::make_pair(host, rest);
 }
 
 }  // namespace utils


### PR DESCRIPTION
Here credentials file specifies the endpoint that
should be used to retrieve authentication token.
HNAV backend, which implements mTLS authentication also conforms to a bit different body and response schema.

Add a possibility to add a custom body for the authentication request and parsing of token from HNAV mTLS server.

Relates-To: HERESDK-7942