### PR TITLE
Add clang-format check

### DIFF
--- a/.github/workflows/psv_pipelines.yml
+++ b/.github/workflows/psv_pipelines.yml
@@ -273,3 +273,49 @@ jobs:
     - name: Commit checker script. Verify commit text
       run: scripts/misc/commit_checker.sh
       shell: bash
+
+  psv-formatting-checker:
+    name: PSV.Clang.Format.Checker
+    runs-on: ubuntu-22.04
+    env:
+      CLANG_FORMAT_FILE: "clang-format.diff"
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Setup environment
+      run: |
+        set +x
+        set -e
+        sudo apt-get update
+        sudo apt-get install -y wget
+        mkdir _os_deps
+        cd _os_deps
+        wget https://apt.llvm.org/bionic/pool/main/l/llvm-toolchain-6.0/clang-format-6.0_6.0.1~svn334776-1~exp1~20190309042703.125_amd64.deb
+        wget https://apt.llvm.org/bionic/pool/main/l/llvm-toolchain-6.0/libllvm6.0_6.0.1~svn334776-1~exp1~20190309042703.125_amd64.deb
+        wget https://mirrors.edge.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
+        wget https://mirrors.edge.kernel.org/ubuntu/pool/universe/w/what-is-python/python-is-python2_2.7.17-4_all.deb
+        sudo apt-get install -y ./libffi6_3.2.1-8_amd64.deb
+        sudo apt-get install -y ./libllvm6.0_6.0.1~svn334776-1~exp1~20190309042703.125_amd64.deb
+        sudo apt-get remove python-is-python3
+        sudo apt-get install -y ./python-is-python2_2.7.17-4_all.deb
+        sudo apt-get install -y ./clang-format-6.0_6.0.1~svn334776-1~exp1~20190309042703.125_amd64.deb
+        cd ..
+      shell: bash
+    - name: "Clang format checker script"
+      run: ./scripts/misc/clang_format_ci.sh
+      shell: bash
+    - name: Store formatting check results
+      uses: actions/upload-artifact@v4
+      with:
+        name: clang-format-diff
+        path: ${{ env.CLANG_FORMAT_FILE }}
+    - name: Verify check result
+      run: |
+        set +x
+        if [ -s ${CLANG_FORMAT_FILE} ] ; then
+          echo "Unformatted files are detected. "
+          echo "You may apply provided patch. Download from the workflow summary and unpack to root of repository."
+          echo "Then run: git apply $CLANG_FORMAT_FILE"
+          exit 1
+        fi
+      shell: bash

--- a/scripts/misc/clang_format_ci.sh
+++ b/scripts/misc/clang_format_ci.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Copyright (C) 2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+#
+
+# Important 2 lines
+set +e
+set -x
+
+# This script gets the changed files in the pull request, and runs
+# clang-format tool to verify them
+
+# Get the current branch name
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+if [[ $CURRENT_BRANCH == "master" ]]; then
+  printf "Currently in master branch, skipping clang-format run.\n"
+  exit 0
+else
+  printf "Currently in %s branch. Running clang-foramt.\n" "$CURRENT_BRANCH"
+fi
+
+git branch --all
+git fetch origin master
+git branch --all
+# Get affected files and filter source files
+FILES=$(git diff-tree --no-commit-id --name-only -r origin/master "$CURRENT_BRANCH" \
+        | grep '\.c\|\.cpp\|\.cxx\|\.h\|\.hpp\|\.hxx')
+
+if [ -z "$FILES" ]; then
+  printf "No affected files, exiting.\n"
+  exit 0
+else
+  printf "Affected files:\n %s\n" "$FILES"
+fi
+
+printf "\n\n### Running clang-format - START ### \n\n"
+
+clang-format-6.0 -i ${FILES}
+RESULT=$?
+
+printf "\n\n### Running clang-format - DONE ### \n\n"
+
+if [ "$RESULT" -ne "0" ]; then
+  printf "\n\nClang-format failed!\n\n"
+  exit ${RESULT}
+fi
+
+CLANG_FORMAT_FILE=${CLANG_FORMAT_FILE:-clang-format.diff}
+git diff > ${CLANG_FORMAT_FILE}
+if [ -s ${CLANG_FORMAT_FILE} ] ; then
+  echo "Unformatted files are detected. "
+  echo "You may apply provided patch. Download from the workflow summary and unpack to root of repository."
+  echo "Then run: git apply $CLANG_FORMAT_FILE"
+  # No error here, otherwise github is skipping further steps so artifacts are not stored
+fi


### PR DESCRIPTION
There is no clang-format 6.0 binaries for current ubuntu versions.
Github pool has no old ubuntu images. So preparation steps are
downloading binaries from older ubuntu distros and installing them.

python-is-python2 symlinks python to python2 and covers clang-format 6.0
package requirement for python. python-is-python3 is conflicting with
the python-is-python2 thus removed
