### PR TITLE
Avoid boost::optional::has_value()

### DIFF
--- a/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.cpp
@@ -156,7 +156,7 @@ client::HttpResponse CallApi(const client::OlpClient& client,
 }
 
 std::string DeduceContentType(const SignInProperties& properties) {
-  if (properties.custom_body.has_value()) {
+  if (properties.custom_body) {
     return "";
   }
   return AuthenticationClientImpl::kApplicationJson;
@@ -328,7 +328,7 @@ client::CancellationToken AuthenticationClientImpl::SignInClient(
     const auto credentials_endpoint = credentials.GetEndpointUrl();
     const auto maybe_host_and_rest =
         olp::utils::Url::ParseHostAndRest(credentials_endpoint);
-    if (maybe_host_and_rest.has_value()) {
+    if (maybe_host_and_rest) {
       const auto& host_and_rest = maybe_host_and_rest.value();
       olp_client_host = host_and_rest.first;
       endpoint = host_and_rest.second;
@@ -814,7 +814,7 @@ client::CancellationToken AuthenticationClientImpl::GetMyAccount(
 
 client::OlpClient::RequestBodyType AuthenticationClientImpl::GenerateClientBody(
     const SignInProperties& properties) {
-  if (properties.custom_body.has_value()) {
+  if (properties.custom_body) {
     const auto& content = properties.custom_body.value();
     return std::make_shared<RequestBodyData>(content.data(),
                                              content.data() + content.size());

--- a/olp-cpp-sdk-core/tests/utils/UrlTest.cpp
+++ b/olp-cpp-sdk-core/tests/utils/UrlTest.cpp
@@ -30,14 +30,14 @@ using UrlTest = testing::Test;
 TEST(UrlTest, ParseHostAndRest) {
   {
     SCOPED_TRACE("Bad Url");
-    EXPECT_FALSE(olp::utils::Url::ParseHostAndRest("bad url").has_value());
+    EXPECT_FALSE(olp::utils::Url::ParseHostAndRest("bad url"));
   }
 
   {
     SCOPED_TRACE("Good Url");
     const auto result = olp::utils::Url::ParseHostAndRest(
         "https://account.api.here.com/oauth2/token");
-    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result);
     const auto& host = result.value().first;
     const auto& rest = result.value().second;
     EXPECT_EQ(host, "https://account.api.here.com");
@@ -48,7 +48,7 @@ TEST(UrlTest, ParseHostAndRest) {
     SCOPED_TRACE("Good Url with port");
     const auto result = olp::utils::Url::ParseHostAndRest(
         "https://account.api.here.com:8080/oauth2/token");
-    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result);
     const auto& host = result.value().first;
     const auto& rest = result.value().second;
     EXPECT_EQ(host, "https://account.api.here.com:8080");


### PR DESCRIPTION
There are checks on old boost versions without this method

Relates-To: MINOR