### PR TITLE
Disable transfer encoding for old CURL versions

### DIFF
--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
@@ -817,6 +817,9 @@ ErrorCode NetworkCurl::SendImplementation(
 
 #if CURL_AT_LEAST_VERSION(7, 21, 0)
   curl_easy_setopt(curl_handle, CURLOPT_ACCEPT_ENCODING, "");
+#endif
+
+#if CURL_AT_LEAST_VERSION(8, 12, 0)
   curl_easy_setopt(curl_handle, CURLOPT_TRANSFER_ENCODING, 1L);
 #endif
 


### PR DESCRIPTION
Otherwise some combinations of server-clients may fail
to transfer the data with bad request error
and data similar to '"TE" may only be "trailers" in HTTP/2'

It has been fixed in CURL 8.12.0 by explicitly stripping TE header
from HTTP/2 requests

Relates-To: NLAM-55