### PR TITLE
Use std::optional if available.

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationClient.h
@@ -36,7 +36,7 @@
 #include <olp/authentication/Types.h>
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/CancellationToken.h>
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 
 /**
  * @brief Rules all the other namespaces.
@@ -65,7 +65,7 @@ class AUTHENTICATION_API AuthenticationClient {
     /**
      * @brief (Optional) The scope assigned to the access token.
      */
-    boost::optional<std::string> scope{boost::none};
+    porting::optional<std::string> scope{porting::none};
 
     /**
      * @brief (Optional) The device ID assigned to the access token.
@@ -73,7 +73,7 @@ class AUTHENTICATION_API AuthenticationClient {
      * @note This field is only necessary if you want to apply a oauth rate
      * limit on a particular device.
      */
-    boost::optional<std::string> device_id{boost::none};
+    porting::optional<std::string> device_id{porting::none};
 
     /**
      * @brief (Optional) The number of seconds left before the access
@@ -89,7 +89,7 @@ class AUTHENTICATION_API AuthenticationClient {
      * requires it. Fully overrides default body and resets the request content
      * type.
      */
-    boost::optional<std::string> custom_body{boost::none};
+    porting::optional<std::string> custom_body{olp::porting::none};
   };
 
   /**

--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationCredentials.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationCredentials.h
@@ -21,7 +21,7 @@
 
 #include <string>
 
-#include <boost/optional/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 #include "AuthenticationApi.h"
 
 namespace olp {
@@ -58,12 +58,13 @@ class AUTHENTICATION_API AuthenticationCredentials {
    * @return An optional value with your credentials if the credentials were
    * read successfully, or no value in case of failure.
    */
