### PR TITLE
Add method to list keys

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/cache/KeyValueCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/KeyValueCache.h
@@ -244,6 +244,20 @@ class CORE_API KeyValueCache {
     OLP_SDK_CORE_UNUSED(prefix);
     return client::ApiError(client::ErrorCode::Unknown, "Not implemented");
   }
+
+  /**
+   * @brief Lists the keys that match the given prefix.
+   *
+   * @param prefix The prefix that matches the keys.
+   *
+   * @return The collection of matched keys or an error. Empty collection if not
+   * keys match the prefix.
+   */
+  virtual OperationOutcome<KeyListType> ListKeysWithPrefix(
+      const std::string& prefix) {
+    OLP_SDK_CORE_UNUSED(prefix);
+    return client::ApiError(client::ErrorCode::Unknown, "Not implemented");
+  }
 };
 
 }  // namespace cache

--- a/olp-cpp-sdk-core/tests/cache/DefaultCacheTest.cpp
+++ b/olp-cpp-sdk-core/tests/cache/DefaultCacheTest.cpp
@@ -749,6 +749,16 @@ TEST(DefaultCacheTest, OpenTypeCache) {
   }
 }
 
+TEST(DefaultCacheTest, ListKeysWithPrefixNotImplemented) {
+  olp::cache::DefaultCache cache;
+
+  const auto result = cache.ListKeysWithPrefix("prefix");
+
+  EXPECT_FALSE(result.IsSuccessful());
+  EXPECT_EQ(olp::client::ErrorCode::Unknown, result.GetError().GetErrorCode());
+  EXPECT_EQ("Not implemented", result.GetError().GetMessage());
+}
+
 struct TestParameters {
   OptionalString disk_path_mutable = kTempDirMutable;
   OptionalString disk_path_protected = olp::porting::none;


### PR DESCRIPTION
Adds interface for the method to list keys available in the cache. 

Allows client software to not maintain the journal or another metadata to
maintain a list of entries available in the database. Moreover, having
an explicit journal is still not reliable as API does not provide an interface
for maintaining transactions in order to have an atomic insert + journal update.

This API will help to implement reliable uploading strategy: in case of
upload failure payload will be stored on the disk and retried later.

In order to query payloads effectively, software needs to access the
list of available keys.

Relates-To: HERESDK-8383