### PR TITLE
Exclude deleted files from format verification

### DIFF
--- a/scripts/misc/clang_format_ci.sh
+++ b/scripts/misc/clang_format_ci.sh
@@ -39,8 +39,8 @@ git branch --all
 git fetch origin master
 git branch --all
 # Get affected files and filter source files
-FILES=$(git diff-tree --no-commit-id --name-only -r origin/master "$CURRENT_BRANCH" \
-        | grep '\.c\|\.cpp\|\.cxx\|\.h\|\.hpp\|\.hxx')
+FILES=$(git diff-tree --no-commit-id --name-only --diff-filter=d -r origin/master "$CURRENT_BRANCH" \
+        | grep '\.c\|\.cpp\|\.cxx\|\.h\|\.hpp\|\.hxx\|\.mm')
 
 if [ -z "$FILES" ]; then
   printf "No affected files, exiting.\n"


### PR DESCRIPTION
Verification script returns error for deleted files thus the whole job marked as failed.
There's no need to check deleted files

Added .mm (Objective-C++) files to the list of verified files as such files are present in the repository and have formatting setup as well