-  static boost::optional<AuthenticationCredentials> ReadFromStream(
+  static porting::optional<AuthenticationCredentials> ReadFromStream(
       std::istream& stream);
 
   /**
-   * @brief Parses the **credentials.properties** file downloaded from the [HERE platform](https://platform.here.com/)
-   * website and retrieves a value with your credentials.
+   * @brief Parses the **credentials.properties** file downloaded from the [HERE
+   * platform](https://platform.here.com/) website and retrieves a value with
+   * your credentials.
    *
    * The file must contain the following lines:
    * * here.access.key.id &ndash; your access key ID
@@ -81,7 +82,7 @@ class AUTHENTICATION_API AuthenticationCredentials {
    * @return The optional value with your credentials if the credentials were
    * read successfully, or no value in case of failure.
    */
-  static boost::optional<AuthenticationCredentials> ReadFromFile(
+  static porting::optional<AuthenticationCredentials> ReadFromFile(
       std::string filename = {});
   AuthenticationCredentials() = delete;
 

--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationSettings.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthenticationSettings.h
@@ -25,7 +25,7 @@
 #include <olp/authentication/AuthenticationApi.h>
 #include <olp/core/client/RetrySettings.h>
 #include <olp/core/http/NetworkProxySettings.h>
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 
 namespace olp {
 namespace http {
@@ -50,9 +50,9 @@ struct AUTHENTICATION_API AuthenticationSettings {
   /**
    * @brief The configuration settings for the network layer.
    *
-   * To remove any existing proxy settings, set to boost::none.
+   * To remove any existing proxy settings, set to olp::porting::none.
    */
-  boost::optional<http::NetworkProxySettings> network_proxy_settings{};
+  porting::optional<http::NetworkProxySettings> network_proxy_settings{};
 
   /**
    * @brief The network instance that is used to internally operate with the

--- a/olp-cpp-sdk-authentication/include/olp/authentication/AuthorizeRequest.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/AuthorizeRequest.h
@@ -19,11 +19,11 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <string>
 #include <vector>
 
 #include <olp/authentication/AuthenticationApi.h>
+#include <olp/core/porting/optional.hpp>
 
 namespace olp {
 namespace authentication {
@@ -83,7 +83,7 @@ class AUTHENTICATION_API AuthorizeRequest final {
    *
    * @return The service ID.
    */
-  inline const std::string& GetServiceId() const { return service_id_; }
+  const std::string& GetServiceId() const { return service_id_; }
 
   /**
    * @brief Sets the service ID.
@@ -92,7 +92,7 @@ class AUTHENTICATION_API AuthorizeRequest final {
    *
    * @return A reference to the updated `DecisionRequest` instance.
    */
-  inline AuthorizeRequest& WithServiceId(std::string service_id) {
+  AuthorizeRequest& WithServiceId(std::string service_id) {
     service_id_ = std::move(service_id);
     return *this;
   }
@@ -109,7 +109,7 @@ class AUTHENTICATION_API AuthorizeRequest final {
    *
    * @return The contract ID or an error.
    */
-  inline const boost::optional<std::string>& GetContractId() const {
+  const porting::optional<std::string>& GetContractId() const {
     return contract_id_;
   }
 
@@ -122,9 +122,9 @@ class AUTHENTICATION_API AuthorizeRequest final {
    *
    * @return A reference to the updated `DecisionRequest` instance.
    */
-  inline AuthorizeRequest& WithContractId(
-      boost::optional<std::string> contract_id) {
-    contract_id_ = std::move(contract_id);
+  template <class T = porting::optional<std::string>>
+  AuthorizeRequest& WithContractId(T&& contract_id) {
+    contract_id_ = std::forward<T>(contract_id);
     return *this;
   }
 
@@ -137,7 +137,7 @@ class AUTHENTICATION_API AuthorizeRequest final {
    *
    * @return A reference to the updated `DecisionRequest` instance.
    */
-  inline AuthorizeRequest& WithContractId(std::string contract_id) {
+  AuthorizeRequest& WithContractId(std::string contract_id) {
     contract_id_ = std::move(contract_id);
     return *this;
   }
@@ -159,8 +159,7 @@ class AUTHENTICATION_API AuthorizeRequest final {
    *
    * @return A reference to the updated `DecisionRequest` instance.
    */
-  inline AuthorizeRequest& WithAction(std::string action,
-                                      std::string resource = "") {
+  AuthorizeRequest& WithAction(std::string action, std::string resource = "") {
     actions_.emplace_back(std::move(action), std::move(resource));
     return *this;
   }
@@ -174,7 +173,7 @@ class AUTHENTICATION_API AuthorizeRequest final {
    *
    * @return The operator type.
    */
-  inline DecisionOperatorType GetOperatorType() const { return operator_type_; }
+  DecisionOperatorType GetOperatorType() const { return operator_type_; }
 
   /**
    * @brief Sets the operator type for the request.
@@ -185,8 +184,7 @@ class AUTHENTICATION_API AuthorizeRequest final {
    *
    * @return A reference to the updated `DecisionRequest` instance.
    */
-  inline AuthorizeRequest& WithOperatorType(
-      DecisionOperatorType operator_type) {
+  AuthorizeRequest& WithOperatorType(DecisionOperatorType operator_type) {
     operator_type_ = operator_type;
     return *this;
   }
@@ -196,7 +194,7 @@ class AUTHENTICATION_API AuthorizeRequest final {
    *
    * @return The diagnostics flag.
    */
-  inline bool GetDiagnostics() const { return diagnostics_; }
+  bool GetDiagnostics() const { return diagnostics_; }
 
   /**
    * @brief Sets the diagnostics flag for the request.
@@ -206,7 +204,7 @@ class AUTHENTICATION_API AuthorizeRequest final {
    *
    * @return A reference to the updated `DecisionRequest` instance.
    */
-  inline AuthorizeRequest& WithDiagnostics(bool diagnostics) {
+  AuthorizeRequest& WithDiagnostics(bool diagnostics) {
     diagnostics_ = diagnostics;
     return *this;
   }
@@ -220,7 +218,7 @@ class AUTHENTICATION_API AuthorizeRequest final {
 
  private:
   std::string service_id_;
-  boost::optional<std::string> contract_id_;
+  porting::optional<std::string> contract_id_;
   Actions actions_;
   DecisionOperatorType operator_type_{DecisionOperatorType::kAnd};
   bool diagnostics_{false};

--- a/olp-cpp-sdk-authentication/include/olp/authentication/Settings.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/Settings.h
@@ -19,12 +19,12 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <memory>
 #include <string>
 
 #include <olp/core/client/RetrySettings.h>
 #include <olp/core/http/NetworkProxySettings.h>
+#include <olp/core/porting/optional.hpp>
 
 #include "AuthenticationApi.h"
 #include "AuthenticationCredentials.h"
@@ -77,7 +77,7 @@ struct AUTHENTICATION_API Settings {
   /**
    * @brief (Optional) The configuration settings for the network layer.
    */
-  boost::optional<http::NetworkProxySettings> network_proxy_settings;
+  porting::optional<http::NetworkProxySettings> network_proxy_settings;
 
   /**
    * @brief (Optional) The server URL of the token endpoint.
@@ -108,7 +108,7 @@ struct AUTHENTICATION_API Settings {
   /**
    * @brief (Optional) The scope to be assigned to an access token requests.
    */
-  boost::optional<std::string> scope;
+  porting::optional<std::string> scope;
 };
 
 }  // namespace authentication

--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenResult.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenResult.h
@@ -19,11 +19,11 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <chrono>
 #include <ctime>
 #include <string>
 
+#include <olp/core/porting/optional.hpp>
 #include "AuthenticationApi.h"
 #include "ErrorResponse.h"
 
@@ -47,7 +47,7 @@ class AUTHENTICATION_API TokenResult {
    * @param scope The scope assigned to the access token.
    */
   TokenResult(std::string access_token, time_t expiry_time,
-              boost::optional<std::string> scope);
+              porting::optional<std::string> scope);
 
   /**
    * @brief Creates the `TokenResult` instance.
@@ -57,7 +57,7 @@ class AUTHENTICATION_API TokenResult {
    * @param scope The scope assigned to the access token.
    */
   TokenResult(std::string access_token, std::chrono::seconds expires_in,
-              boost::optional<std::string> scope);
+              porting::optional<std::string> scope);
   /**
    * @brief Creates the default `TokenResult` instance.
    */
@@ -92,13 +92,13 @@ class AUTHENTICATION_API TokenResult {
    * @return The optional string that contains the scope assigned to the access
    * token.
    */
-  const boost::optional<std::string>& GetScope() const;
+  const porting::optional<std::string>& GetScope() const;
 
  private:
   std::string access_token_;
   time_t expiry_time_{};
   std::chrono::seconds expires_in_{};
-  boost::optional<std::string> scope_;
+  porting::optional<std::string> scope_;
 };
 
 }  // namespace authentication

--- a/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.cpp
@@ -265,24 +265,24 @@ Response<SignInResponseType> AuthenticationClientImpl::GetSignInResponse(
 }
 
 template <>
-boost::optional<SignInResult> AuthenticationClientImpl::FindInCache(
+porting::optional<SignInResult> AuthenticationClientImpl::FindInCache(
     const std::string& key) {
   return client_token_cache_->locked(
       [&](utils::LruCache<std::string, SignInResult>& cache) {
         auto it = cache.Find(key);
-        return it != cache.end() ? boost::make_optional(it->value())
-                                 : boost::none;
+        return it != cache.end() ? porting::make_optional(it->value())
+                                 : porting::none;
       });
 }
 
 template <>
-boost::optional<SignInUserResult> AuthenticationClientImpl::FindInCache(
+porting::optional<SignInUserResult> AuthenticationClientImpl::FindInCache(
     const std::string& key) {
   return user_token_cache_->locked(
       [&](utils::LruCache<std::string, SignInUserResult>& cache) {
         auto it = cache.Find(key);
-        return it != cache.end() ? boost::make_optional(it->value())
-                                 : boost::none;
+        return it != cache.end() ? porting::make_optional(it->value())
+                                 : porting::none;
       });
 }
 
@@ -325,7 +325,7 @@ client::CancellationToken AuthenticationClientImpl::SignInClient(
     // endpoint with it. Construction of the `OlpClient` requires the host part
     // of URL, while `CallAuth` method - the rest of URL, hence we need to split
     // URL passed in the Credentials object.
-    const auto credentials_endpoint = credentials.GetEndpointUrl();
+    const auto& credentials_endpoint = credentials.GetEndpointUrl();
     const auto maybe_host_and_rest =
         olp::utils::Url::ParseHostAndRest(credentials_endpoint);
     if (maybe_host_and_rest) {
@@ -338,7 +338,7 @@ client::CancellationToken AuthenticationClientImpl::SignInClient(
     // settings object.
     auto settings = settings_;
     settings.token_endpoint_url = olp_client_host;
-    auto client = CreateOlpClient(settings, boost::none, false);
+    auto client = CreateOlpClient(settings, porting::none, false);
 
     RequestTimer timer = CreateRequestTimer(client, context);
 
@@ -472,7 +472,7 @@ client::CancellationToken AuthenticationClientImpl::SignInApple(
       return client::ApiError::Cancelled();
     }
 
-    auto client = CreateOlpClient(settings_, boost::none);
+    auto client = CreateOlpClient(settings_, porting::none);
 
     auto auth_response = CallApi(client, kOauthEndpoint, context,
                                  properties.GetAccessToken(), request_body);
@@ -534,7 +534,7 @@ client::CancellationToken AuthenticationClientImpl::HandleUserRequest(
       return client::ApiError::Cancelled();
     }
 
-    auto client = CreateOlpClient(settings_, boost::none, false);
+    auto client = CreateOlpClient(settings_, porting::none, false);
 
     RequestTimer timer = CreateRequestTimer(client, context);
 
@@ -834,12 +834,12 @@ client::OlpClient::RequestBodyType AuthenticationClientImpl::GenerateClientBody(
 
   if (properties.scope) {
     writer.Key(kScope);
-    writer.String(properties.scope.get().c_str());
+    writer.String(properties.scope->c_str());
   }
 
   if (properties.device_id) {
     writer.Key(kDeviceId);
-    writer.String(properties.device_id.get().c_str());
+    writer.String(properties.device_id->c_str());
   }
 
   writer.EndObject();

--- a/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.h
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientImpl.h
@@ -178,7 +178,7 @@ class AuthenticationClientImpl {
       const client::CancellationContext& context, const std::string& key);
 
   template <typename SignInResponseType>
-  boost::optional<SignInResponseType> FindInCache(const std::string& key);
+  porting::optional<SignInResponseType> FindInCache(const std::string& key);
 
   template <typename SignInResponseType>
   void StoreInCache(const std::string& key, SignInResponseType);

--- a/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.cpp
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <iomanip>
 #include <sstream>
+#include <utility>
 
 #include <olp/authentication/Crypto.h>
 #include <rapidjson/document.h>
@@ -123,7 +124,7 @@ std::time_t ParseTime(const std::string& value) {
 
 #endif
 
-boost::optional<std::time_t> GetTimestampFromHeaders(
+porting::optional<std::time_t> GetTimestampFromHeaders(
     const olp::http::Headers& headers) {
   auto it =
       std::find_if(begin(headers), end(headers),
@@ -134,7 +135,7 @@ boost::optional<std::time_t> GetTimestampFromHeaders(
   if (it != end(headers)) {
     return ParseTime(it->second);
   }
-  return boost::none;
+  return porting::none;
 }
 
 IntrospectAppResult GetIntrospectAppResult(const rapidjson::Document& doc) {
@@ -263,11 +264,11 @@ UserAccountInfoResponse GetUserAccountInfoResponse(
 
 client::OlpClient CreateOlpClient(
     const AuthenticationSettings& auth_settings,
-    boost::optional<client::AuthenticationSettings> authentication_settings,
-    bool retry) {
+    porting::optional<client::AuthenticationSettings> authentication_settings,
+    const bool retry) {
   client::OlpClientSettings settings;
   settings.network_request_handler = auth_settings.network_request_handler;
-  settings.authentication_settings = authentication_settings;
+  settings.authentication_settings = std::move(authentication_settings);
   settings.proxy_settings = auth_settings.network_proxy_settings;
   settings.retry_settings = auth_settings.retry_settings;
 

--- a/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.h
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClientUtils.h
@@ -70,7 +70,7 @@ inline client::CancellationToken AddTask(
  * @param headers http headers.
  * @return optional time_t time from headers.
  */
-boost::optional<std::time_t> GetTimestampFromHeaders(
+porting::optional<std::time_t> GetTimestampFromHeaders(
     const http::Headers& headers);
 
 /*
@@ -129,7 +129,7 @@ std::time_t ParseTime(const std::string& value);
  */
 client::OlpClient CreateOlpClient(
     const AuthenticationSettings& auth_settings,
-    boost::optional<client::AuthenticationSettings> authentication_settings,
+    porting::optional<client::AuthenticationSettings> authentication_settings,
     bool retry = true);
 
 /*

--- a/olp-cpp-sdk-authentication/src/AuthenticationCredentials.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationCredentials.cpp
@@ -58,7 +58,7 @@ std::string GetDefaultPath() {
 namespace olp {
 namespace authentication {
 
-boost::optional<AuthenticationCredentials>
+porting::optional<AuthenticationCredentials>
 AuthenticationCredentials::ReadFromStream(std::istream& stream) {
   static const std::regex kRegex{kRegexString};
 
@@ -89,20 +89,20 @@ AuthenticationCredentials::ReadFromStream(std::istream& stream) {
   }
 
   return (!access_key_id.empty() && !access_key_secret.empty())
-             ? boost::make_optional<AuthenticationCredentials>(
+             ? porting::make_optional<AuthenticationCredentials>(
                    {std::move(access_key_id), std::move(access_key_secret),
                     std::move(token_endpoint_url)})
-             : boost::none;
+             : porting::none;
 }
 
-boost::optional<AuthenticationCredentials>
+porting::optional<AuthenticationCredentials>
 AuthenticationCredentials::ReadFromFile(std::string filename) {
   if (filename.empty()) {
     filename = GetDefaultPath();
   }
 
   std::ifstream stream(filename, std::ios::in);
-  return stream ? ReadFromStream(stream) : boost::none;
+  return stream ? ReadFromStream(stream) : porting::none;
 }
 
 AuthenticationCredentials::AuthenticationCredentials(std::string key,

--- a/olp-cpp-sdk-authentication/src/AuthorizeRequest.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthorizeRequest.cpp
@@ -28,7 +28,7 @@ std::string AuthorizeRequest::CreateKey() const {
   std::stringstream out;
   out << service_id_;
   if (GetContractId()) {
-    out << "[" << GetContractId().get() << "]";
+    out << "[" << *GetContractId() << "]";
   }
   return out.str();
 }

--- a/olp-cpp-sdk-authentication/src/TokenEndpointImpl.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenEndpointImpl.cpp
@@ -129,7 +129,7 @@ std::string GenerateUid() {
 
 client::OlpClient::RequestBodyType GenerateClientBody(
     const TokenRequest& token_request,
-    const boost::optional<std::string>& scope) {
+    const porting::optional<std::string>& scope) {
   rapidjson::StringBuffer data;
   rapidjson::Writer<rapidjson::StringBuffer> writer(data);
   writer.StartObject();
@@ -146,7 +146,7 @@ client::OlpClient::RequestBodyType GenerateClientBody(
 
   if (scope) {
     writer.Key(kScope);
-    writer.String(scope.get().c_str());
+    writer.String(scope->c_str());
   }
 
   writer.EndObject();
@@ -211,10 +211,11 @@ client::CancellationToken TokenEndpointImpl::RequestToken(
           return;
         }
 
-        callback(TokenResult{
-            sign_in_result.GetAccessToken(), sign_in_result.GetExpiresIn(),
-            sign_in_result.GetScope().empty() ? boost::optional<std::string>{}
-                                              : sign_in_result.GetScope()});
+        callback(TokenResult{sign_in_result.GetAccessToken(),
+                             sign_in_result.GetExpiresIn(),
+                             sign_in_result.GetScope().empty()
+                                 ? olp::porting::optional<std::string>{}
+                                 : sign_in_result.GetScope()});
       });
 }
 
@@ -251,7 +252,7 @@ TokenResponse TokenEndpointImpl::RequestToken(
 
   return TokenResult{
       sign_in_result.GetAccessToken(), sign_in_result.GetExpiresIn(),
-      sign_in_result.GetScope().empty() ? boost::optional<std::string>{}
+      sign_in_result.GetScope().empty() ? olp::porting::optional<std::string>{}
                                         : sign_in_result.GetScope()};
 }
 
@@ -266,7 +267,7 @@ SignInResponse TokenEndpointImpl::SignInClient(
     return client::ApiError::Cancelled();
   }
 
-  auto client = CreateOlpClient(settings_, boost::none, false);
+  auto client = CreateOlpClient(settings_, porting::none, false);
 
   RequestTimer timer = CreateRequestTimer(client, context);
 

--- a/olp-cpp-sdk-authentication/src/TokenEndpointImpl.h
+++ b/olp-cpp-sdk-authentication/src/TokenEndpointImpl.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <string>
 
 #include <olp/authentication/AuthenticationClient.h>
@@ -30,6 +29,7 @@
 #include <olp/authentication/Types.h>
 #include <olp/core/client/CancellationContext.h>
 #include <olp/core/client/OlpClient.h>
+#include <olp/core/porting/optional.hpp>
 #include "TokenRequest.h"
 
 namespace olp {
@@ -90,7 +90,7 @@ class TokenEndpointImpl {
                                   client::CancellationContext& context) const;
 
   const AuthenticationCredentials credentials_;
-  const boost::optional<std::string> scope_;
+  const porting::optional<std::string> scope_;
   const AuthenticationSettings settings_;
   AuthenticationClient auth_client_;
 };

--- a/olp-cpp-sdk-authentication/src/TokenResult.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenResult.cpp
@@ -22,7 +22,7 @@
 namespace olp {
 namespace authentication {
 TokenResult::TokenResult(std::string access_token, time_t expiry_time,
-                         boost::optional<std::string> scope)
+                         porting::optional<std::string> scope)
     : access_token_(std::move(access_token)),
       expiry_time_(expiry_time),
       scope_(std::move(scope)) {
@@ -33,7 +33,7 @@ TokenResult::TokenResult(std::string access_token, time_t expiry_time,
 
 TokenResult::TokenResult(std::string access_token,
                          std::chrono::seconds expires_in,
-                         boost::optional<std::string> scope)
+                         porting::optional<std::string> scope)
     : access_token_(std::move(access_token)),
       expires_in_(expires_in),
       scope_(std::move(scope)) {
@@ -46,7 +46,7 @@ time_t TokenResult::GetExpiryTime() const { return expiry_time_; }
 
 std::chrono::seconds TokenResult::GetExpiresIn() const { return expires_in_; }
 
-const boost::optional<std::string>& TokenResult::GetScope() const {
+const porting::optional<std::string>& TokenResult::GetScope() const {
   return scope_;
 }
 

--- a/olp-cpp-sdk-authentication/tests/DecisionApiClientTest.cpp
+++ b/olp-cpp-sdk-authentication/tests/DecisionApiClientTest.cpp
@@ -27,11 +27,9 @@ namespace auth = olp::authentication;
 TEST(DecisionApiClientTest, AuthorizeRequestTest) {
   EXPECT_EQ(auth::AuthorizeRequest().WithServiceId("ServiceId").GetServiceId(),
             "ServiceId");
-  EXPECT_EQ(auth::AuthorizeRequest()
-                .WithContractId("ContractId")
-                .GetContractId()
-                .get(),
-            "ContractId");
+  EXPECT_EQ(
+      *auth::AuthorizeRequest().WithContractId("ContractId").GetContractId(),
+      "ContractId");
   auto request = auth::AuthorizeRequest().WithAction("action1").WithAction(
       "action2", std::string("hrn::test"));
   EXPECT_EQ(auth::AuthorizeRequest().GetDiagnostics(), false);


### PR DESCRIPTION
Currently, SDK requires C++11 minimum.
So, boost::optional type is used for optional values. For C++17 and above more convenient is to use std::optional instead. The task NLAM-23 is about making this type configurable. This commit is a second part of the task: olp-cpp-sdk-authentication.

Relates-To: NLAM-23