### PR TITLE
Use porting::optional in olp-cpp-sdk-write instead of boost::optional.

### DIFF
--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/StreamLayerClient.h
@@ -124,10 +124,10 @@ class DATASERVICE_WRITE_API StreamLayerClient {
    *
    * @param request The `PublishDataRequest` object.
    *
-   * @return An optional boost that is `boost::none` if the queue call is
+   * @return An optional boost that is `olp::porting::none` if the queue call is
    * successful. Otherwise, it contains a string with error details.
    */
-  boost::optional<std::string> Queue(model::PublishDataRequest request);
+  porting::optional<std::string> Queue(model::PublishDataRequest request);
 
   /**
    * @brief Flushes `PublishDataRequests` that are queued via the Queue API.

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/generated/model/Index.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/generated/model/Index.h
@@ -24,7 +24,7 @@
 #include <string>
 #include <utility>
 
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 
 #include <olp/dataservice/write/DataServiceWriteApi.h>
 
@@ -324,9 +324,9 @@ class DATASERVICE_WRITE_API Index final {
       : id_(std::move(uuid)), indexFields_(std::move(indexFields)) {}
 
  private:
-  boost::optional<std::string> checksum_;
-  boost::optional<std::map<std::string, std::string>> metadata_;
-  boost::optional<int64_t> size_;
+  porting::optional<std::string> checksum_;
+  porting::optional<std::map<std::string, std::string>> metadata_;
+  porting::optional<int64_t> size_;
   std::string id_;
   std::map<IndexName, std::shared_ptr<IndexValue>> indexFields_;
 
@@ -336,14 +336,16 @@ class DATASERVICE_WRITE_API Index final {
    *
    * @return The checksum.
    */
-  const boost::optional<std::string>& GetCheckSum() const { return checksum_; }
+  const porting::optional<std::string>& GetCheckSum() const {
+    return checksum_;
+  }
 
   /**
    * @brief Gets a mutable reference to the checksum of the index layer.
    *
    * @return The mutable reference to the checksum.
    */
-  boost::optional<std::string>& GetMutableCheckSum() { return checksum_; }
+  porting::optional<std::string>& GetMutableCheckSum() { return checksum_; }
 
   /**
    * @brief Sets the checksum.
@@ -357,7 +359,7 @@ class DATASERVICE_WRITE_API Index final {
    *
    * @return The metadata of the index layer.
    */
-  const boost::optional<std::map<std::string, std::string>>& GetMetadata()
+  const porting::optional<std::map<std::string, std::string>>& GetMetadata()
       const {
     return metadata_;
   }
@@ -367,7 +369,7 @@ class DATASERVICE_WRITE_API Index final {
    *
    * @return The mutable reference to the metadata.
    */
-  boost::optional<std::map<std::string, std::string>>& GetMutableMetadata() {
+  porting::optional<std::map<std::string, std::string>>& GetMutableMetadata() {
     return metadata_;
   }
 
@@ -435,14 +437,14 @@ class DATASERVICE_WRITE_API Index final {
    *
    * @return The size of the index layer.
    */
-  const boost::optional<int64_t>& GetSize() const { return size_; }
+  const porting::optional<int64_t>& GetSize() const { return size_; }
 
   /**
    * @brief Gets a mutable reference to the size of the index layer.
    *
    * @return The mutable reference to the size of the index layer.
    */
-  boost::optional<int64_t>& GetMutableSize() { return size_; }
+  porting::optional<int64_t>& GetMutableSize() { return size_; }
 
   /**
    * @brief Sets the size of the index layer.

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/generated/model/Publication.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/generated/model/Publication.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 
 #include <olp/dataservice/write/DataServiceWriteApi.h>
 #include <olp/dataservice/write/generated/model/Details.h>
@@ -44,11 +44,11 @@ class DATASERVICE_WRITE_API Publication {
   virtual ~Publication() = default;
 
  private:
-  boost::optional<std::string> id_;
-  boost::optional<Details> details_;
-  boost::optional<std::vector<std::string>> layer_ids_;
-  boost::optional<int64_t> catalog_version_;
-  boost::optional<std::vector<VersionDependency>> version_dependencies_;
+  porting::optional<std::string> id_;
+  porting::optional<Details> details_;
+  porting::optional<std::vector<std::string>> layer_ids_;
+  porting::optional<int64_t> catalog_version_;
+  porting::optional<std::vector<VersionDependency>> version_dependencies_;
 
  public:
   /**
@@ -56,14 +56,14 @@ class DATASERVICE_WRITE_API Publication {
    *
    * @return The publication ID.
    */
-  const boost::optional<std::string>& GetId() const { return id_; }
+  const porting::optional<std::string>& GetId() const { return id_; }
 
   /**
    * @brief Gets a mutable reference to the publication ID.
    *
    * @return The mutable reference to the publication ID.
    */
-  boost::optional<std::string>& GetMutableId() { return id_; }
+  porting::optional<std::string>& GetMutableId() { return id_; }
 
   /**
    * @brief Sets the publication ID.
@@ -77,14 +77,14 @@ class DATASERVICE_WRITE_API Publication {
    *
    * @return The details of the publication.
    */
-  const boost::optional<Details>& GetDetails() const { return details_; }
+  const porting::optional<Details>& GetDetails() const { return details_; }
 
   /**
    * @brief Gets a mutable reference to the details of the publication.
    *
    * @return The mutable reference to the details of the publication.
    */
-  boost::optional<Details>& GetMutableDetails() { return details_; }
+  porting::optional<Details>& GetMutableDetails() { return details_; }
 
   /**
    * @brief Sets the details of the publication.
@@ -98,7 +98,7 @@ class DATASERVICE_WRITE_API Publication {
    *
    * @return The layer ID.
    */
-  const boost::optional<std::vector<std::string>>& GetLayerIds() const {
+  const porting::optional<std::vector<std::string>>& GetLayerIds() const {
     return layer_ids_;
   }
 
@@ -108,7 +108,7 @@ class DATASERVICE_WRITE_API Publication {
    *
    * @return The mutable reference to the layer ID.
    */
-  boost::optional<std::vector<std::string>>& GetMutableLayerIds() {
+  porting::optional<std::vector<std::string>>& GetMutableLayerIds() {
     return layer_ids_;
   }
 
@@ -126,7 +126,7 @@ class DATASERVICE_WRITE_API Publication {
    *
    * @return The catalog version.
    */
-  const boost::optional<int64_t>& GetCatalogVersion() const {
+  const porting::optional<int64_t>& GetCatalogVersion() const {
     return catalog_version_;
   }
 
@@ -137,7 +137,7 @@ class DATASERVICE_WRITE_API Publication {
    * @return The mutable reference to the version of the catalog to be
    * published.
    */
-  boost::optional<int64_t>& GetMutableCatalogVersion() {
+  porting::optional<int64_t>& GetMutableCatalogVersion() {
     return catalog_version_;
   }
 
@@ -155,7 +155,7 @@ class DATASERVICE_WRITE_API Publication {
    *
    * @return The version dependencies.
    */
-  const boost::optional<std::vector<VersionDependency>>&
+  const porting::optional<std::vector<VersionDependency>>&
   GetVersionDependencies() const {
     return version_dependencies_;
   }
@@ -165,7 +165,7 @@ class DATASERVICE_WRITE_API Publication {
    *
    * @return The mutable reference to the version dependencies.
    */
-  boost::optional<std::vector<VersionDependency>>&
+  porting::optional<std::vector<VersionDependency>>&
   GetMutableVersionDependencies() {
     return version_dependencies_;
   }

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/PublishDataRequest.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/PublishDataRequest.h
@@ -24,7 +24,7 @@
 #include <utility>
 #include <vector>
 
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 
 #include <olp/dataservice/write/DataServiceWriteApi.h>
 
@@ -113,7 +113,7 @@ class DATASERVICE_WRITE_API PublishDataRequest {
    *
    * @return The trace ID of the request.
    */
-  inline const boost::optional<std::string>& GetTraceId() const {
+  inline const porting::optional<std::string>& GetTraceId() const {
     return trace_id_;
   }
 
@@ -152,10 +152,10 @@ class DATASERVICE_WRITE_API PublishDataRequest {
    * billing records together. If supplied, it must be 4–16 characters
    * long and contain only alphanumeric ASCII characters [A-Za-z0-9].
    *
-   * @return The `BillingTag` string or `boost::none` if the billing tag is not
-   * set.
+   * @return The `BillingTag` string or `olp::porting::none` if the billing tag
+   * is not set.
    */
-  inline const boost::optional<std::string>& GetBillingTag() const {
+  inline const porting::optional<std::string>& GetBillingTag() const {
     return billing_tag_;
   }
 
@@ -164,7 +164,7 @@ class DATASERVICE_WRITE_API PublishDataRequest {
    *
    * @see `GetBillingTag()` for information on usage and format.
    *
-   * @param billing_tag The `BillingTag` string or `boost::none`.
+   * @param billing_tag The `BillingTag` string or `olp::porting::none`.
    */
   inline PublishDataRequest& WithBillingTag(const std::string& billing_tag) {
     billing_tag_ = billing_tag;
@@ -177,7 +177,7 @@ class DATASERVICE_WRITE_API PublishDataRequest {
    * @see `GetBillingTag()` for information on usage and format.
    *
    * @param billing_tag The rvalue reference to the `BillingTag` string or
-   * `boost::none`.
+   * `olp::porting::none`.
    */
   inline PublishDataRequest& WithBillingTag(std::string&& billing_tag) {
     billing_tag_ = std::move(billing_tag);
@@ -195,7 +195,7 @@ class DATASERVICE_WRITE_API PublishDataRequest {
    *
    * @return The request checksum.
    */
-  inline const boost::optional<std::string>& GetChecksum() const {
+  inline const porting::optional<std::string>& GetChecksum() const {
     return checksum_;
   }
 
@@ -228,11 +228,11 @@ class DATASERVICE_WRITE_API PublishDataRequest {
 
   std::string layer_id_;
 
-  boost::optional<std::string> trace_id_;
+  porting::optional<std::string> trace_id_;
 
-  boost::optional<std::string> billing_tag_;
+  porting::optional<std::string> billing_tag_;
 
-  boost::optional<std::string> checksum_;
+  porting::optional<std::string> checksum_;
 };
 
 }  // namespace model

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/PublishIndexRequest.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/PublishIndexRequest.h
@@ -24,7 +24,7 @@
 #include <utility>
 #include <vector>
 
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 
 #include <olp/dataservice/write/DataServiceWriteApi.h>
 #include <olp/dataservice/write/generated/model/Index.h>
@@ -112,10 +112,10 @@ class DATASERVICE_WRITE_API PublishIndexRequest {
    * billing records together. If supplied, it must be 4–16 characters
    * long and contain only alphanumeric ASCII characters [A-Za-z0-9].
    *
-   * @return The `BillingTag` string or `boost::none` if the billing tag is not
-   * set.
+   * @return The `BillingTag` string or `olp::porting::none` if the billing tag
+   * is not set.
    */
-  inline const boost::optional<std::string>& GetBillingTag() const {
+  inline const porting::optional<std::string>& GetBillingTag() const {
     return billing_tag_;
   }
 
@@ -125,7 +125,7 @@ class DATASERVICE_WRITE_API PublishIndexRequest {
    * @see `GetBillingTag()` for information on usage and format.
    *
    * @param billing_tag The rvalue reference to the `BillingTag` string or
-   * `boost::none`.
+   * `olp::porting::none`.
    */
   inline PublishIndexRequest& WithBillingTag(const std::string& billing_tag) {
     billing_tag_ = billing_tag;
@@ -138,7 +138,7 @@ class DATASERVICE_WRITE_API PublishIndexRequest {
    * @see `GetBillingTag()` for information on usage and format.
    *
    * @param billing_tag The rvalue reference to the `BillingTag` string or
-   * `boost::none`.
+   * `olp::porting::none`.
    */
   inline PublishIndexRequest& WithBillingTag(std::string&& billing_tag) {
     billing_tag_ = std::move(billing_tag);
@@ -156,7 +156,7 @@ class DATASERVICE_WRITE_API PublishIndexRequest {
    *
    * @return The request checksum.
    */
-  inline const boost::optional<std::string>& GetChecksum() const {
+  inline const porting::optional<std::string>& GetChecksum() const {
     return checksum_;
   }
 
@@ -226,9 +226,9 @@ class DATASERVICE_WRITE_API PublishIndexRequest {
 
   std::string layer_id_;
 
-  boost::optional<std::string> billing_tag_;
+  porting::optional<std::string> billing_tag_;
 
-  boost::optional<std::string> checksum_;
+  porting::optional<std::string> checksum_;
 
   Index index_;
 };

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/PublishPartitionDataRequest.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/PublishPartitionDataRequest.h
@@ -24,7 +24,7 @@
 #include <utility>
 #include <vector>
 
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 
 #include <olp/dataservice/write/DataServiceWriteApi.h>
 
@@ -111,7 +111,7 @@ class DATASERVICE_WRITE_API PublishPartitionDataRequest {
    *
    * @return The partition ID.
    */
-  inline const boost::optional<std::string>& GetPartitionId() const {
+  inline const porting::optional<std::string>& GetPartitionId() const {
     return partition_id_;
   }
 
@@ -150,10 +150,10 @@ class DATASERVICE_WRITE_API PublishPartitionDataRequest {
    * billing records together. If supplied, it must be 4–16 characters
    * long and contain only alphanumeric ASCII characters [A-Za-z0-9].
    *
-   * @return The `BillingTag` string or `boost::none` if the billing tag is not
-   * set.
+   * @return The `BillingTag` string or `olp::porting::none` if the billing tag
+   * is not set.
    */
-  inline const boost::optional<std::string>& GetBillingTag() const {
+  inline const porting::optional<std::string>& GetBillingTag() const {
     return billing_tag_;
   }
 
@@ -162,7 +162,7 @@ class DATASERVICE_WRITE_API PublishPartitionDataRequest {
    *
    * @see `GetBillingTag()` for information on usage and format.
    *
-   * @param billing_tag The `BillingTag` string or `boost::none`.
+   * @param billing_tag The `BillingTag` string or `olp::porting::none`.
    */
   inline PublishPartitionDataRequest& WithBillingTag(
       const std::string& billing_tag) {
@@ -176,7 +176,7 @@ class DATASERVICE_WRITE_API PublishPartitionDataRequest {
    * @see `GetBillingTag()` for information on usage and format.
    *
    * @param billing_tag The rvalue reference to the `BillingTag` string or
-   * `boost::none`.
+   * `olp::porting::none`.
    */
   inline PublishPartitionDataRequest& WithBillingTag(
       std::string&& billing_tag) {
@@ -195,7 +195,7 @@ class DATASERVICE_WRITE_API PublishPartitionDataRequest {
    *
    * @return The request checksum.
    */
-  inline const boost::optional<std::string>& GetChecksum() const {
+  inline const porting::optional<std::string>& GetChecksum() const {
     return checksum_;
   }
 
@@ -229,11 +229,11 @@ class DATASERVICE_WRITE_API PublishPartitionDataRequest {
 
   std::string layer_id_;
 
-  boost::optional<std::string> partition_id_;
+  porting::optional<std::string> partition_id_;
 
-  boost::optional<std::string> billing_tag_;
+  porting::optional<std::string> billing_tag_;
 
-  boost::optional<std::string> checksum_;
+  porting::optional<std::string> checksum_;
 };
 
 }  // namespace model

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/PublishSdiiRequest.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/PublishSdiiRequest.h
@@ -24,7 +24,7 @@
 #include <utility>
 #include <vector>
 
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 
 #include <olp/dataservice/write/DataServiceWriteApi.h>
 
@@ -127,7 +127,7 @@ class DATASERVICE_WRITE_API PublishSdiiRequest {
    *
    * @return The trace ID of the request.
    */
-  inline const boost::optional<std::string>& GetTraceId() const {
+  inline const porting::optional<std::string>& GetTraceId() const {
     return trace_id_;
   }
 
@@ -166,10 +166,10 @@ class DATASERVICE_WRITE_API PublishSdiiRequest {
    * billing records together. If supplied, it must be 4–16 characters
    * long and contain only alphanumeric ASCII characters [A-Za-z0-9].
    *
-   * @return The `BillingTag` string or `boost::none` if the billing tag is not
-   * set.
+   * @return The `BillingTag` string or `olp::porting::none` if the billing tag
+   * is not set.
    */
-  inline const boost::optional<std::string>& GetBillingTag() const {
+  inline const porting::optional<std::string>& GetBillingTag() const {
     return billing_tag_;
   }
 
@@ -178,7 +178,7 @@ class DATASERVICE_WRITE_API PublishSdiiRequest {
    *
    * @see `GetBillingTag()` for information on usage and format.
    *
-   * @param billing_tag The `BillingTag` string or `boost::none`.
+   * @param billing_tag The `BillingTag` string or `olp::porting::none`.
    */
   inline PublishSdiiRequest& WithBillingTag(const std::string& billing_tag) {
     billing_tag_ = billing_tag;
@@ -191,7 +191,7 @@ class DATASERVICE_WRITE_API PublishSdiiRequest {
    * @see `GetBillingTag()` for information on usage and format.
    *
    * @param billing_tag The rvalue reference to the `BillingTag` string or
-   * `boost::none`.
+   * `olp::porting::none`.
    */
   inline PublishSdiiRequest& WithBillingTag(std::string&& billing_tag) {
     billing_tag_ = std::move(billing_tag);
@@ -209,7 +209,7 @@ class DATASERVICE_WRITE_API PublishSdiiRequest {
    *
    * @return The request checksum.
    */
-  inline const boost::optional<std::string>& GetChecksum() const {
+  inline const porting::optional<std::string>& GetChecksum() const {
     return checksum_;
   }
 
@@ -242,11 +242,11 @@ class DATASERVICE_WRITE_API PublishSdiiRequest {
 
   std::string layer_id_;
 
-  boost::optional<std::string> trace_id_;
+  porting::optional<std::string> trace_id_;
 
-  boost::optional<std::string> billing_tag_;
+  porting::optional<std::string> billing_tag_;
 
-  boost::optional<std::string> checksum_;
+  porting::optional<std::string> checksum_;
 };
 
 }  // namespace model

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/StartBatchRequest.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/StartBatchRequest.h
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 
 #include <olp/dataservice/write/DataServiceWriteApi.h>
 #include <olp/dataservice/write/generated/model/VersionDependency.h>
@@ -48,7 +48,7 @@ class DATASERVICE_WRITE_API StartBatchRequest {
    *
    * @param layers The layer IDs.
    */
-  inline StartBatchRequest& WithLayers(std::vector<std::string> layers) {
+  StartBatchRequest& WithLayers(std::vector<std::string> layers) {
     layers_ = std::move(layers);
     return *this;
   }
@@ -58,7 +58,7 @@ class DATASERVICE_WRITE_API StartBatchRequest {
    *
    * @return The layer IDs.
    */
-  inline const boost::optional<std::vector<std::string>>& GetLayers() const {
+  const porting::optional<std::vector<std::string>>& GetLayers() const {
     return layers_;
   }
 
@@ -67,7 +67,7 @@ class DATASERVICE_WRITE_API StartBatchRequest {
    *
    * @param versionDependencies The version dependencies.
    */
-  inline StartBatchRequest& WithVersionDependencies(
+  StartBatchRequest& WithVersionDependencies(
       std::vector<VersionDependency> versionDependencies) {
     versionDependencies_ = std::move(versionDependencies);
     return *this;
@@ -78,7 +78,7 @@ class DATASERVICE_WRITE_API StartBatchRequest {
    *
    * @return The version dependencies.
    */
-  inline const boost::optional<std::vector<VersionDependency>>&
+  const porting::optional<std::vector<VersionDependency>>&
   GetVersionDependencies() const {
     return versionDependencies_;
   }
@@ -90,10 +90,10 @@ class DATASERVICE_WRITE_API StartBatchRequest {
    * billing records together. If supplied, it must be 4–16 characters
    * long and contain only alphanumeric ASCII characters [A-Za-z0-9].
    *
-   * @return The `BillingTag` string or `boost::none` if the billing tag is not
-   * set.
+   * @return The `BillingTag` string or `olp::porting::none` if the billing tag
+   * is not set.
    */
-  inline const boost::optional<std::string>& GetBillingTag() const {
+  const porting::optional<std::string>& GetBillingTag() const {
     return billing_tag_;
   }
 
@@ -102,17 +102,17 @@ class DATASERVICE_WRITE_API StartBatchRequest {
    *
    * @see `GetBillingTag()` for information on usage and format.
    *
-   * @param billing_tag The `BillingTag` string or `boost::none`.
+   * @param billing_tag The `BillingTag` string or `olp::porting::none`.
    */
-  inline StartBatchRequest& WithBillingTag(std::string billing_tag) {
+  StartBatchRequest& WithBillingTag(std::string billing_tag) {
     billing_tag_ = std::move(billing_tag);
     return *this;
   }
 
  private:
-  boost::optional<std::vector<std::string>> layers_;
-  boost::optional<std::vector<VersionDependency>> versionDependencies_;
-  boost::optional<std::string> billing_tag_;
+  porting::optional<std::vector<std::string>> layers_;
+  porting::optional<std::vector<VersionDependency>> versionDependencies_;
+  porting::optional<std::string> billing_tag_;
 };
 
 }  // namespace model

--- a/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/UpdateIndexRequest.h
+++ b/olp-cpp-sdk-dataservice-write/include/olp/dataservice/write/model/UpdateIndexRequest.h
@@ -24,7 +24,7 @@
 #include <utility>
 #include <vector>
 
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 
 #include <olp/dataservice/write/DataServiceWriteApi.h>
 #include <olp/dataservice/write/generated/model/Index.h>
@@ -80,10 +80,10 @@ class DATASERVICE_WRITE_API UpdateIndexRequest {
    * billing records together. If supplied, it must be 4–16 characters
    * long and contain only alphanumeric ASCII characters [A-Za-z0-9].
    *
-   * @return The `BillingTag` string or `boost::none` if the billing tag is not
-   * set.
+   * @return The `BillingTag` string or `olp::porting::none` if the billing tag
+   * is not set.
    */
-  inline const boost::optional<std::string>& GetBillingTag() const {
+  inline const porting::optional<std::string>& GetBillingTag() const {
     return billing_tag_;
   }
 
@@ -92,7 +92,7 @@ class DATASERVICE_WRITE_API UpdateIndexRequest {
    *
    * @see `GetBillingTag()` for information on usage and format.
    *
-   * @param billing_tag The `BillingTag` string or `boost::none`.
+   * @param billing_tag The `BillingTag` string or `olp::porting::none`.
    */
   inline UpdateIndexRequest& WithBillingTag(const std::string& billing_tag) {
     billing_tag_ = billing_tag;
@@ -105,7 +105,7 @@ class DATASERVICE_WRITE_API UpdateIndexRequest {
    * @see `GetBillingTag()` for information on usage and format.
    *
    * @param billing_tag The rvalue reference to the `BillingTag` string or
-   * `boost::none`.
+   * `olp::porting::none`.
    */
   inline UpdateIndexRequest& WithBillingTag(std::string&& billing_tag) {
     billing_tag_ = std::move(billing_tag);
@@ -123,7 +123,7 @@ class DATASERVICE_WRITE_API UpdateIndexRequest {
    *
    * @return The request checksum.
    */
-  inline const boost::optional<std::string>& GetChecksum() const {
+  inline const porting::optional<std::string>& GetChecksum() const {
     return checksum_;
   }
 
@@ -222,9 +222,9 @@ class DATASERVICE_WRITE_API UpdateIndexRequest {
  private:
   std::string layer_id_;
 
-  boost::optional<std::string> billing_tag_;
+  porting::optional<std::string> billing_tag_;
 
-  boost::optional<std::string> checksum_;
+  porting::optional<std::string> checksum_;
 
   std::vector<Index> indexAdditions_;
 

--- a/olp-cpp-sdk-dataservice-write/src/CatalogSettings.h
+++ b/olp-cpp-sdk-dataservice-write/src/CatalogSettings.h
@@ -38,7 +38,7 @@ class Catalog;
 
 class CatalogSettings {
  public:
-  using BillingTag = boost::optional<std::string>;
+  using BillingTag = porting::optional<std::string>;
 
   struct LayerSettings {
     std::string content_type;

--- a/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.cpp
@@ -74,7 +74,7 @@ olp::client::CancellationToken IndexLayerClientImpl::InitApiClients(
     ul.lock();
   }
   if (apiclient_index_ && !apiclient_index_->GetBaseUrl().empty()) {
-    callback(boost::none);
+    callback(olp::porting::none);
     return {};
   }
 
@@ -97,7 +97,7 @@ olp::client::CancellationToken IndexLayerClientImpl::InitApiClients(
       self->cond_var_.notify_one();
     } else {
       self->apiclient_index_->SetBaseUrl(apis.GetResult().at(0).GetBaseUrl());
-      callback(boost::none);
+      callback(olp::porting::none);
       self->cond_var_.notify_all();
     }
   };
@@ -250,7 +250,7 @@ client::CancellationToken IndexLayerClientImpl::DeleteIndexData(
 
   auto delete_index_data_function = [=]() -> client::CancellationToken {
     return BlobApi::deleteBlob(
-        *self->apiclient_blob_, layer_id, index_id, boost::none,
+        *self->apiclient_blob_, layer_id, index_id, olp::porting::none,
         [=](DeleteBlobRespone response) {
           self->tokenList_.RemoveTask(op_id);
           if (!response.IsSuccessful()) {
@@ -262,10 +262,10 @@ client::CancellationToken IndexLayerClientImpl::DeleteIndexData(
   };
 
   auto init_api_client_callback =
-      [=](boost::optional<client::ApiError> init_api_error) {
+      [=](porting::optional<client::ApiError> init_api_error) {
         if (init_api_error) {
           self->tokenList_.RemoveTask(op_id);
-          callback(DeleteBlobRespone(init_api_error.get()));
+          callback(DeleteBlobRespone(*init_api_error));
           return;
         }
 
@@ -319,16 +319,16 @@ client::CancellationToken IndexLayerClientImpl::UpdateIndex(
 
   auto UpdateIndex_function = [=]() -> client::CancellationToken {
     return IndexApi::performUpdate(*self->apiclient_index_, request,
-                                   boost::none, updateIndex_callback);
+                                   olp::porting::none, updateIndex_callback);
   };
 
   cancel_context->ExecuteOrCancelled(
       [=]() -> client::CancellationToken {
         return self->InitApiClients(
-            cancel_context, [=](boost::optional<client::ApiError> api_error) {
+            cancel_context, [=](porting::optional<client::ApiError> api_error) {
               if (api_error) {
                 self->tokenList_.RemoveTask(op_id);
-                callback(UpdateIndexResponse(api_error.get()));
+                callback(UpdateIndexResponse(*api_error));
                 return;
               }
               cancel_context->ExecuteOrCancelled(UpdateIndex_function,

--- a/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.h
@@ -43,7 +43,7 @@ class PublishDataRequest;
 }
 
 using InitApiClientsCallback =
-    std::function<void(boost::optional<client::ApiError>)>;
+    std::function<void(porting::optional<client::ApiError>)>;
 
 class IndexLayerClientImpl final
     : public std::enable_shared_from_this<IndexLayerClientImpl> {

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClient.cpp
@@ -53,7 +53,7 @@ olp::client::CancellationToken StreamLayerClient::PublishData(
   return impl_->PublishData(request, std::move(callback));
 }
 
-boost::optional<std::string> StreamLayerClient::Queue(
+porting::optional<std::string> StreamLayerClient::Queue(
     model::PublishDataRequest request) {
   return impl_->Queue(request);
 }

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
@@ -101,26 +101,26 @@ size_t StreamLayerClientImpl::QueueSize() const {
   return 0;
 }
 
-boost::optional<std::string> StreamLayerClientImpl::Queue(
+porting::optional<std::string> StreamLayerClientImpl::Queue(
     const model::PublishDataRequest& request) {
   if (!cache_) {
-    return boost::make_optional<std::string>(
+    return olp::porting::make_optional<std::string>(
         "No cache provided to StreamLayerClient");
   }
 
   if (!request.GetData()) {
-    return boost::make_optional<std::string>(
+    return olp::porting::make_optional<std::string>(
         "PublishDataRequest does not contain any Data");
   }
 
   if (request.GetLayerId().empty()) {
-    return boost::make_optional<std::string>(
+    return olp::porting::make_optional<std::string>(
         "PublishDataRequest does not contain a Layer ID");
   }
 
   if (!(StreamLayerClientImpl::QueueSize() <
         stream_client_settings_.maximum_requests)) {
-    return boost::make_optional<std::string>(
+    return olp::porting::make_optional<std::string>(
         "Maximum number of requests has reached");
   }
 
@@ -143,10 +143,10 @@ boost::optional<std::string> StreamLayerClientImpl::Queue(
                 [&uuid_list]() { return uuid_list; });
   }
 
-  return boost::none;
+  return olp::porting::none;
 }
 
-boost::optional<model::PublishDataRequest>
+porting::optional<model::PublishDataRequest>
 StreamLayerClientImpl::PopFromQueue() {
   std::lock_guard<std::mutex> lock(cache_mutex_);
 
@@ -155,14 +155,14 @@ StreamLayerClientImpl::PopFromQueue() {
 
   if (uuid_list_any.empty()) {
     OLP_SDK_LOG_ERROR(kLogTag, "Unable to Restore UUID list from Cache");
-    return boost::none;
+    return olp::porting::none;
   }
 
   auto uuid_list = boost::any_cast<std::string>(uuid_list_any);
 
   auto pos = uuid_list.find(",");
   if (pos == std::string::npos) {
-    return boost::none;
+    return olp::porting::none;
   }
 
   const auto publish_data_key = uuid_list.substr(0, pos);
@@ -179,7 +179,7 @@ StreamLayerClientImpl::PopFromQueue() {
   if (publish_data_any.empty()) {
     OLP_SDK_LOG_ERROR(kLogTag,
                       "Unable to Restore PublishData Request from Cache");
-    return boost::none;
+    return olp::porting::none;
   }
 
   return boost::any_cast<model::PublishDataRequest>(publish_data_any);
@@ -225,7 +225,7 @@ olp::client::CancellationToken StreamLayerClientImpl::Flush(
         while ((!maximum_events_number || counter < maximum_events_number) &&
                (this->QueueSize() > 0) && !context.IsCancelled()) {
           auto publish_request = this->PopFromQueue();
-          if (publish_request == boost::none) {
+          if (publish_request == olp::porting::none) {
             continue;
           }
 
@@ -412,7 +412,7 @@ PublishDataResponse StreamLayerClientImpl::PublishDataGreaterThanTwentyMib(
                          "doesn't contain any publication"));
   }
   const std::string publication_id =
-      init_publicaion_response.GetResult().GetId().get();
+      *init_publicaion_response.GetResult().GetId();
 
   // 2. Put blob API:
   const auto data_handle = GenerateUuid();

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.h
@@ -21,7 +21,7 @@
 
 #include <mutex>
 
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettings.h>
@@ -54,13 +54,14 @@ class StreamLayerClientImpl {
   olp::client::CancellationToken PublishData(model::PublishDataRequest request,
                                              PublishDataCallback callback);
 
-  boost::optional<std::string> Queue(const model::PublishDataRequest& request);
+  porting::optional<std::string> Queue(
+      const model::PublishDataRequest& request);
   olp::client::CancellableFuture<StreamLayerClient::FlushResponse> Flush(
       model::FlushRequest request);
   olp::client::CancellationToken Flush(
       model::FlushRequest request, StreamLayerClient::FlushCallback callback);
   size_t QueueSize() const;
-  boost::optional<model::PublishDataRequest> PopFromQueue();
+  porting::optional<model::PublishDataRequest> PopFromQueue();
 
   client::CancellableFuture<PublishSdiiResponse> PublishSdii(
       model::PublishSdiiRequest request);

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.h
@@ -39,9 +39,9 @@ namespace dataservice {
 namespace write {
 
 using InitApiClientsCallback =
-    std::function<void(boost::optional<client::ApiError>)>;
+    std::function<void(porting::optional<client::ApiError>)>;
 using InitCatalogModelCallback =
-    std::function<void(boost::optional<client::ApiError>)>;
+    std::function<void(porting::optional<client::ApiError>)>;
 
 using UploadPartitionResult = client::ApiNoResult;
 using UploadPartitionResponse =
@@ -109,7 +109,7 @@ class VersionedLayerClientImpl
       CheckDataExistsCallback callback);
 
  private:
-  using BillingTag = boost::optional<std::string>;
+  using BillingTag = porting::optional<std::string>;
 
   client::CancellationToken InitApiClients(
       std::shared_ptr<client::CancellationContext> cancel_context,

--- a/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.h
+++ b/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.h
@@ -43,7 +43,7 @@ class Partition;
 }  // namespace model
 
 using InitApiClientsCallback =
-    std::function<void(boost::optional<client::ApiError>)>;
+    std::function<void(porting::optional<client::ApiError>)>;
 using DataHandleMap = std::map<std::string, std::string>;
 using DataHandleMapResponse =
     client::ApiResponse<DataHandleMap, client::ApiError>;
@@ -106,9 +106,9 @@ class VolatileLayerClientImpl final
 
   DataHandleMapResponse GetDataHandleMap(
       const std::string& layerId, const std::vector<std::string>& partitionIds,
-      boost::optional<int64_t> version,
-      boost::optional<std::vector<std::string>> additionalFields,
-      boost::optional<std::string> billingTag,
+      porting::optional<int64_t> version,
+      porting::optional<std::vector<std::string>> additionalFields,
+      porting::optional<std::string> billingTag,
       const client::CancellationContext context);
 
  private:

--- a/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.cpp
@@ -43,7 +43,8 @@ client::CancellationToken BlobApi::PutBlob(
     const std::string& content_type, const std::string& content_encoding,
     const std::string& data_handle,
     const std::shared_ptr<std::vector<unsigned char>>& data,
-    const boost::optional<std::string>& billing_tag, PutBlobCallback callback) {
+    const porting::optional<std::string>& billing_tag,
+    PutBlobCallback callback) {
   std::multimap<std::string, std::string> header_params;
   std::multimap<std::string, std::string> query_params;
   std::multimap<std::string, std::string> form_params;
@@ -54,8 +55,7 @@ client::CancellationToken BlobApi::PutBlob(
   }
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   std::string put_blob_uri = "/layers/" + layer_id + "/data/" + data_handle;
@@ -81,7 +81,7 @@ PutBlobResponse BlobApi::PutBlob(
     const std::string& content_type, const std::string& content_encoding,
     const std::string& data_handle,
     const std::shared_ptr<std::vector<unsigned char>>& data,
-    const boost::optional<std::string>& billing_tag,
+    const porting::optional<std::string>& billing_tag,
     client::CancellationContext cancel_context) {
   std::multimap<std::string, std::string> header_params;
   std::multimap<std::string, std::string> query_params;
@@ -94,8 +94,7 @@ PutBlobResponse BlobApi::PutBlob(
   }
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   std::string put_blob_uri = "/layers/" + layer_id + "/data/" + data_handle;
@@ -107,8 +106,8 @@ PutBlobResponse BlobApi::PutBlob(
 
   if (http_response.GetStatus() != olp::http::HttpStatusCode::OK &&
       http_response.GetStatus() != olp::http::HttpStatusCode::NO_CONTENT) {
-    return PutBlobResponse(
-        client::ApiError(http_response.GetStatus(), http_response.GetResponseAsString()));
+    return PutBlobResponse(client::ApiError(
+        http_response.GetStatus(), http_response.GetResponseAsString()));
   }
 
   return PutBlobResponse(client::ApiNoResult());
@@ -117,7 +116,7 @@ PutBlobResponse BlobApi::PutBlob(
 client::CancellationToken BlobApi::deleteBlob(
     const client::OlpClient& client, const std::string& layer_id,
     const std::string& data_handle,
-    const boost::optional<std::string>& billing_tag,
+    const porting::optional<std::string>& billing_tag,
     const DeleteBlobCallback& callback) {
   std::multimap<std::string, std::string> header_params;
   std::multimap<std::string, std::string> query_params;
@@ -126,8 +125,7 @@ client::CancellationToken BlobApi::deleteBlob(
   header_params.insert(std::make_pair("Accept", "application/json"));
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   std::string delete_blob_uri = "/layers/" + layer_id + "/data/" + data_handle;
@@ -148,7 +146,7 @@ client::CancellationToken BlobApi::deleteBlob(
 client::CancellationToken BlobApi::checkBlobExists(
     const client::OlpClient& client, const std::string& layer_id,
     const std::string& data_handle,
-    const boost::optional<std::string>& billing_tag,
+    const porting::optional<std::string>& billing_tag,
     const CheckBlobCallback& callback) {
   std::multimap<std::string, std::string> header_params;
   std::multimap<std::string, std::string> query_params;
@@ -157,8 +155,7 @@ client::CancellationToken BlobApi::checkBlobExists(
   header_params.insert(std::make_pair("Accept", "application/json"));
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   std::string check_blob_uri = "/layers/" + layer_id + "/data/" + data_handle;

--- a/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/BlobApi.h
@@ -84,7 +84,7 @@ class BlobApi {
       const std::string& content_type, const std::string& content_encoding,
       const std::string& data_handle,
       const std::shared_ptr<std::vector<unsigned char>>& data,
-      const boost::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& billing_tag,
       PutBlobCallback callback);
 
   /**
@@ -95,7 +95,7 @@ class BlobApi {
       const std::string& content_type, const std::string& content_encoding,
       const std::string& data_handle,
       const std::shared_ptr<std::vector<unsigned char>>& data,
-      const boost::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& billing_tag,
       client::CancellationContext cancel_contex);
 
   /**
@@ -118,7 +118,7 @@ class BlobApi {
   static client::CancellationToken deleteBlob(
       const client::OlpClient& client, const std::string& layer_id,
       const std::string& data_handle,
-      const boost::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& billing_tag,
       const DeleteBlobCallback& callback);
 
   /**
@@ -138,7 +138,7 @@ class BlobApi {
   static client::CancellationToken checkBlobExists(
       const client::OlpClient& client, const std::string& layer_id,
       const std::string& data_handle,
-      const boost::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& billing_tag,
       const CheckBlobCallback& callback);
 };
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.cpp
@@ -39,7 +39,7 @@ namespace client = olp::client;
 
 client::CancellationToken ConfigApi::GetCatalog(
     std::shared_ptr<client::OlpClient> client, const std::string& catalog_hrn,
-    boost::optional<std::string> billing_tag,
+    porting::optional<std::string> billing_tag,
     const CatalogCallback& catalogCallback) {
   std::multimap<std::string, std::string> headerParams;
   headerParams.insert(std::make_pair("Accept", "application/json"));
@@ -51,24 +51,25 @@ client::CancellationToken ConfigApi::GetCatalog(
 
   std::string catalogUri = "/catalogs/" + catalog_hrn;
 
-  client::NetworkAsyncCallback callback = [catalogCallback](
-                                              client::HttpResponse response) {
-    if (response.GetStatus() != http::HttpStatusCode::OK) {
-      catalogCallback(CatalogResponse(
-          client::ApiError(response.GetStatus(), response.GetResponseAsString())));
-    } else {
-      catalogCallback(parser::parse_result<CatalogResponse>(response.GetRawResponse()));
-    }
-  };
+  client::NetworkAsyncCallback callback =
+      [catalogCallback](client::HttpResponse response) {
+        if (response.GetStatus() != http::HttpStatusCode::OK) {
+          catalogCallback(CatalogResponse(client::ApiError(
+              response.GetStatus(), response.GetResponseAsString())));
+        } else {
+          catalogCallback(
+              parser::parse_result<CatalogResponse>(response.GetRawResponse()));
+        }
+      };
 
   return client->CallApi(catalogUri, "GET", queryParams, headerParams,
                          formParams, nullptr, "", callback);
 }
 
-CatalogResponse ConfigApi::GetCatalog(const client::OlpClient& client,
-                                      const std::string& catalog_hrn,
-                                      boost::optional<std::string> billing_tag,
-                                      client::CancellationContext context) {
+CatalogResponse ConfigApi::GetCatalog(
+    const client::OlpClient& client, const std::string& catalog_hrn,
+    porting::optional<std::string> billing_tag,
+    client::CancellationContext context) {
   std::multimap<std::string, std::string> header_params;
   header_params.insert(std::make_pair("Accept", "application/json"));
   std::multimap<std::string, std::string> query_params;
@@ -81,7 +82,8 @@ CatalogResponse ConfigApi::GetCatalog(const client::OlpClient& client,
       std::move(catalog_uri), "GET", std::move(query_params),
       std::move(header_params), {}, nullptr, std::string{}, std::move(context));
   if (response.GetStatus() != olp::http::HttpStatusCode::OK) {
-    return client::ApiError(response.GetStatus(), response.GetResponseAsString());
+    return client::ApiError(response.GetStatus(),
+                            response.GetResponseAsString());
   }
   return parser::parse_result<CatalogResponse>(response.GetRawResponse());
 }

--- a/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.h
@@ -22,7 +22,7 @@
 #include <memory>
 #include <string>
 
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
@@ -51,6 +51,7 @@ class ConfigApi {
    * @param billing_tag An optional free-form tag which is used for grouping
    * billing records together. If supplied, it must be between 4 - 16
    * characters, contain only alpha/numeric ASCII characters  [A-Za-z0-9].
+   * @param callback
    * @param A callback function to invoke with the catalog configuration
    * response.
    *
@@ -58,7 +59,7 @@ class ConfigApi {
    */
   static client::CancellationToken GetCatalog(
       std::shared_ptr<client::OlpClient> client, const std::string& catalog_hrn,
-      boost::optional<std::string> billing_tag,
+      porting::optional<std::string> billing_tag,
       const CatalogCallback& callback);
 
   /**
@@ -75,7 +76,7 @@ class ConfigApi {
    */
   static CatalogResponse GetCatalog(const client::OlpClient& client,
                                     const std::string& catalog_hrn,
-                                    boost::optional<std::string> billing_tag,
+                                    porting::optional<std::string> billing_tag,
                                     client::CancellationContext context);
 };
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/ConfigApi.h
@@ -51,9 +51,8 @@ class ConfigApi {
    * @param billing_tag An optional free-form tag which is used for grouping
    * billing records together. If supplied, it must be between 4 - 16
    * characters, contain only alpha/numeric ASCII characters  [A-Za-z0-9].
-   * @param callback
-   * @param A callback function to invoke with the catalog configuration
-   * response.
+   * @param callback A callback function to invoke with the catalog
+   * configuration response.
    *
    * @return The cancellation token.
    */

--- a/olp-cpp-sdk-dataservice-write/src/generated/IndexApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/IndexApi.cpp
@@ -41,7 +41,7 @@ namespace write {
 client::CancellableFuture<InsertIndexesResponse> IndexApi::insertIndexes(
     const client::OlpClient& client, const model::Index& indexes,
     const std::string& layer_id,
-    const boost::optional<std::string>& billing_tag) {
+    const porting::optional<std::string>& billing_tag) {
   auto promise = std::make_shared<std::promise<InsertIndexesResponse>>();
   auto cancel_token = insertIndexes(client, indexes, layer_id, billing_tag,
                                     [promise](InsertIndexesResponse response) {
@@ -54,7 +54,7 @@ client::CancellableFuture<InsertIndexesResponse> IndexApi::insertIndexes(
 client::CancellationToken IndexApi::insertIndexes(
     const client::OlpClient& client, const model::Index& indexes,
     const std::string& layer_id,
-    const boost::optional<std::string>& billing_tag,
+    const porting::optional<std::string>& billing_tag,
     InsertIndexesCallback callback) {
   std::multimap<std::string, std::string> header_params;
   std::multimap<std::string, std::string> query_params;
@@ -63,8 +63,7 @@ client::CancellationToken IndexApi::insertIndexes(
   header_params.insert(std::make_pair("Accept", "application/json"));
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   std::string insert_indexes_uri = "/layers/" + layer_id;
@@ -90,7 +89,7 @@ client::CancellationToken IndexApi::insertIndexes(
 InsertIndexesResponse IndexApi::InsertIndexes(
     const client::OlpClient& client, const model::Index& indexes,
     const std::string& layer_id,
-    const boost::optional<std::string>& billing_tag,
+    const porting::optional<std::string>& billing_tag,
     client::CancellationContext context) {
   std::multimap<std::string, std::string> header_params;
   std::multimap<std::string, std::string> query_params;
@@ -99,8 +98,7 @@ InsertIndexesResponse IndexApi::InsertIndexes(
   header_params.insert(std::make_pair("Accept", "application/json"));
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   std::string insert_indexes_uri = "/layers/" + layer_id;
@@ -113,7 +111,8 @@ InsertIndexesResponse IndexApi::InsertIndexes(
       client.CallApi(insert_indexes_uri, "POST", query_params, header_params,
                      form_params, data, "application/json", context);
   if (http_response.GetStatus() > http::HttpStatusCode::CREATED) {
-    return client::ApiError(http_response.GetStatus(), http_response.GetResponseAsString());
+    return client::ApiError(http_response.GetStatus(),
+                            http_response.GetResponseAsString());
   }
 
   return client::ApiNoResult();
@@ -121,7 +120,7 @@ InsertIndexesResponse IndexApi::InsertIndexes(
 
 client::CancellableFuture<UpdateIndexesResponse> IndexApi::performUpdate(
     const client::OlpClient& client, const model::UpdateIndexRequest& request,
-    const boost::optional<std::string>& billing_tag) {
+    const porting::optional<std::string>& billing_tag) {
   auto promise = std::make_shared<std::promise<UpdateIndexesResponse>>();
   auto cancel_token = performUpdate(client, request, billing_tag,
                                     [promise](InsertIndexesResponse response) {
@@ -133,7 +132,7 @@ client::CancellableFuture<UpdateIndexesResponse> IndexApi::performUpdate(
 
 client::CancellationToken IndexApi::performUpdate(
     const client::OlpClient& client, const model::UpdateIndexRequest& request,
-    const boost::optional<std::string>& billing_tag,
+    const porting::optional<std::string>& billing_tag,
     InsertIndexesCallback callback) {
   std::multimap<std::string, std::string> header_params;
   std::multimap<std::string, std::string> query_params;
@@ -142,8 +141,7 @@ client::CancellationToken IndexApi::performUpdate(
   header_params.insert(std::make_pair("Accept", "application/json"));
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   std::string update_indexes_uri = "/layers/" + request.GetLayerId();

--- a/olp-cpp-sdk-dataservice-write/src/generated/IndexApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/IndexApi.h
@@ -71,7 +71,7 @@ class IndexApi {
   static client::CancellableFuture<InsertIndexesResponse> insertIndexes(
       const client::OlpClient& client, const model::Index& indexes,
       const std::string& layer_id,
-      const boost::optional<std::string>& billing_tag = boost::none);
+      const porting::optional<std::string>& billing_tag = olp::porting::none);
 
   /**
    * @brief Inserts index data to an index layer
@@ -93,16 +93,16 @@ class IndexApi {
   static client::CancellationToken insertIndexes(
       const client::OlpClient& client, const model::Index& indexes,
       const std::string& layer_id,
-      const boost::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& billing_tag,
       InsertIndexesCallback callback);
 
   /**
-  * @brief Synchronous version of \c insertIndexes method.
-  */
+   * @brief Synchronous version of \c insertIndexes method.
+   */
   static InsertIndexesResponse InsertIndexes(
       const client::OlpClient& client, const model::Index& indexes,
       const std::string& layer_id,
-      const boost::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& billing_tag,
       client::CancellationContext context);
 
   /**
@@ -120,7 +120,7 @@ class IndexApi {
    */
   static client::CancellableFuture<UpdateIndexesResponse> performUpdate(
       const client::OlpClient& client, const model::UpdateIndexRequest& request,
-      const boost::optional<std::string>& billing_tag = boost::none);
+      const porting::optional<std::string>& billing_tag = olp::porting::none);
 
   /**
    * @brief Updates index layer partitions
@@ -140,7 +140,7 @@ class IndexApi {
    */
   static client::CancellationToken performUpdate(
       const client::OlpClient& client, const model::UpdateIndexRequest& request,
-      const boost::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& billing_tag,
       UpdateIndexesCallback callback);
 };
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.cpp
@@ -54,24 +54,24 @@ client::CancellationToken IngestApi::IngestData(
     const client::OlpClient& client, const std::string& layer_id,
     const std::string& content_type,
     const std::shared_ptr<std::vector<unsigned char>>& data,
-    const boost::optional<std::string>& trace_id,
-    const boost::optional<std::string>& billing_tag,
-    const boost::optional<std::string>& checksum, IngestDataCallback callback) {
+    const porting::optional<std::string>& trace_id,
+    const porting::optional<std::string>& billing_tag,
+    const porting::optional<std::string>& checksum,
+    IngestDataCallback callback) {
   std::multimap<std::string, std::string> query_params;
   std::multimap<std::string, std::string> form_params;
   std::multimap<std::string, std::string> header_params;
 
   header_params.insert(std::make_pair("Accept", "application/json"));
   if (trace_id) {
-    header_params.insert(std::make_pair(kHeaderParamTraceId, trace_id.get()));
+    header_params.insert(std::make_pair(kHeaderParamTraceId, *trace_id));
   }
   if (checksum) {
-    header_params.insert(std::make_pair(kHeaderParamChecksum, checksum.get()));
+    header_params.insert(std::make_pair(kHeaderParamChecksum, *checksum));
   }
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   std::string ingest_uri = "/layers/" + layer_id;
@@ -85,8 +85,8 @@ client::CancellationToken IngestApi::IngestData(
           return;
         }
 
-        callback(
-            parser::parse_result<IngestDataResponse>(http_response.GetRawResponse()));
+        callback(parser::parse_result<IngestDataResponse>(
+            http_response.GetRawResponse()));
       });
 
   return cancel_token;
@@ -96,9 +96,9 @@ IngestDataResponse IngestApi::IngestData(
     const client::OlpClient& client, const std::string& layer_id,
     const std::string& content_type, const std::string& content_encoding,
     const std::shared_ptr<std::vector<unsigned char>>& data,
-    const boost::optional<std::string>& trace_id,
-    const boost::optional<std::string>& billing_tag,
-    const boost::optional<std::string>& checksum,
+    const porting::optional<std::string>& trace_id,
+    const porting::optional<std::string>& billing_tag,
+    const porting::optional<std::string>& checksum,
     client::CancellationContext context) {
   std::multimap<std::string, std::string> query_params;
   std::multimap<std::string, std::string> form_params;
@@ -112,16 +112,15 @@ IngestDataResponse IngestApi::IngestData(
   }
 
   if (trace_id) {
-    header_params.insert(std::make_pair(kHeaderParamTraceId, trace_id.get()));
+    header_params.insert(std::make_pair(kHeaderParamTraceId, *trace_id));
   }
 
   if (checksum) {
-    header_params.insert(std::make_pair(kHeaderParamChecksum, checksum.get()));
+    header_params.insert(std::make_pair(kHeaderParamChecksum, *checksum));
   }
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   const std::string ingest_uri = "/layers/" + layer_id;
@@ -133,19 +132,20 @@ IngestDataResponse IngestApi::IngestData(
     OLP_SDK_LOG_ERROR_F(
         kLogTag, "Error during OlpClient::CallApi call, uri=%s, status=%i",
         ingest_uri.c_str(), http_response.GetStatus());
-    return IngestDataResponse{
-        client::ApiError(http_response.GetStatus(), http_response.GetResponseAsString())};
+    return IngestDataResponse{client::ApiError(
+        http_response.GetStatus(), http_response.GetResponseAsString())};
   }
 
-  return parser::parse_result<IngestDataResponse>(http_response.GetRawResponse());
+  return parser::parse_result<IngestDataResponse>(
+      http_response.GetRawResponse());
 }
 
 IngestSdiiResponse IngestApi::IngestSdii(
     const client::OlpClient& client, const std::string& layer_id,
     const std::shared_ptr<std::vector<unsigned char>>& sdii_message_list,
-    const boost::optional<std::string>& trace_id,
-    const boost::optional<std::string>& billing_tag,
-    const boost::optional<std::string>& checksum,
+    const porting::optional<std::string>& trace_id,
+    const porting::optional<std::string>& billing_tag,
+    const porting::optional<std::string>& checksum,
     client::CancellationContext context) {
   std::multimap<std::string, std::string> header_params;
   std::multimap<std::string, std::string> query_params;
@@ -153,15 +153,14 @@ IngestSdiiResponse IngestApi::IngestSdii(
 
   header_params.insert(std::make_pair("Accept", "application/json"));
   if (trace_id) {
-    header_params.insert(std::make_pair(kHeaderParamTraceId, trace_id.get()));
+    header_params.insert(std::make_pair(kHeaderParamTraceId, *trace_id));
   }
   if (checksum) {
-    header_params.insert(std::make_pair(kHeaderParamChecksum, checksum.get()));
+    header_params.insert(std::make_pair(kHeaderParamChecksum, *checksum));
   }
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   std::string ingest_uri = "/layers/" + layer_id + "/sdiiMessageList";

--- a/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/IngestApi.h
@@ -21,7 +21,7 @@
 
 #include <vector>
 
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
@@ -83,9 +83,9 @@ class IngestApi {
       const client::OlpClient& client, const std::string& layer_id,
       const std::string& content_type,
       const std::shared_ptr<std::vector<unsigned char>>& data,
-      const boost::optional<std::string>& trace_id,
-      const boost::optional<std::string>& billing_tag,
-      const boost::optional<std::string>& checksum,
+      const porting::optional<std::string>& trace_id,
+      const porting::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& checksum,
       IngestDataCallback callback);
 
   /**
@@ -94,7 +94,8 @@ class IngestApi {
    * @param layer_id Layer of the catalog where you want to store the data. The
    * layer type must be Stream.
    * @param content_type The content type configured for the target layer.
-   * @param content_encoding The content encoding configured for the target layer.
+   * @param content_encoding The content encoding configured for the target
+   * layer.
    * @param data Content to be uploaded to OLP.
    * @param trace_id Optional. A unique message ID, such as a UUID. This can be
    * included in the request if you want to use an ID that you define. If you do
@@ -117,9 +118,9 @@ class IngestApi {
       const client::OlpClient& client, const std::string& layer_id,
       const std::string& content_type, const std::string& content_encoding,
       const std::shared_ptr<std::vector<unsigned char>>& data,
-      const boost::optional<std::string>& trace_id,
-      const boost::optional<std::string>& billing_tag,
-      const boost::optional<std::string>& checksum,
+      const porting::optional<std::string>& trace_id,
+      const porting::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& checksum,
       client::CancellationContext context);
 
   /**
@@ -152,9 +153,9 @@ class IngestApi {
   static IngestSdiiResponse IngestSdii(
       const client::OlpClient& client, const std::string& layer_id,
       const std::shared_ptr<std::vector<unsigned char>>& sdii_message_list,
-      const boost::optional<std::string>& trace_id,
-      const boost::optional<std::string>& billing_tag,
-      const boost::optional<std::string>& checksum,
+      const porting::optional<std::string>& trace_id,
+      const porting::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& checksum,
       client::CancellationContext context);
 };
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/MetadataApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/MetadataApi.cpp
@@ -57,7 +57,7 @@ namespace client = olp::client;
 
 client::CancellationToken MetadataApi::GetLayerVersions(
     const client::OlpClient& client, int64_t version,
-    boost::optional<std::string> billingTag,
+    porting::optional<std::string> billingTag,
     const LayerVersionsCallback& layerVersionsCallback) {
   std::multimap<std::string, std::string> headerParams;
   headerParams.insert(std::make_pair("Accept", "application/json"));
@@ -75,11 +75,11 @@ client::CancellationToken MetadataApi::GetLayerVersions(
   client::NetworkAsyncCallback callback =
       [layerVersionsCallback](client::HttpResponse response) {
         if (response.GetStatus() != http::HttpStatusCode::OK) {
-          layerVersionsCallback(
-              client::ApiError(response.GetStatus(), response.GetResponseAsString()));
+          layerVersionsCallback(client::ApiError(
+              response.GetStatus(), response.GetResponseAsString()));
         } else {
-          layerVersionsCallback(
-              parser::parse_result<LayerVersionsResponse>(response.GetRawResponse()));
+          layerVersionsCallback(parser::parse_result<LayerVersionsResponse>(
+              response.GetRawResponse()));
         }
       };
 
@@ -89,9 +89,10 @@ client::CancellationToken MetadataApi::GetLayerVersions(
 
 client::CancellationToken MetadataApi::GetPartitions(
     const client::OlpClient& client, const std::string& layerId,
-    boost::optional<int64_t> version,
-    boost::optional<std::vector<std::string>> additionalFields,
-    boost::optional<std::string> range, boost::optional<std::string> billingTag,
+    porting::optional<int64_t> version,
+    porting::optional<std::vector<std::string>> additionalFields,
+    porting::optional<std::string> range,
+    porting::optional<std::string> billingTag,
     const PartitionsCallback& partitionsCallback) {
   std::multimap<std::string, std::string> headerParams;
   headerParams.insert(std::make_pair("Accept", "application/json"));
@@ -115,16 +116,16 @@ client::CancellationToken MetadataApi::GetPartitions(
 
   std::string metadataUri = "/layers/" + layerId + "/partitions";
 
-  client::NetworkAsyncCallback callback =
-      [partitionsCallback](client::HttpResponse response) {
-        if (response.GetStatus() != http::HttpStatusCode::OK) {
-          partitionsCallback(
-              client::ApiError(response.GetStatus(), response.GetResponseAsString()));
-        } else {
-          partitionsCallback(
-              parser::parse_result<PartitionsResponse>(response.GetRawResponse()));
-        }
-      };
+  client::NetworkAsyncCallback callback = [partitionsCallback](
+                                              client::HttpResponse response) {
+    if (response.GetStatus() != http::HttpStatusCode::OK) {
+      partitionsCallback(client::ApiError(response.GetStatus(),
+                                          response.GetResponseAsString()));
+    } else {
+      partitionsCallback(
+          parser::parse_result<PartitionsResponse>(response.GetRawResponse()));
+    }
+  };
 
   return client.CallApi(metadataUri, "GET", queryParams, headerParams,
                         formParams, nullptr, "", callback);
@@ -132,7 +133,7 @@ client::CancellationToken MetadataApi::GetPartitions(
 
 client::CancellationToken MetadataApi::GetLatestCatalogVersion(
     const client::OlpClient& client, int64_t startVersion,
-    boost::optional<std::string> billingTag,
+    porting::optional<std::string> billingTag,
     const CatalogVersionCallback& catalogVersionCallback) {
   std::multimap<std::string, std::string> headerParams;
   headerParams.insert(std::make_pair("Accept", "application/json"));
@@ -151,11 +152,11 @@ client::CancellationToken MetadataApi::GetLatestCatalogVersion(
   client::NetworkAsyncCallback callback =
       [catalogVersionCallback](client::HttpResponse response) {
         if (response.GetStatus() != http::HttpStatusCode::OK) {
-          catalogVersionCallback(
-              client::ApiError(response.GetStatus(), response.GetResponseAsString()));
+          catalogVersionCallback(client::ApiError(
+              response.GetStatus(), response.GetResponseAsString()));
         } else {
-          catalogVersionCallback(
-              parser::parse_result<CatalogVersionResponse>(response.GetRawResponse()));
+          catalogVersionCallback(parser::parse_result<CatalogVersionResponse>(
+              response.GetRawResponse()));
         }
       };
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/MetadataApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/MetadataApi.h
@@ -24,7 +24,7 @@
 
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 #include "generated/model/LayerVersions.h"
 #include "generated/model/Partitions.h"
 #include "olp/dataservice/write/model/VersionResponse.h"
@@ -68,7 +68,7 @@ class MetadataApi {
    */
   static client::CancellationToken GetLayerVersions(
       const client::OlpClient& client, int64_t version,
-      boost::optional<std::string> billingTag,
+      porting::optional<std::string> billingTag,
       const LayerVersionsCallback& callback);
 
   /**
@@ -97,10 +97,10 @@ class MetadataApi {
    */
   static client::CancellationToken GetPartitions(
       const client::OlpClient& client, const std::string& layerId,
-      boost::optional<int64_t> version,
-      boost::optional<std::vector<std::string>> additionalFields,
-      boost::optional<std::string> range,
-      boost::optional<std::string> billingTag,
+      porting::optional<int64_t> version,
+      porting::optional<std::vector<std::string>> additionalFields,
+      porting::optional<std::string> range,
+      porting::optional<std::string> billingTag,
       const PartitionsCallback& callback);
 
   /**
@@ -121,7 +121,7 @@ class MetadataApi {
    */
   static client::CancellationToken GetLatestCatalogVersion(
       const client::OlpClient& client, int64_t startVersion,
-      boost::optional<std::string> billingTag,
+      porting::optional<std::string> billingTag,
       const CatalogVersionCallback& callback);
 };
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/PublishApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/PublishApi.cpp
@@ -45,7 +45,7 @@ namespace write {
 
 client::CancellationToken PublishApi::InitPublication(
     const client::OlpClient& client, const model::Publication& publication,
-    const boost::optional<std::string>& billing_tag,
+    const porting::optional<std::string>& billing_tag,
     InitPublicationCallback callback) {
   std::multimap<std::string, std::string> header_params;
   std::multimap<std::string, std::string> query_params;
@@ -54,8 +54,7 @@ client::CancellationToken PublishApi::InitPublication(
   header_params.insert(std::make_pair("Accept", "application/json"));
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   std::string init_publication_uri = "/publications";
@@ -82,7 +81,7 @@ client::CancellationToken PublishApi::InitPublication(
 
 InitPublicationResponse PublishApi::InitPublication(
     const client::OlpClient& client, const model::Publication& publication,
-    const boost::optional<std::string>& billing_tag,
+    const porting::optional<std::string>& billing_tag,
     client::CancellationContext cancellation_context) {
   std::multimap<std::string, std::string> header_params;
   std::multimap<std::string, std::string> query_params;
@@ -91,8 +90,7 @@ InitPublicationResponse PublishApi::InitPublication(
   header_params.insert(std::make_pair("Accept", "application/json"));
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   std::string init_publication_uri = "/publications";
@@ -117,7 +115,7 @@ client::CancellationToken PublishApi::UploadPartitions(
     const client::OlpClient& client,
     const model::PublishPartitions& publish_partitions,
     const std::string& publication_id, const std::string& layer_id,
-    const boost::optional<std::string>& billing_tag,
+    const porting::optional<std::string>& billing_tag,
     UploadPartitionsCallback callback) {
   std::multimap<std::string, std::string> header_params;
   std::multimap<std::string, std::string> query_params;
@@ -126,8 +124,7 @@ client::CancellationToken PublishApi::UploadPartitions(
   header_params.insert(std::make_pair("Accept", "application/json"));
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   std::string upload_partitions_uri =
@@ -159,7 +156,7 @@ UploadPartitionsResponse PublishApi::UploadPartitions(
     const client::OlpClient& client,
     const model::PublishPartitions& publish_partitions,
     const std::string& publication_id, const std::string& layer_id,
-    const boost::optional<std::string>& billing_tag,
+    const porting::optional<std::string>& billing_tag,
     client::CancellationContext cancellation_context) {
   std::multimap<std::string, std::string> header_params;
   std::multimap<std::string, std::string> query_params;
@@ -168,8 +165,7 @@ UploadPartitionsResponse PublishApi::UploadPartitions(
   header_params.insert(std::make_pair("Accept", "application/json"));
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   std::string upload_partitions_uri =
@@ -195,7 +191,7 @@ UploadPartitionsResponse PublishApi::UploadPartitions(
 
 client::CancellationToken PublishApi::SubmitPublication(
     const client::OlpClient& client, const std::string& publication_id,
-    const boost::optional<std::string>& billing_tag,
+    const porting::optional<std::string>& billing_tag,
     SubmitPublicationCallback callback) {
   std::multimap<std::string, std::string> header_params;
   std::multimap<std::string, std::string> query_params;
@@ -204,8 +200,7 @@ client::CancellationToken PublishApi::SubmitPublication(
   header_params.insert(std::make_pair("Accept", "application/json"));
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   std::string submit_publication_uri = "/publications/" + publication_id;
@@ -229,7 +224,7 @@ client::CancellationToken PublishApi::SubmitPublication(
 
 SubmitPublicationResponse PublishApi::SubmitPublication(
     const client::OlpClient& client, const std::string& publication_id,
-    const boost::optional<std::string>& billing_tag,
+    const porting::optional<std::string>& billing_tag,
     client::CancellationContext cancellation_context) {
   std::multimap<std::string, std::string> header_params;
   std::multimap<std::string, std::string> query_params;
@@ -238,8 +233,7 @@ SubmitPublicationResponse PublishApi::SubmitPublication(
   header_params.insert(std::make_pair("Accept", "application/json"));
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   std::string submit_publication_uri = "/publications/" + publication_id;
@@ -258,7 +252,7 @@ SubmitPublicationResponse PublishApi::SubmitPublication(
 
 client::CancellationToken PublishApi::GetPublication(
     const client::OlpClient& client, const std::string& publication_id,
-    const boost::optional<std::string>& billing_tag,
+    const porting::optional<std::string>& billing_tag,
     GetPublicationCallback callback) {
   std::multimap<std::string, std::string> header_params;
   std::multimap<std::string, std::string> query_params;
@@ -267,8 +261,7 @@ client::CancellationToken PublishApi::GetPublication(
   header_params.insert(std::make_pair("Accept", "application/json"));
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   std::string get_publication_uri = "/publications/" + publication_id;
@@ -292,7 +285,7 @@ client::CancellationToken PublishApi::GetPublication(
 
 SubmitPublicationResponse PublishApi::CancelPublication(
     const client::OlpClient& client, const std::string& publication_id,
-    const boost::optional<std::string>& billing_tag,
+    const porting::optional<std::string>& billing_tag,
     client::CancellationContext context) {
   std::multimap<std::string, std::string> header_params;
   std::multimap<std::string, std::string> query_params;
@@ -301,8 +294,7 @@ SubmitPublicationResponse PublishApi::CancelPublication(
   header_params.insert(std::make_pair("Accept", "application/json"));
 
   if (billing_tag) {
-    query_params.insert(
-        std::make_pair(kQueryParamBillingTag, billing_tag.get()));
+    query_params.insert(std::make_pair(kQueryParamBillingTag, *billing_tag));
   }
 
   std::string submit_publication_uri = "/publications/" + publication_id;

--- a/olp-cpp-sdk-dataservice-write/src/generated/PublishApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/PublishApi.h
@@ -88,13 +88,13 @@ class PublishApi {
    */
   static client::CancellationToken InitPublication(
       const client::OlpClient& client, const model::Publication& publication,
-      const boost::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& billing_tag,
       InitPublicationCallback callback);
 
   /** @brief Sync version of \c InitPublication method. */
   static InitPublicationResponse InitPublication(
       const client::OlpClient& client, const model::Publication& publication,
-      const boost::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& billing_tag,
       client::CancellationContext cancellation_context);
 
   /**
@@ -124,7 +124,7 @@ class PublishApi {
       const client::OlpClient& client,
       const model::PublishPartitions& publish_partitions,
       const std::string& publication_id, const std::string& layer_id,
-      const boost::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& billing_tag,
       UploadPartitionsCallback callback);
 
   /** @brief Sync version of \c UploadPartitions method. */
@@ -132,7 +132,7 @@ class PublishApi {
       const client::OlpClient& client,
       const model::PublishPartitions& publish_partitions,
       const std::string& publication_id, const std::string& layer_id,
-      const boost::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& billing_tag,
       client::CancellationContext cancellation_context);
 
   /**
@@ -157,13 +157,13 @@ class PublishApi {
    */
   static client::CancellationToken SubmitPublication(
       const client::OlpClient& client, const std::string& publication_id,
-      const boost::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& billing_tag,
       SubmitPublicationCallback callback);
 
   /** @brief Sync version of \c SubmitPublication method. */
   static SubmitPublicationResponse SubmitPublication(
       const client::OlpClient& client, const std::string& publication_id,
-      const boost::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& billing_tag,
       client::CancellationContext cancellation_context);
 
   /**
@@ -186,7 +186,7 @@ class PublishApi {
    */
   static client::CancellationToken GetPublication(
       const client::OlpClient& client, const std::string& publication_id,
-      const boost::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& billing_tag,
       GetPublicationCallback callback);
 
   /**
@@ -205,7 +205,7 @@ class PublishApi {
    */
   static SubmitPublicationResponse CancelPublication(
       const client::OlpClient& client, const std::string& publication_id,
-      const boost::optional<std::string>& billing_tag,
+      const porting::optional<std::string>& billing_tag,
       client::CancellationContext context);
 };
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/QueryApi.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/QueryApi.cpp
@@ -55,9 +55,9 @@ namespace client = olp::client;
 client::CancellationToken QueryApi::GetPartitionsById(
     const client::OlpClient& client, const std::string& layerId,
     const std::vector<std::string>& partitionIds,
-    boost::optional<int64_t> version,
-    boost::optional<std::vector<std::string>> additionalFields,
-    boost::optional<std::string> billingTag,
+    porting::optional<int64_t> version,
+    porting::optional<std::vector<std::string>> additionalFields,
+    porting::optional<std::string> billingTag,
     const PartitionsCallback& partitionsCallback) {
   std::multimap<std::string, std::string> headerParams;
   headerParams.insert(std::make_pair("Accept", "application/json"));
@@ -80,16 +80,16 @@ client::CancellationToken QueryApi::GetPartitionsById(
 
   std::string queryUri = "/layers/" + layerId + "/partitions";
 
-  client::NetworkAsyncCallback callback =
-      [partitionsCallback](client::HttpResponse response) {
-        if (response.GetStatus() != http::HttpStatusCode::OK) {
-          partitionsCallback(
-              client::ApiError(response.GetStatus(), response.GetResponseAsString()));
-        } else {
-          partitionsCallback(
-              parser::parse_result<PartitionsResponse>(response.GetRawResponse()));
-        }
-      };
+  client::NetworkAsyncCallback callback = [partitionsCallback](
+                                              client::HttpResponse response) {
+    if (response.GetStatus() != http::HttpStatusCode::OK) {
+      partitionsCallback(client::ApiError(response.GetStatus(),
+                                          response.GetResponseAsString()));
+    } else {
+      partitionsCallback(
+          parser::parse_result<PartitionsResponse>(response.GetRawResponse()));
+    }
+  };
 
   return client.CallApi(queryUri, "GET", queryParams, headerParams, formParams,
                         nullptr, "", callback);
@@ -98,9 +98,9 @@ client::CancellationToken QueryApi::GetPartitionsById(
 QueryApi::PartitionsResponse QueryApi::GetPartitionsById(
     const client::OlpClient& client, const std::string& layer_id,
     const std::vector<std::string>& partition_ids,
-    boost::optional<int64_t> version,
-    boost::optional<std::vector<std::string>> additional_fields,
-    boost::optional<std::string> billing_tag,
+    porting::optional<int64_t> version,
+    porting::optional<std::vector<std::string>> additional_fields,
+    porting::optional<std::string> billing_tag,
     client::CancellationContext context) {
   std::multimap<std::string, std::string> header_params;
   header_params.insert(std::make_pair("Accept", "application/json"));
@@ -128,9 +128,11 @@ QueryApi::PartitionsResponse QueryApi::GetPartitionsById(
                      nullptr, "", context);
 
   if (http_response.GetStatus() != http::HttpStatusCode::OK) {
-    return client::ApiError(http_response.GetStatus(), http_response.GetResponseAsString());
+    return client::ApiError(http_response.GetStatus(),
+                            http_response.GetResponseAsString());
   }
-  return parser::parse_result<PartitionsResponse>(http_response.GetRawResponse());
+  return parser::parse_result<PartitionsResponse>(
+      http_response.GetRawResponse());
 }
 
 }  // namespace write

--- a/olp-cpp-sdk-dataservice-write/src/generated/QueryApi.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/QueryApi.h
@@ -25,7 +25,7 @@
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiResponse.h>
 #include <olp/core/client/CancellationContext.h>
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 #include "generated/model/Partitions.h"
 
 namespace olp {
@@ -49,17 +49,17 @@ class QueryApi {
   static client::CancellationToken GetPartitionsById(
       const client::OlpClient& client, const std::string& layerId,
       const std::vector<std::string>& partitionIds,
-      boost::optional<int64_t> version,
-      boost::optional<std::vector<std::string>> additionalFields,
-      boost::optional<std::string> billingTag,
+      porting::optional<int64_t> version,
+      porting::optional<std::vector<std::string>> additionalFields,
+      porting::optional<std::string> billingTag,
       const PartitionsCallback& callback);
 
   static PartitionsResponse GetPartitionsById(
       const client::OlpClient& client, const std::string& layerId,
       const std::vector<std::string>& partition_ids,
-      boost::optional<int64_t> version,
-      boost::optional<std::vector<std::string>> additional_fields,
-      boost::optional<std::string> billing_tag,
+      porting::optional<int64_t> version,
+      porting::optional<std::vector<std::string>> additional_fields,
+      porting::optional<std::string> billing_tag,
       client::CancellationContext context);
 };
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/model/Partitions.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/model/Partitions.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 
 namespace olp {
 namespace dataservice {
@@ -42,27 +42,29 @@ class Partition {
   virtual ~Partition() = default;
 
  private:
-  boost::optional<std::string> checksum_;
-  boost::optional<int64_t> compressed_data_size_;
+  porting::optional<std::string> checksum_;
+  porting::optional<int64_t> compressed_data_size_;
   std::string data_handle_;
-  boost::optional<int64_t> data_size_;
+  porting::optional<int64_t> data_size_;
   std::string partition_;
-  boost::optional<int64_t> version_;
+  porting::optional<int64_t> version_;
 
  public:
-  const boost::optional<std::string>& GetChecksum() const { return checksum_; }
-  boost::optional<std::string>& GetMutableChecksum() { return checksum_; }
-  void SetChecksum(const boost::optional<std::string>& value) {
+  const porting::optional<std::string>& GetChecksum() const {
+    return checksum_;
+  }
+  porting::optional<std::string>& GetMutableChecksum() { return checksum_; }
+  void SetChecksum(const porting::optional<std::string>& value) {
     this->checksum_ = value;
   }
 
-  const boost::optional<int64_t>& GetCompressedDataSize() const {
+  const porting::optional<int64_t>& GetCompressedDataSize() const {
     return compressed_data_size_;
   }
-  boost::optional<int64_t>& GetMutableCompressedDataSize() {
+  porting::optional<int64_t>& GetMutableCompressedDataSize() {
     return compressed_data_size_;
   }
-  void SetCompressedDataSize(const boost::optional<int64_t>& value) {
+  void SetCompressedDataSize(const porting::optional<int64_t>& value) {
     this->compressed_data_size_ = value;
   }
 
@@ -70,9 +72,9 @@ class Partition {
   std::string& GetMutableDataHandle() { return data_handle_; }
   void SetDataHandle(const std::string& value) { this->data_handle_ = value; }
 
-  const boost::optional<int64_t>& GetDataSize() const { return data_size_; }
-  boost::optional<int64_t>& GetMutableDataSize() { return data_size_; }
-  void SetDataSize(const boost::optional<int64_t>& value) {
+  const porting::optional<int64_t>& GetDataSize() const { return data_size_; }
+  porting::optional<int64_t>& GetMutableDataSize() { return data_size_; }
+  void SetDataSize(const porting::optional<int64_t>& value) {
     this->data_size_ = value;
   }
 
@@ -80,9 +82,9 @@ class Partition {
   std::string& GetMutablePartition() { return partition_; }
   void SetPartition(const std::string& value) { this->partition_ = value; }
 
-  const boost::optional<int64_t>& GetVersion() const { return version_; }
-  boost::optional<int64_t>& GetMutableVersion() { return version_; }
-  void SetVersion(const boost::optional<int64_t>& value) {
+  const porting::optional<int64_t>& GetVersion() const { return version_; }
+  porting::optional<int64_t>& GetMutableVersion() { return version_; }
+  void SetVersion(const porting::optional<int64_t>& value) {
     this->version_ = value;
   }
 };

--- a/olp-cpp-sdk-dataservice-write/src/generated/model/PublishPartition.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/model/PublishPartition.h
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 
 namespace olp {
 namespace dataservice {
@@ -40,37 +40,39 @@ class PublishPartition {
   virtual ~PublishPartition() = default;
 
  private:
-  boost::optional<std::string> partition_;
-  boost::optional<std::string> checksum_;
-  boost::optional<int64_t> compressed_data_size_;
-  boost::optional<int64_t> data_size_;
+  porting::optional<std::string> partition_;
+  porting::optional<std::string> checksum_;
+  porting::optional<int64_t> compressed_data_size_;
+  porting::optional<int64_t> data_size_;
   std::shared_ptr<std::vector<unsigned char>> data_;
-  boost::optional<std::string> data_handle_;
-  boost::optional<int64_t> timestamp_;
+  porting::optional<std::string> data_handle_;
+  porting::optional<int64_t> timestamp_;
 
  public:
-  const boost::optional<std::string>& GetPartition() const {
+  const porting::optional<std::string>& GetPartition() const {
     return partition_;
   }
-  boost::optional<std::string>& GetMutablePartition() { return partition_; }
+  porting::optional<std::string>& GetMutablePartition() { return partition_; }
   void SetPartition(const std::string& value) { this->partition_ = value; }
 
-  const boost::optional<std::string>& GetChecksum() const { return checksum_; }
-  boost::optional<std::string>& GetMutableChecksum() { return checksum_; }
+  const porting::optional<std::string>& GetChecksum() const {
+    return checksum_;
+  }
+  porting::optional<std::string>& GetMutableChecksum() { return checksum_; }
   void SetChecksum(const std::string& value) { this->checksum_ = value; }
 
-  const boost::optional<int64_t>& GetCompressedDataSize() const {
+  const porting::optional<int64_t>& GetCompressedDataSize() const {
     return compressed_data_size_;
   }
-  boost::optional<int64_t>& GetMutableCompressedDataSize() {
+  porting::optional<int64_t>& GetMutableCompressedDataSize() {
     return compressed_data_size_;
   }
   void SetCompressedDataSize(const int64_t& value) {
     this->compressed_data_size_ = value;
   }
 
-  const boost::optional<int64_t>& GetDataSize() const { return data_size_; }
-  boost::optional<int64_t>& GetMutableDataSize() { return data_size_; }
+  const porting::optional<int64_t>& GetDataSize() const { return data_size_; }
+  porting::optional<int64_t>& GetMutableDataSize() { return data_size_; }
   void SetDataSize(const int64_t& value) { this->data_size_ = value; }
 
   const std::shared_ptr<std::vector<unsigned char>>& GetData() const {
@@ -83,14 +85,16 @@ class PublishPartition {
     this->data_ = value;
   }
 
-  const boost::optional<std::string>& GetDataHandle() const {
+  const porting::optional<std::string>& GetDataHandle() const {
     return data_handle_;
   }
-  boost::optional<std::string>& GetMutableDataHandle() { return data_handle_; }
+  porting::optional<std::string>& GetMutableDataHandle() {
+    return data_handle_;
+  }
   void SetDataHandle(const std::string& value) { this->data_handle_ = value; }
 
-  const boost::optional<int64_t>& GetTimestamp() const { return timestamp_; }
-  boost::optional<int64_t>& GetMutableTimestamp() { return timestamp_; }
+  const porting::optional<int64_t>& GetTimestamp() const { return timestamp_; }
+  porting::optional<int64_t>& GetMutableTimestamp() { return timestamp_; }
   void SetTimestamp(const int64_t& value) { this->timestamp_ = value; }
 };
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/model/PublishPartitions.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/model/PublishPartitions.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/optional.hpp>
+#include <olp/core/porting/optional.hpp>
 
 #include <generated/model/PublishPartition.h>
 
@@ -41,13 +41,14 @@ class PublishPartitions {
   virtual ~PublishPartitions() = default;
 
  private:
-  boost::optional<std::vector<PublishPartition>> partitions_;
+  porting::optional<std::vector<PublishPartition>> partitions_;
 
  public:
-  const boost::optional<std::vector<PublishPartition>>& GetPartitions() const {
+  const porting::optional<std::vector<PublishPartition>>& GetPartitions()
+      const {
     return partitions_;
   }
-  boost::optional<std::vector<PublishPartition>>& GetMutablePartitions() {
+  porting::optional<std::vector<PublishPartition>>& GetMutablePartitions() {
     return partitions_;
   }
   void SetPartitions(const std::vector<PublishPartition>& value) {

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PartitionsParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PartitionsParser.cpp
@@ -23,16 +23,16 @@
 
 namespace olp {
 namespace parser {
-using namespace olp::dataservice::write;
+namespace model = dataservice::write::model;
 
 void from_json(const rapidjson::Value& value, model::Partition& x) {
-  x.SetChecksum(parse<boost::optional<std::string>>(value, "checksum"));
+  x.SetChecksum(parse<porting::optional<std::string>>(value, "checksum"));
   x.SetCompressedDataSize(
-      parse<boost::optional<int64_t>>(value, "compressedDataSize"));
+      parse<porting::optional<int64_t>>(value, "compressedDataSize"));
   x.SetDataHandle(parse<std::string>(value, "dataHandle"));
-  x.SetDataSize(parse<boost::optional<int64_t>>(value, "dataSize"));
+  x.SetDataSize(parse<porting::optional<int64_t>>(value, "dataSize"));
   x.SetPartition(parse<std::string>(value, "partition"));
-  x.SetVersion(parse<boost::optional<int64_t>>(value, "version"));
+  x.SetVersion(parse<porting::optional<int64_t>>(value, "version"));
 }
 
 void from_json(const rapidjson::Value& value, model::Partitions& x) {

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/IndexInfoSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/IndexInfoSerializer.cpp
@@ -29,7 +29,13 @@ void to_json(const dataservice::write::model::Index &x, rapidjson::Value &value,
 
   rapidjson::Value indexFields(rapidjson::kObjectType);
   for (auto &field_pair : x.GetIndexFields()) {
-    using namespace dataservice::write::model;
+    using dataservice::write::model::BooleanIndexValue;
+    using dataservice::write::model::HereTileIndexValue;
+    using dataservice::write::model::IndexType;
+    using dataservice::write::model::IntIndexValue;
+    using dataservice::write::model::StringIndexValue;
+    using dataservice::write::model::TimeWindowIndexValue;
+
     const auto &field = field_pair.second;
     const auto key = rapidjson::StringRef(field_pair.first.c_str());
     auto index_type = field->getIndexType();
@@ -59,7 +65,7 @@ void to_json(const dataservice::write::model::Index &x, rapidjson::Value &value,
   // by another model.
   if (x.GetMetadata()) {
     rapidjson::Value metadatas(rapidjson::kObjectType);
-    for (auto metadata : x.GetMetadata().get()) {
+    for (const auto &metadata : *x.GetMetadata()) {
       auto metadata_value = metadata.second;
       auto metadata_key = metadata.first.c_str();
       indexFields.AddMember(
@@ -70,13 +76,12 @@ void to_json(const dataservice::write::model::Index &x, rapidjson::Value &value,
   }
 
   if (x.GetCheckSum()) {
-    jsonValue.AddMember("checksum",
-                        rapidjson::StringRef(x.GetCheckSum().get().c_str()),
-                        allocator);
+    jsonValue.AddMember(
+        "checksum", rapidjson::StringRef(x.GetCheckSum()->c_str()), allocator);
   }
 
   if (x.GetSize()) {
-    jsonValue.AddMember("size", x.GetSize().get(), allocator);
+    jsonValue.AddMember("size", *x.GetSize(), allocator);
   }
   value.PushBack(jsonValue, allocator);
 }

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublicationSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublicationSerializer.cpp
@@ -25,8 +25,7 @@ void to_json(const dataservice::write::model::Publication& x,
              rapidjson::Value& value,
              rapidjson::Document::AllocatorType& allocator) {
   if (x.GetId()) {
-    value.AddMember("id", rapidjson::StringRef(x.GetId().get().c_str()),
-                    allocator);
+    value.AddMember("id", rapidjson::StringRef(x.GetId()->c_str()), allocator);
   }
 
   // TODO: Separate Details Model serializtion into it's own file when needed by
@@ -47,19 +46,19 @@ void to_json(const dataservice::write::model::Publication& x,
 
   if (x.GetLayerIds()) {
     rapidjson::Value layer_ids(rapidjson::kArrayType);
-    for (auto& layer_id : x.GetLayerIds().get()) {
+    for (auto& layer_id : *x.GetLayerIds()) {
       layer_ids.PushBack(rapidjson::StringRef(layer_id.c_str()), allocator);
     }
     value.AddMember("layerIds", layer_ids, allocator);
   }
 
   if (x.GetCatalogVersion()) {
-    value.AddMember("catalogVersion", x.GetCatalogVersion().get(), allocator);
+    value.AddMember("catalogVersion", *x.GetCatalogVersion(), allocator);
   }
 
   if (x.GetVersionDependencies()) {
     rapidjson::Value version_dependencies(rapidjson::kArrayType);
-    for (auto& version_dependency : x.GetVersionDependencies().get()) {
+    for (auto& version_dependency : *x.GetVersionDependencies()) {
       // TODO: Separate VersionDependency Model serializtion into it's own file
       // when needed by another model.
       rapidjson::Value version_dependency_json(rapidjson::kObjectType);

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishDataRequestSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishDataRequestSerializer.cpp
@@ -35,20 +35,18 @@ void to_json(const dataservice::write::model::PublishDataRequest& x,
                   allocator);
 
   if (x.GetTraceId()) {
-    value.AddMember("traceId",
-                    rapidjson::StringRef(x.GetTraceId().get().c_str()),
+    value.AddMember("traceId", rapidjson::StringRef(x.GetTraceId()->c_str()),
                     allocator);
   }
 
   if (x.GetBillingTag()) {
     value.AddMember("billingTag",
-                    rapidjson::StringRef(x.GetBillingTag().get().c_str()),
+                    rapidjson::StringRef(x.GetBillingTag()->c_str()),
                     allocator);
   }
 
   if (x.GetChecksum()) {
-    value.AddMember("checksum",
-                    rapidjson::StringRef(x.GetChecksum().get().c_str()),
+    value.AddMember("checksum", rapidjson::StringRef(x.GetChecksum()->c_str()),
                     allocator);
   }
 }

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionSerializer.cpp
@@ -26,23 +26,21 @@ void to_json(const dataservice::write::model::PublishPartition& x,
              rapidjson::Document::AllocatorType& allocator) {
   if (x.GetPartition()) {
     value.AddMember("partition",
-                    rapidjson::StringRef(x.GetPartition().get().c_str()),
-                    allocator);
+                    rapidjson::StringRef(x.GetPartition()->c_str()), allocator);
   }
 
   if (x.GetChecksum()) {
-    value.AddMember("checksum",
-                    rapidjson::StringRef(x.GetChecksum().get().c_str()),
+    value.AddMember("checksum", rapidjson::StringRef(x.GetChecksum()->c_str()),
                     allocator);
   }
 
   if (x.GetCompressedDataSize()) {
-    value.AddMember("compressedDataSize", x.GetCompressedDataSize().get(),
+    value.AddMember("compressedDataSize", *x.GetCompressedDataSize(),
                     allocator);
   }
 
   if (x.GetDataSize()) {
-    value.AddMember("dataSize", x.GetDataSize().get(), allocator);
+    value.AddMember("dataSize", *x.GetDataSize(), allocator);
   }
 
   if (x.GetData()) {
@@ -54,12 +52,12 @@ void to_json(const dataservice::write::model::PublishPartition& x,
 
   if (x.GetDataHandle()) {
     value.AddMember("dataHandle",
-                    rapidjson::StringRef(x.GetDataHandle().get().c_str()),
+                    rapidjson::StringRef(x.GetDataHandle()->c_str()),
                     allocator);
   }
 
   if (x.GetTimestamp()) {
-    value.AddMember("timestamp", x.GetTimestamp().get(), allocator);
+    value.AddMember("timestamp", *x.GetTimestamp(), allocator);
   }
 }
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionsSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionsSerializer.cpp
@@ -28,7 +28,7 @@ void to_json(const dataservice::write::model::PublishPartitions& x,
              rapidjson::Document::AllocatorType& allocator) {
   if (x.GetPartitions()) {
     rapidjson::Value partitions(rapidjson::kArrayType);
-    for (auto& partition : x.GetPartitions().get()) {
+    for (auto& partition : *x.GetPartitions()) {
       rapidjson::Value partition_value(rapidjson::kObjectType);
       to_json(partition, partition_value, allocator);
       partitions.PushBack(partition_value, allocator);

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/UpdateIndexRequestSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/UpdateIndexRequestSerializer.cpp
@@ -32,7 +32,13 @@ void to_json(const dataservice::write::model::UpdateIndexRequest &x,
 
     rapidjson::Value indexFields(rapidjson::kObjectType);
     for (const auto &field_pair : addition.GetIndexFields()) {
-      using namespace dataservice::write::model;
+      using dataservice::write::model::BooleanIndexValue;
+      using dataservice::write::model::HereTileIndexValue;
+      using dataservice::write::model::IndexType;
+      using dataservice::write::model::IntIndexValue;
+      using dataservice::write::model::StringIndexValue;
+      using dataservice::write::model::TimeWindowIndexValue;
+
       const auto &field = field_pair.second;
       const auto key = rapidjson::StringRef(field_pair.first.c_str());
       auto index_type = field->getIndexType();
@@ -63,9 +69,9 @@ void to_json(const dataservice::write::model::UpdateIndexRequest &x,
     // by another model.
     if (addition.GetMetadata()) {
       rapidjson::Value metadatas(rapidjson::kObjectType);
-      for (const auto& metadata : addition.GetMetadata().get()) {
-        const auto& metadata_value = metadata.second;
-        const auto& metadata_key = metadata.first.c_str();
+      for (const auto &metadata : *addition.GetMetadata()) {
+        const auto &metadata_value = metadata.second;
+        const auto &metadata_key = metadata.first.c_str();
         indexFields.AddMember(
             rapidjson::StringRef(metadata_key),
             rapidjson::StringRef(metadata_value.c_str(), metadata_value.size()),
@@ -75,13 +81,12 @@ void to_json(const dataservice::write::model::UpdateIndexRequest &x,
 
     if (addition.GetCheckSum()) {
       additionValue.AddMember(
-          "checksum",
-          rapidjson::StringRef(addition.GetCheckSum().get().c_str()),
+          "checksum", rapidjson::StringRef(addition.GetCheckSum()->c_str()),
           allocator);
     }
 
     if (addition.GetSize()) {
-      additionValue.AddMember("size", addition.GetSize().get(), allocator);
+      additionValue.AddMember("size", *addition.GetSize(), allocator);
     }
 
     additions.PushBack(additionValue, allocator);

--- a/olp-cpp-sdk-dataservice-write/tests/ParserTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/ParserTest.cpp
@@ -41,7 +41,13 @@
 
 namespace {
 
-using namespace olp::dataservice::write::model;
+using olp::dataservice::write::model::Details;
+using olp::dataservice::write::model::Publication;
+using olp::dataservice::write::model::PublishPartition;
+using olp::dataservice::write::model::PublishPartitions;
+using olp::dataservice::write::model::ResponseOk;
+using olp::dataservice::write::model::ResponseOkSingle;
+using olp::dataservice::write::model::VersionDependency;
 
 TEST(ParserTest, ResponseOkSingle) {
   auto json = R"(
@@ -472,11 +478,11 @@ TEST(ParserTest, PublishPartition) {
 
   auto response = olp::parser::parse<PublishPartition>(json);
 
-  EXPECT_STREQ("314010583", response.GetPartition().get().c_str());
+  EXPECT_STREQ("314010583", response.GetPartition()->c_str());
   EXPECT_STREQ("ff7494d6f17da702862e550c907c0a91",
-               response.GetChecksum().get().c_str());
-  EXPECT_EQ(152417, response.GetCompressedDataSize().get());
-  EXPECT_EQ(250110, response.GetDataSize().get());
+               response.GetChecksum()->c_str());
+  EXPECT_EQ(152417, *response.GetCompressedDataSize());
+  EXPECT_EQ(250110, *response.GetDataSize());
   auto data = response.GetData();
   EXPECT_STREQ(
       "iVBORw0KGgoAAAANSUhEUgAAADAAAAAwBAMAAAClLOS0AAAABGdBTUEAALGPC/"
@@ -485,8 +491,8 @@ TEST(ParserTest, PublishPartition) {
       "3zHYufF1Lf9HdIZBfNEiKAAAAAElFTkSuQmCC",
       std::string(data->begin(), data->end()).c_str());
   EXPECT_STREQ("1b2ca68f-d4a0-4379-8120-cd025640510c",
-               response.GetDataHandle().get().c_str());
-  EXPECT_EQ(1519219235, response.GetTimestamp().get());
+               response.GetDataHandle()->c_str());
+  EXPECT_EQ(1519219235, *response.GetTimestamp());
 }
 
 TEST(ParserTest, PublishPartitions) {
@@ -507,15 +513,15 @@ TEST(ParserTest, PublishPartitions) {
   )";
 
   auto response = olp::parser::parse<PublishPartitions>(json);
-  ASSERT_EQ(1, response.GetPartitions().get().size());
+  ASSERT_EQ(1, response.GetPartitions()->size());
 
-  auto partition = response.GetPartitions().get().at(0);
+  auto partition = response.GetPartitions()->at(0);
 
-  EXPECT_STREQ("314010583", partition.GetPartition().get().c_str());
+  EXPECT_STREQ("314010583", partition.GetPartition()->c_str());
   EXPECT_STREQ("ff7494d6f17da702862e550c907c0a91",
-               partition.GetChecksum().get().c_str());
-  EXPECT_EQ(152417, partition.GetCompressedDataSize().get());
-  EXPECT_EQ(250110, partition.GetDataSize().get());
+               partition.GetChecksum()->c_str());
+  EXPECT_EQ(152417, *partition.GetCompressedDataSize());
+  EXPECT_EQ(250110, *partition.GetDataSize());
   auto data = partition.GetData();
   EXPECT_STREQ(
       "iVBORw0KGgoAAAANSUhEUgAAADAAAAAwBAMAAAClLOS0AAAABGdBTUEAALGPC/"
@@ -524,8 +530,8 @@ TEST(ParserTest, PublishPartitions) {
       "3zHYufF1Lf9HdIZBfNEiKAAAAAElFTkSuQmCC",
       std::string(data->begin(), data->end()).c_str());
   EXPECT_STREQ("1b2ca68f-d4a0-4379-8120-cd025640510c",
-               partition.GetDataHandle().get().c_str());
-  EXPECT_EQ(1519219235, partition.GetTimestamp().get());
+               partition.GetDataHandle()->c_str());
+  EXPECT_EQ(1519219235, *partition.GetTimestamp());
 }
 
 TEST(ParserTest, Details) {
@@ -560,7 +566,8 @@ TEST(ParserTest, VersionDependency) {
   auto response = olp::parser::parse<VersionDependency>(json);
 
   EXPECT_TRUE(response.GetDirect());
-  EXPECT_STREQ("hrn:here:data::olp-here-test:my-catalog", response.GetHrn().c_str());
+  EXPECT_STREQ("hrn:here:data::olp-here-test:my-catalog",
+               response.GetHrn().c_str());
   EXPECT_EQ(1, response.GetVersion());
 }
 
@@ -592,22 +599,22 @@ TEST(ParserTest, Publication) {
   auto response = olp::parser::parse<Publication>(json);
 
   EXPECT_STREQ("34bc2a16-0373-4157-8ccc-19ba08a6672b",
-               response.GetId().get().c_str());
+               response.GetId()->c_str());
 
-  auto details = response.GetDetails().get();
+  auto details = *response.GetDetails();
   EXPECT_STREQ("initialized", details.GetState().c_str());
   EXPECT_STREQ("Publication initialized", details.GetMessage().c_str());
   EXPECT_EQ(1523459129829, details.GetStarted());
   EXPECT_EQ(1523459129829, details.GetModified());
   EXPECT_EQ(1523459129829, details.GetExpires());
 
-  ASSERT_EQ(1, response.GetLayerIds().get().size());
-  EXPECT_STREQ("my-layer", response.GetLayerIds().get().at(0).c_str());
+  ASSERT_EQ(1, response.GetLayerIds()->size());
+  EXPECT_STREQ("my-layer", response.GetLayerIds()->at(0).c_str());
 
-  EXPECT_EQ(1, response.GetCatalogVersion().get());
+  EXPECT_EQ(1, *response.GetCatalogVersion());
 
-  ASSERT_EQ(1, response.GetVersionDependencies().get().size());
-  auto version_dependency = response.GetVersionDependencies().get().at(0);
+  ASSERT_EQ(1, response.GetVersionDependencies()->size());
+  auto version_dependency = response.GetVersionDependencies()->at(0);
 
   EXPECT_TRUE(version_dependency.GetDirect());
   EXPECT_STREQ("hrn:here:data::olp-here-test:my-catalog",

--- a/olp-cpp-sdk-dataservice-write/tests/StreamLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/StreamLayerClientImplTest.cpp
@@ -373,9 +373,8 @@ TEST_F(StreamLayerClientImplTest, CancelPublishDataLessThanTwentyMib) {
                                          olp::http::Network::Callback,
                                          olp::http::Network::HeaderCallback,
                                          olp::http::Network::DataCallback) {
-    std::thread([cancel_context]() {
-      cancel_context->CancelOperation();
-    }).detach();
+    std::thread([cancel_context]() { cancel_context->CancelOperation(); })
+        .detach();
 
     constexpr auto unused_request_id = 5;
     return olp::http::SendOutcome(unused_request_id);
@@ -742,7 +741,7 @@ TEST_F(StreamLayerClientImplTest, QueueAndFlush) {
                         client::CancellationContext /*context*/)
                          -> write::PublishDataResponse {
         write::PublishDataResult result;
-        result.SetTraceID(request.GetTraceId().get());
+        result.SetTraceID(*request.GetTraceId());
         return write::PublishDataResponse{result};
       });
   ON_CALL(*client, GenerateUuid)
@@ -761,8 +760,8 @@ TEST_F(StreamLayerClientImplTest, QueueAndFlush) {
             .WithData(std::make_shared<std::vector<unsigned char>>(1, 'z'))
             .WithLayerId("layer");
 
-    auto error = client->Queue(std::move(request));
-    EXPECT_EQ(boost::none, error) << *error;
+    auto error = client->Queue(request);
+    EXPECT_EQ(olp::porting::none, error) << *error;
   }
 
   EXPECT_EQ(client->QueueSize(), kBatchSize);

--- a/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplPublishToBatchTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplPublishToBatchTest.cpp
@@ -135,7 +135,7 @@ class VersionedLayerClientImplPublishToBatchTest : public ::testing::Test {
       int status = olp::http::HttpStatusCode::NO_CONTENT) {
     auto api = MockApiRequest("publish");
     const std::string url = api.GetBaseUrl() + "/layers/" + layer +
-                            "/publications/" + publication.GetId().get() +
+                            "/publications/" + *publication.GetId() +
                             "/partitions";
 
     EXPECT_CALL(*network_, Send(IsPostRequest(url), _, _, _, _))

--- a/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplTest.cpp
@@ -154,8 +154,8 @@ TEST_F(VersionedLayerClientImplTest, StartBatch) {
     ASSERT_TRUE(result.GetId());
     ASSERT_TRUE(result.GetDetails());
     ASSERT_TRUE(result.GetLayerIds());
-    ASSERT_EQ(result.GetLayerIds().get().size(), 1);
-    ASSERT_EQ(result.GetLayerIds().get().front(), kLayer);
+    ASSERT_EQ(result.GetLayerIds()->size(), 1);
+    ASSERT_EQ(result.GetLayerIds()->front(), kLayer);
     ASSERT_NE("", response.GetResult().GetId().value());
     Mock::VerifyAndClearExpectations(network_.get());
     Mock::VerifyAndClearExpectations(cache_.get());
@@ -196,8 +196,8 @@ TEST_F(VersionedLayerClientImplTest, StartBatch) {
     ASSERT_TRUE(result.GetId());
     ASSERT_TRUE(result.GetDetails());
     ASSERT_TRUE(result.GetLayerIds());
-    ASSERT_EQ(result.GetLayerIds().get().size(), 1);
-    ASSERT_EQ(result.GetLayerIds().get().front(), kLayer);
+    ASSERT_EQ(result.GetLayerIds()->size(), 1);
+    ASSERT_EQ(result.GetLayerIds()->front(), kLayer);
     ASSERT_NE("", response.GetResult().GetId().value());
     Mock::VerifyAndClearExpectations(network_.get());
     Mock::VerifyAndClearExpectations(cache_.get());
@@ -228,8 +228,8 @@ TEST_F(VersionedLayerClientImplTest, StartBatch) {
     ASSERT_TRUE(result.GetId());
     ASSERT_TRUE(result.GetDetails());
     ASSERT_TRUE(result.GetLayerIds());
-    ASSERT_EQ(result.GetLayerIds().get().size(), 1);
-    ASSERT_EQ(result.GetLayerIds().get().front(), kLayer);
+    ASSERT_EQ(result.GetLayerIds()->size(), 1);
+    ASSERT_EQ(result.GetLayerIds()->front(), kLayer);
     ASSERT_NE("", response.GetResult().GetId().value());
     Mock::VerifyAndClearExpectations(network_.get());
     Mock::VerifyAndClearExpectations(cache_.get());
@@ -417,8 +417,7 @@ TEST_F(VersionedLayerClientImplTest, CompleteBatch) {
   ASSERT_FALSE(api.empty());
   ASSERT_TRUE(publication.GetId());
 
-  const auto publication_publish_url =
-      kPublishUrl + "/" + publication.GetId().get();
+  const auto publication_publish_url = kPublishUrl + "/" + *publication.GetId();
 
   // auth token should be valid till the end of all tests
   EXPECT_CALL(


### PR DESCRIPTION
Currently, SDK requires C++11 minimum.
So, boost::optional type is used for optional values. For C++17 and above more convenient is to use std::optional instead. The task NLAM-23 is about making this type configurable. This commit is a second part of the task: olp-cpp-sdk-write.

Relates-To: NLAM-23