### PR TITLE
Add censor API to Log

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/logging/Log.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/Log.h
@@ -571,7 +571,17 @@ class CORE_API Log {
    *
    * @param message The line to be censored out from the log.
    */
-  static void censor(const std::string& message);
+  static void addCensor(const std::string& message);
+
+  /**
+   * @brief Removes a line from censoring out from the log.
+   *
+   * Censoring out is a replacement with a predefiend mask with length not
+   * correlated with the original line length.
+   *
+   * @param message The line to be excluded from censoring out from the log.
+   */
+  static void removeCensor(const std::string& message);
 };
 }  // namespace logging
 }  // namespace olp

--- a/olp-cpp-sdk-core/tests/logging/LogTest.cpp
+++ b/olp-cpp-sdk-core/tests/logging/LogTest.cpp
@@ -429,9 +429,9 @@ TEST(LogTest, LogCensor) {
   constexpr auto secret_02 = "to hide";
   constexpr auto secret_mask = "******";
 
-  olp::logging::Log::censor(secret_01);
-  olp::logging::Log::censor(secret_02);
-  olp::logging::Log::censor(secret_mask);
+  olp::logging::Log::addCensor(secret_01);
+  olp::logging::Log::addCensor(secret_02);
+  olp::logging::Log::addCensor(secret_mask);
 
   OLP_SDK_LOG_INFO_F("", "Nothing to censor");
   OLP_SDK_LOG_INFO_F("", "Inlined1st secretin message");
@@ -452,6 +452,16 @@ TEST(LogTest, LogCensor) {
   EXPECT_EQ("***** twice *****", appender->messages_[5].message_);
   EXPECT_EQ("no loop **********", appender->messages_[6].message_);
   EXPECT_EQ("Fatal *****", appender->messages_[7].message_);
+
+  olp::logging::Log::removeCensor("not exisiting secret");
+  OLP_SDK_LOG_TRACE_F("trace", "%s %s", "plain", secret_01);
+  olp::logging::Log::removeCensor(secret_01);
+  OLP_SDK_LOG_TRACE_F("trace", "%s %s", "plain", secret_01);
+
+  ASSERT_EQ(10U, appender->messages_.size());
+
+  EXPECT_EQ("plain *****", appender->messages_[8].message_);
+  EXPECT_EQ("plain 1st secret", appender->messages_[9].message_);
 }
 
 TEST(LogTest, LogLimits) {


### PR DESCRIPTION
It allows to set values to be masked from the log messages at runtime

Relates-To: NLAM-140