### PR TITLE
Create olp::porting::any to use either boost::any or std::any

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ option(OLP_SDK_ENABLE_TESTING "Flag to enable/disable building unit and integrat
 option(OLP_SDK_BUILD_DOC "Build SDK documentation" OFF)
 option(OLP_SDK_NO_EXCEPTION "Disable exception handling" OFF)
 option(OLP_SDK_USE_STD_OPTIONAL "Use std::optional instead of boost::optional with C++17 and above" OFF)
+option(OLP_SDK_USE_STD_ANY "Use std::any instead of boost::any with C++17 and above" OFF)
 option(OLP_SDK_BOOST_THROW_EXCEPTION_EXTERNAL "The boost::throw_exception() is defined externally" OFF)
 option(OLP_SDK_BUILD_EXTERNAL_DEPS "Download and build external dependencies" ON)
 option(OLP_SDK_BUILD_EXAMPLES "Enable examples targets" OFF)

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -131,6 +131,7 @@ cmake --build . --target docs
 | `OLP_SDK_BUILD_EXTERNAL_DEPS` | Defaults to `ON`. If enabled, CMake downloads and compiles dependencies. |
 | `OLP_SDK_NO_EXCEPTION` | Defaults to `OFF`. If enabled, all libraries are built without exceptions. |
 | `OLP_SDK_USE_STD_OPTIONAL` | Defaults to `OFF`. If enabled, all libraries are built with std::optional type instead of boost::optional for C++17 and above. |
+| `OLP_SDK_USE_STD_ANY` | Defaults to `OFF`. If enabled, all libraries are built with std::any type instead of boost::any for C++17 and above. |
 | `OLP_SDK_BOOST_THROW_EXCEPTION_EXTERNAL` | Defaults to `OFF`. When `OLP_SDK_NO_EXCEPTION` is `ON`, `boost` requires `boost::throw_exception()` to be defined. If enabled, the external definition of `boost::throw_exception()` is used. Otherwise, the library uses own definition. |
 | `OLP_SDK_MSVC_PARALLEL_BUILD_ENABLE` (Windows Only) | Defaults to `ON`. If enabled, the `/MP` compilation flag is added to build the Data SDK using multiple cores. |
 | `OLP_SDK_DISABLE_DEBUG_LOGGING`| Defaults to `OFF`. If enabled, the debug and trace level log messages are not printed. |

--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -128,6 +128,7 @@ set(OLP_SDK_PLATFORM_HEADERS
 )
 
 set(OLP_SDK_PORTING_HEADERS
+    ./include/olp/core/porting/any.h
     ./include/olp/core/porting/deprecated.h
     ./include/olp/core/porting/export.h
     ./include/olp/core/porting/make_unique.h
@@ -448,6 +449,11 @@ endif()
 if (OLP_SDK_USE_STD_OPTIONAL)
     target_compile_definitions(${PROJECT_NAME}
         PUBLIC OLP_CPP_SDK_USE_STD_OPTIONAL)
+endif()
+
+if (OLP_SDK_USE_STD_ANY)
+    target_compile_definitions(${PROJECT_NAME}
+        PUBLIC OLP_SDK_USE_STD_ANY)
 endif()
 
 target_include_directories(${PROJECT_NAME} PUBLIC

--- a/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/DefaultCache.h
@@ -158,7 +158,7 @@ class CORE_API DefaultCache : public KeyValueCache {
    *
    * @return True if the operation is successful; false otherwise.
    */
-  bool Put(const std::string& key, const boost::any& value,
+  bool Put(const std::string& key, const olp::porting::any& value,
            const Encoder& encoder, time_t expiry) override;
 
   /**
@@ -181,7 +181,8 @@ class CORE_API DefaultCache : public KeyValueCache {
    *
    * @return The key-value pair.
    */
-  boost::any Get(const std::string& key, const Decoder& decoder) override;
+  olp::porting::any Get(const std::string& key,
+                        const Decoder& decoder) override;
 
   /**
    * @brief Gets the key and binary data from the cache.

--- a/olp-cpp-sdk-core/include/olp/core/cache/KeyValueCache.h
+++ b/olp-cpp-sdk-core/include/olp/core/cache/KeyValueCache.h
@@ -30,14 +30,14 @@
 #include <olp/core/client/ApiError.h>
 #include <olp/core/client/ApiNoResult.h>
 #include <olp/core/client/ApiResponse.h>
+#include <olp/core/porting/any.h>
 #include <olp/core/utils/WarningWorkarounds.h>
-#include <boost/any.hpp>
 
 namespace olp {
 namespace cache {
 
 using Encoder = std::function<std::string()>;
-using Decoder = std::function<boost::any(const std::string&)>;
+using Decoder = std::function<olp::porting::any(const std::string&)>;
 
 template <typename Result>
 using OperationOutcome = client::ApiResponse<Result, client::ApiError>;
@@ -74,7 +74,7 @@ class CORE_API KeyValueCache {
    *
    * @return True if the operation is successful; false otherwise.
    */
-  virtual bool Put(const std::string& key, const boost::any& value,
+  virtual bool Put(const std::string& key, const olp::porting::any& value,
                    const Encoder& encoder, time_t expiry = kDefaultExpiry) = 0;
 
   /**
@@ -97,7 +97,8 @@ class CORE_API KeyValueCache {
    *
    * @return The key-value pair.
    */
-  virtual boost::any Get(const std::string& key, const Decoder& encoder) = 0;
+  virtual olp::porting::any Get(const std::string& key,
+                                const Decoder& encoder) = 0;
 
   /**
    * @brief Gets the key and binary data from the cache.

--- a/olp-cpp-sdk-core/include/olp/core/porting/any.h
+++ b/olp-cpp-sdk-core/include/olp/core/porting/any.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#if (__cplusplus >= 201703L) && defined(OLP_SDK_USE_STD_ANY)
+#include <any>
+
+namespace olp {
+namespace porting {
+
+using any = std::any;
+
+template <typename T>
+inline T any_cast(const any& operand) {
+  return std::any_cast<T>(operand);
+}
+
+template <typename T>
+inline T any_cast(any& operand) {
+  return std::any_cast<T>(operand);
+}
+
+template <typename T>
+inline T any_cast(any&& operand) {
+  return std::any_cast<T>(std::move(operand));
+}
+
+template <typename T>
+inline const T* any_cast(const any* operand) noexcept {
+  return std::any_cast<T>(operand);
+}
+
+template <typename T>
+inline T* any_cast(any* operand) noexcept {
+  return std::any_cast<T>(operand);
+}
+
+inline bool has_value(const any& operand) noexcept {
+  return operand.has_value();
+}
+
+inline void reset(any& operand) noexcept { operand.reset(); }
+
+template <typename T, typename... Args>
+inline any make_any(Args&&... args) {
+  return std::make_any<T>(std::forward<Args>(args)...);
+}
+
+template <typename T, typename U, typename... Args>
+inline any make_any(std::initializer_list<U> il, Args&&... args) {
+  return std::make_any<T>(il, std::forward<Args>(args)...);
+}
+
+}  // namespace porting
+}  // namespace olp
+
+#else
+#include <boost/any.hpp>
+
+namespace olp {
+namespace porting {
+
+using any = boost::any;
+
+template <typename T>
+inline T any_cast(const any& operand) {
+  return boost::any_cast<T>(operand);
+}
+
+template <typename T>
+inline T any_cast(any& operand) {
+  return boost::any_cast<T>(operand);
+}
+
+template <typename T>
+inline T any_cast(any&& operand) {
+  return boost::any_cast<T>(operand);
+}
+
+template <typename T>
+inline const T* any_cast(const any* operand) noexcept {
+  return boost::any_cast<T>(operand);
+}
+
+template <typename T>
+inline T* any_cast(any* operand) noexcept {
+  return boost::any_cast<T>(operand);
+}
+
+inline bool has_value(const any& operand) noexcept { return !operand.empty(); }
+
+inline void reset(any& operand) noexcept { operand = boost::any(); }
+
+template <typename T, typename... Args>
+inline any make_any(Args&&... args) {
+  return any(T(std::forward<Args>(args)...));
+}
+
+template <typename T, typename U, typename... Args>
+inline any make_any(std::initializer_list<U> il, Args&&... args) {
+  return any(T(il, std::forward<Args>(args)...));
+}
+
+}  // namespace porting
+}  // namespace olp
+
+#endif

--- a/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
@@ -42,7 +42,7 @@ bool DefaultCache::Clear() { return impl_->Clear(); }
 
 void DefaultCache::Compact() { return impl_->Compact(); }
 
-bool DefaultCache::Put(const std::string& key, const boost::any& value,
+bool DefaultCache::Put(const std::string& key, const olp::porting::any& value,
                        const Encoder& encoder, time_t expiry) {
   return impl_->Put(key, value, encoder, expiry);
 }
@@ -52,7 +52,8 @@ bool DefaultCache::Put(const std::string& key,
   return impl_->Put(key, value, expiry);
 }
 
-boost::any DefaultCache::Get(const std::string& key, const Decoder& decoder) {
+olp::porting::any DefaultCache::Get(const std::string& key,
+                                    const Decoder& decoder) {
   return impl_->Get(key, decoder);
 }
 

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -273,7 +273,8 @@ void DefaultCacheImpl::Compact() {
   }
 }
 
-bool DefaultCacheImpl::Put(const std::string& key, const boost::any& value,
+bool DefaultCacheImpl::Put(const std::string& key,
+                           const olp::porting::any& value,
                            const Encoder& encoder, time_t expiry) {
   std::lock_guard<std::mutex> lock(cache_lock_);
   if (!is_open_) {
@@ -301,11 +302,11 @@ bool DefaultCacheImpl::Put(const std::string& key,
   return Write(key, value, expiry).IsSuccessful();
 }
 
-boost::any DefaultCacheImpl::Get(const std::string& key,
-                                 const Decoder& decoder) {
+olp::porting::any DefaultCacheImpl::Get(const std::string& key,
+                                        const Decoder& decoder) {
   std::lock_guard<std::mutex> lock(cache_lock_);
   if (!is_open_) {
-    return boost::any();
+    return olp::porting::any();
   }
 
   if (memory_cache_) {
@@ -329,7 +330,7 @@ boost::any DefaultCacheImpl::Get(const std::string& key,
     return decoded_item;
   }
 
-  return boost::any();
+  return olp::porting::any();
 }
 
 KeyValueCache::ValueTypePtr DefaultCacheImpl::Get(const std::string& key) {
@@ -784,10 +785,9 @@ DefaultCache::StorageOpenResult DefaultCacheImpl::SetupProtectedCache() {
         settings_.disk_path_protected->c_str());
 
     open_mode = static_cast<OpenOptions>(open_mode | OpenOptions::ReadOnly);
-    status =
-        protected_cache_->Open(*settings_.disk_path_protected,
-                               *settings_.disk_path_protected,
-                               protected_storage_settings, open_mode, false);
+    status = protected_cache_->Open(
+        *settings_.disk_path_protected, *settings_.disk_path_protected,
+        protected_storage_settings, open_mode, false);
   }
 
   if (status != OpenResult::Success) {
@@ -1068,7 +1068,7 @@ OperationOutcome<KeyValueCache::ValueTypePtr> DefaultCacheImpl::Read(
     auto value = memory_cache_->Get(key);
     if (!value.empty()) {
       PromoteKeyLru(key);
-      return boost::any_cast<KeyValueCache::ValueTypePtr>(value);
+      return olp::porting::any_cast<KeyValueCache::ValueTypePtr>(value);
     }
   }
 

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.h
@@ -51,10 +51,10 @@ class DefaultCacheImpl {
   bool Put(const std::string& key, const KeyValueCache::ValueTypePtr value,
            time_t expiry);
 
-  bool Put(const std::string& key, const boost::any& value,
+  bool Put(const std::string& key, const olp::porting::any& value,
            const Encoder& encoder, time_t expiry);
 
-  boost::any Get(const std::string& key, const Decoder& decoder);
+  olp::porting::any Get(const std::string& key, const Decoder& decoder);
 
   DefaultCache::ValueTypePtr Get(const std::string& key);
 

--- a/olp-cpp-sdk-core/src/cache/InMemoryCache.h
+++ b/olp-cpp-sdk-core/src/cache/InMemoryCache.h
@@ -27,8 +27,8 @@
 #include <tuple>
 #include <vector>
 
+#include <olp/core/porting/any.h>
 #include <olp/core/utils/LruCache.h>
-#include <boost/any.hpp>
 
 namespace olp {
 namespace cache {
@@ -42,7 +42,7 @@ class InMemoryCache {
   static constexpr size_t kSizeMax = std::numeric_limits<std::size_t>::max();
   static constexpr time_t kExpiryMax = std::numeric_limits<time_t>::max();
 
-  using ItemTuple = std::tuple<std::string, time_t, boost::any, size_t>;
+  using ItemTuple = std::tuple<std::string, time_t, olp::porting::any, size_t>;
   using ItemTuples = std::vector<ItemTuple>;
   using TimeProvider = std::function<time_t()>;
   using ModelCacheCostFunc = std::function<std::size_t(const ItemTuple&)>;
@@ -70,10 +70,10 @@ class InMemoryCache {
                 ModelCacheCostFunc cache_cost = DefaultCacheCost(),
                 TimeProvider time_provider = DefaultTimeProvider());
 
-  bool Put(const std::string& key, const boost::any& item,
+  bool Put(const std::string& key, const olp::porting::any& item,
            time_t expire_seconds = kExpiryMax, size_t = 1u);
 
-  boost::any Get(const std::string& key);
+  olp::porting::any Get(const std::string& key);
   size_t Size() const;
   void Clear();
 

--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -61,6 +61,8 @@ set(OLP_CPP_SDK_CORE_TESTS_SOURCES
     ./logging/MessageFormatterTest.cpp
     ./logging/MockAppender.cpp
 
+    ./porting/AnyTest.cpp
+
     ./thread/ContinuationTest.cpp
     ./thread/ExecutionContextTest.cpp
     ./thread/PriorityQueueExtendedTest.cpp

--- a/olp-cpp-sdk-core/tests/client/ApiLookupClientImplTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/ApiLookupClientImplTest.cpp
@@ -104,7 +104,7 @@ TEST_F(ApiLookupClientImplTest, LookupApi) {
     SCOPED_TRACE("Fetch from cache [CacheOnly] negative");
     EXPECT_CALL(*cache_, Get(cache_key, _))
         .Times(1)
-        .WillOnce(Return(boost::any()));
+        .WillOnce(Return(olp::porting::any()));
 
     client::CancellationContext context;
     client::ApiLookupClientImpl client(catalog_hrn, settings_);
@@ -154,7 +154,7 @@ TEST_F(ApiLookupClientImplTest, LookupApi) {
         .WillRepeatedly(Return(true));
     EXPECT_CALL(*cache_, Get(cache_key, _))
         .Times(1)
-        .WillOnce(Return(boost::any()));
+        .WillOnce(Return(olp::porting::any()));
 
     client::CancellationContext context;
     client::ApiLookupClientImpl client(catalog_hrn, settings_);
@@ -183,7 +183,9 @@ TEST_F(ApiLookupClientImplTest, LookupApi) {
     EXPECT_CALL(*cache_, Put(_, _, _, expiry))
         .Times(3)
         .WillRepeatedly(Return(true));
-    EXPECT_CALL(*cache_, Get(_, _)).Times(1).WillOnce(Return(boost::any()));
+    EXPECT_CALL(*cache_, Get(_, _))
+        .Times(1)
+        .WillOnce(Return(olp::porting::any()));
 
     client::CancellationContext context;
     client::ApiLookupClientImpl client(catalog_hrn, settings_);
@@ -368,7 +370,9 @@ TEST_F(ApiLookupClientImplTest, LookupApi) {
                                          olp::http::HttpStatusCode::OK),
                                      kResponseLookupResource));
 
-    EXPECT_CALL(*cache_, Get(_, _)).Times(1).WillOnce(Return(boost::any()));
+    EXPECT_CALL(*cache_, Get(_, _))
+        .Times(1)
+        .WillOnce(Return(olp::porting::any()));
 
     // Response contains three services that are cached independently.
     EXPECT_CALL(*cache_, Put(_, _, _, _)).Times(3);
@@ -569,7 +573,7 @@ TEST_F(ApiLookupClientImplTest, LookupApiAsync) {
     SCOPED_TRACE("Fetch from cache [CacheOnly] negative");
     EXPECT_CALL(*cache_, Get(cache_key, _))
         .Times(1)
-        .WillOnce(Return(boost::any()));
+        .WillOnce(Return(olp::porting::any()));
 
     std::promise<client::ApiLookupClient::LookupApiResponse> promise;
     auto future = promise.get_future();
@@ -631,7 +635,7 @@ TEST_F(ApiLookupClientImplTest, LookupApiAsync) {
         .WillRepeatedly(Return(true));
     EXPECT_CALL(*cache_, Get(cache_key, _))
         .Times(1)
-        .WillOnce(Return(boost::any()));
+        .WillOnce(Return(olp::porting::any()));
 
     std::promise<client::ApiLookupClient::LookupApiResponse> promise;
     auto future = promise.get_future();
@@ -665,7 +669,9 @@ TEST_F(ApiLookupClientImplTest, LookupApiAsync) {
     EXPECT_CALL(*cache_, Put(_, _, _, expiry))
         .Times(3)
         .WillRepeatedly(Return(true));
-    EXPECT_CALL(*cache_, Get(_, _)).Times(1).WillOnce(Return(boost::any()));
+    EXPECT_CALL(*cache_, Get(_, _))
+        .Times(1)
+        .WillOnce(Return(olp::porting::any()));
 
     std::promise<client::ApiLookupClient::LookupApiResponse> promise;
     auto future = promise.get_future();
@@ -803,7 +809,9 @@ TEST_F(ApiLookupClientImplTest, LookupApiAsync) {
                                          olp::http::HttpStatusCode::OK),
                                      kResponseLookupResource));
 
-    EXPECT_CALL(*cache_, Get(_, _)).Times(1).WillOnce(Return(boost::any()));
+    EXPECT_CALL(*cache_, Get(_, _))
+        .Times(1)
+        .WillOnce(Return(olp::porting::any()));
 
     // Response contains three services that are cached independently.
     EXPECT_CALL(*cache_, Put(_, _, _, _)).Times(3);

--- a/olp-cpp-sdk-core/tests/porting/AnyTest.cpp
+++ b/olp-cpp-sdk-core/tests/porting/AnyTest.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gtest/gtest.h>
+#include <olp/core/porting/any.h>
+#include <string>
+
+TEST(AnyTest, AnyCastConstReference) {
+  // Test any_cast with const reference (covers line 84 in any.h)
+  const olp::porting::any const_any = std::string("test_value");
+
+  auto result = olp::porting::any_cast<std::string>(const_any);
+  EXPECT_EQ("test_value", result);
+}
+
+TEST(AnyTest, AnyCastNonConstReference) {
+  // Test any_cast with non-const reference
+  olp::porting::any any_obj = std::string("test_value");
+
+  auto result = olp::porting::any_cast<std::string>(any_obj);
+  EXPECT_EQ("test_value", result);
+}
+
+TEST(AnyTest, AnyCastRValueReference) {
+  // Test any_cast with rvalue reference
+  auto result = olp::porting::any_cast<std::string>(
+      olp::porting::any(std::string("test_value")));
+  EXPECT_EQ("test_value", result);
+}
+
+TEST(AnyTest, AnyCastConstPointer) {
+  // Test any_cast with const pointer
+  const olp::porting::any any_obj = std::string("test_value");
+
+  const std::string* ptr = olp::porting::any_cast<std::string>(&any_obj);
+  ASSERT_NE(nullptr, ptr);
+  EXPECT_EQ("test_value", *ptr);
+}
+
+TEST(AnyTest, AnyCastNonConstPointer) {
+  // Test any_cast with non-const pointer
+  olp::porting::any any_obj = std::string("test_value");
+
+  std::string* ptr = olp::porting::any_cast<std::string>(&any_obj);
+  ASSERT_NE(nullptr, ptr);
+  EXPECT_EQ("test_value", *ptr);
+}
+
+TEST(AnyTest, HasValue) {
+  // Test has_value function
+  olp::porting::any empty_any;
+  EXPECT_FALSE(olp::porting::has_value(empty_any));
+
+  olp::porting::any filled_any = std::string("test");
+  EXPECT_TRUE(olp::porting::has_value(filled_any));
+}
+
+TEST(AnyTest, Reset) {
+  // Test reset function
+  olp::porting::any any_obj = std::string("test_value");
+  EXPECT_TRUE(olp::porting::has_value(any_obj));
+
+  olp::porting::reset(any_obj);
+  EXPECT_FALSE(olp::porting::has_value(any_obj));
+}
+
+TEST(AnyTest, MakeAny) {
+  // Test make_any with variadic arguments
+  auto any_obj = olp::porting::make_any<std::string>("test");
+  auto result = olp::porting::any_cast<std::string>(any_obj);
+  EXPECT_EQ("test", result);
+}
+
+TEST(AnyTest, MakeAnyWithInitializerList) {
+  // Test make_any with initializer list
+  auto any_obj = olp::porting::make_any<std::vector<int>>({1, 2, 3, 4, 5});
+  auto result = olp::porting::any_cast<std::vector<int>>(any_obj);
+  EXPECT_EQ(5u, result.size());
+  EXPECT_EQ(1, result[0]);
+  EXPECT_EQ(5, result[4]);
+}

--- a/olp-cpp-sdk-dataservice-read/tests/ApiClientLookupTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/ApiClientLookupTest.cpp
@@ -77,7 +77,7 @@ TEST(ApiClientLookupTest, LookupApi) {
     SCOPED_TRACE("Fetch from cache [CacheOnly] negative");
     EXPECT_CALL(*cache, Get(cache_key, _))
         .Times(1)
-        .WillOnce(Return(boost::any()));
+        .WillOnce(Return(olp::porting::any()));
 
     client::CancellationContext context;
     auto response = read::ApiClientLookup::LookupApi(
@@ -251,7 +251,7 @@ TEST(ApiClientLookupTest, LookupApiConcurrent) {
 
   testing::InSequence s;
 
-  EXPECT_CALL(*cache, Get(cache_key, _)).WillOnce(Return(boost::any()));
+  EXPECT_CALL(*cache, Get(cache_key, _)).WillOnce(Return(olp::porting::any()));
   EXPECT_CALL(*network, Send(IsGetRequest(lookup_url), _, _, _, _))
       .Times(1)
       .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(

--- a/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/CatalogRepositoryTest.cpp
@@ -140,7 +140,7 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionCacheOnlyNotFound) {
 
   EXPECT_CALL(*cache_, Get(_, _))
       .Times(1)
-      .WillOnce(testing::Return(boost::any{}));
+      .WillOnce(testing::Return(olp::porting::any{}));
 
   ON_CALL(*network_, Send(_, _, _, _, _))
       .WillByDefault([](olp::http::NetworkRequest, olp::http::Network::Payload,
@@ -169,7 +169,7 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionCacheOnlyRequestWithMinVersion) {
 
   EXPECT_CALL(*cache_, Get(_, _))
       .Times(2)
-      .WillRepeatedly(testing::Return(boost::any{}));
+      .WillRepeatedly(testing::Return(olp::porting::any{}));
 
   ON_CALL(*network_, Send(_, _, _, _, _))
       .WillByDefault([](olp::http::NetworkRequest, olp::http::Network::Payload,
@@ -218,11 +218,11 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyNotFound) {
   ON_CALL(*cache_, Get(_, _))
       .WillByDefault([](const std::string&, const olp::cache::Decoder&) {
         ADD_FAILURE() << "Cache should not be used in OnlineOnly request";
-        return boost::any{};
+        return olp::porting::any{};
       });
 
   EXPECT_CALL(*cache_, Get(testing::Eq(kMetadataCacheKey), _))
-      .WillOnce(testing::Return(boost::any()));
+      .WillOnce(testing::Return(olp::porting::any()));
 
   EXPECT_CALL(*network_, Send(IsGetRequest(kLookupMetadata), _, _, _, _))
       .Times(1)
@@ -247,11 +247,11 @@ TEST_F(CatalogRepositoryTest, GetLatestVersionOnlineOnlyFound) {
   ON_CALL(*cache_, Get(_, _))
       .WillByDefault([](const std::string&, const olp::cache::Decoder&) {
         ADD_FAILURE() << "Cache should not be used in OnlineOnly request";
-        return boost::any{};
+        return olp::porting::any{};
       });
 
   EXPECT_CALL(*cache_, Get(testing::Eq(kMetadataCacheKey), _))
-      .WillOnce(testing::Return(boost::any()));
+      .WillOnce(testing::Return(olp::porting::any()));
 
   EXPECT_CALL(*network_, Send(IsGetRequest(kLookupMetadata), _, _, _, _))
       .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
@@ -411,7 +411,7 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyFound) {
   ON_CALL(*cache_, Get(_, _))
       .WillByDefault([](const std::string&, const olp::cache::Decoder&) {
         ADD_FAILURE() << "Cache should not be used in OnlineOnly request";
-        return boost::any{};
+        return olp::porting::any{};
       });
 
   ON_CALL(*network_, Send(IsGetRequest(kUrlLookupConfig), _, _, _, _))
@@ -437,7 +437,8 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineIfNotFound) {
   auto request = read::CatalogRequest();
   request.WithFetchOption(read::OnlineIfNotFound);
 
-  EXPECT_CALL(*cache_, Get(_, _)).WillRepeatedly(testing::Return(boost::any{}));
+  EXPECT_CALL(*cache_, Get(_, _))
+      .WillRepeatedly(testing::Return(olp::porting::any{}));
 
   EXPECT_CALL(*cache_,
               Put(testing::Eq(kCatalog + "::config::v1::api"), _, _, _))
@@ -517,7 +518,7 @@ TEST_F(CatalogRepositoryTest, GetCatalogCacheOnlyNotFound) {
 
   EXPECT_CALL(*cache_, Get(_, _))
       .Times(1)
-      .WillOnce(testing::Return(boost::any{}));
+      .WillOnce(testing::Return(olp::porting::any{}));
 
   ON_CALL(*network_, Send(_, _, _, _, _))
       .WillByDefault([](olp::http::NetworkRequest, olp::http::Network::Payload,
@@ -545,7 +546,7 @@ TEST_F(CatalogRepositoryTest, GetCatalogOnlineOnlyNotFound) {
   ON_CALL(*cache_, Get(_, _))
       .WillByDefault([](const std::string&, const olp::cache::Decoder&) {
         ADD_FAILURE() << "Cache should not be used in OnlineOnly request";
-        return boost::any{};
+        return olp::porting::any{};
       });
 
   EXPECT_CALL(*network_, Send(IsGetRequest(kUrlLookupConfig), _, _, _, _))

--- a/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/DataRepositoryTest.cpp
@@ -653,7 +653,7 @@ TEST_F(DataRepositoryTest, GetBlobDataFailedToCache) {
       .WillRepeatedly(testing::Return(olp::client::ApiError::CacheIO()));
 
   EXPECT_CALL(*cache_mock, Get(_, _))
-      .WillRepeatedly(testing::Return(boost::any()));
+      .WillRepeatedly(testing::Return(olp::porting::any()));
   EXPECT_CALL(*cache_mock, Get(_)).WillRepeatedly(testing::Return(nullptr));
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(kUrlLookup), _, _, _, _))
@@ -698,7 +698,7 @@ TEST_F(DataRepositoryTest, GetVersionedDataTileFailedToCache) {
       .WillRepeatedly(testing::Return(olp::client::ApiError::CacheIO()));
 
   EXPECT_CALL(*cache_mock, Get(_, _))
-      .WillRepeatedly(testing::Return(boost::any()));
+      .WillRepeatedly(testing::Return(olp::porting::any()));
   EXPECT_CALL(*cache_mock, Get(_)).WillRepeatedly(testing::Return(nullptr));
 
   EXPECT_CALL(*network_mock_, Send(IsGetRequest(kUrlLookup), _, _, _, _))

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -205,7 +205,7 @@ TEST_F(PartitionsRepositoryTest, GetPartitionById) {
     ON_CALL(*cache, Get(_, _))
         .WillByDefault([](const std::string&, const cache::Decoder&) {
           ADD_FAILURE() << "Cache should not be used in OnlineOnly request";
-          return boost::any{};
+          return olp::porting::any{};
         });
   };
 
@@ -1011,7 +1011,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
                                          olp::http::HttpStatusCode::OK),
                                      kSubQuadsWithParent));
     EXPECT_CALL(*mock_cache, Get(_, _))
-        .WillOnce(Return(boost::any(kUrlQueryApi)));
+        .WillOnce(Return(olp::porting::any(kUrlQueryApi)));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
     EXPECT_CALL(*mock_cache, Write(_, _, _))
@@ -1051,7 +1051,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
                                      kSubQuads));
-    EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(boost::any()));
+    EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(olp::porting::any()));
     EXPECT_CALL(*mock_cache, Put(_, _, _, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
@@ -1117,7 +1117,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
             ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                    olp::http::HttpStatusCode::BAD_REQUEST),
                                kErrorServiceUnavailable));
-    EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(boost::any()));
+    EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(olp::porting::any()));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
 
@@ -1158,7 +1158,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
             ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                    olp::http::HttpStatusCode::BAD_REQUEST),
                                kErrorServiceUnavailable));
-    EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(boost::any()));
+    EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(olp::porting::any()));
     EXPECT_CALL(*mock_cache, Put(_, _, _, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
@@ -1199,7 +1199,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
                                      kInvalidJson));
-    EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(boost::any()));
+    EXPECT_CALL(*mock_cache, Get(_, _)).WillOnce(Return(olp::porting::any()));
     EXPECT_CALL(*mock_cache, Put(_, _, _, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_cache, Get(_))
         .WillRepeatedly(Return(KeyValueCache::ValueTypePtr()));
@@ -1744,7 +1744,8 @@ TEST_F(PartitionsRepositoryTest, GetVersionedPartitionsBatch_MockedCache) {
         settings.network_request_handler = mock_network;
         settings.retry_settings.timeout = 1;
 
-        EXPECT_CALL(*cache, Get(_, _)).WillRepeatedly(Return(boost::any{}));
+        EXPECT_CALL(*cache, Get(_, _))
+            .WillRepeatedly(Return(olp::porting::any{}));
         EXPECT_CALL(*cache, Put(Eq(kCacheKeyMetadata), _, _, _))
             .WillRepeatedly(Return(true));
         EXPECT_CALL(*cache, Read(_))
@@ -1985,7 +1986,7 @@ TEST_F(PartitionsRepositoryTest, StreamPartitions) {
     auto async_stream = std::make_shared<repository::AsyncJsonStream>();
     client::CancellationContext context;
 
-    EXPECT_CALL(*cache, Get(_, _)).WillOnce(Return(boost::any()));
+    EXPECT_CALL(*cache, Get(_, _)).WillOnce(Return(olp::porting::any()));
     EXPECT_CALL(*network, Send(IsGetRequest(kOlpSdkUrlLookupQuery), _, _, _, _))
         .WillOnce(
             ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
@@ -2008,7 +2009,7 @@ TEST_F(PartitionsRepositoryTest, StreamPartitions) {
     auto async_stream = std::make_shared<repository::AsyncJsonStream>();
     client::CancellationContext context;
 
-    EXPECT_CALL(*cache, Get(_, _)).WillOnce(Return(boost::any()));
+    EXPECT_CALL(*cache, Get(_, _)).WillOnce(Return(olp::porting::any()));
     EXPECT_CALL(*network, Send(IsGetRequest(kOlpSdkUrlLookupQuery), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
@@ -2054,7 +2055,7 @@ TEST_F(PartitionsRepositoryTest, StreamPartitions) {
     auto async_stream = std::make_shared<repository::AsyncJsonStream>();
     client::CancellationContext context;
 
-    EXPECT_CALL(*cache, Get(_, _)).WillOnce(Return(boost::any()));
+    EXPECT_CALL(*cache, Get(_, _)).WillOnce(Return(olp::porting::any()));
     EXPECT_CALL(*network, Send(IsGetRequest(kOlpSdkUrlLookupQuery), _, _, _, _))
         .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
                                          olp::http::HttpStatusCode::OK),
@@ -2149,7 +2150,7 @@ TEST_F(PartitionsRepositoryTest_GetPartitionById,
   EXPECT_CALL(*cache_, Read(cache_key_))
       .WillOnce(Return(client::ApiError::NotFound()));
   EXPECT_CALL(*cache_, Get(Eq(kCacheKeyMetadata), _))
-      .WillOnce(Return(boost::any{}));
+      .WillOnce(Return(olp::porting::any{}));
 
   EXPECT_CALL(*network_, Send(IsGetRequest(kOlpSdkUrlLookupQuery), _, _, _, _))
       .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(
@@ -2194,7 +2195,7 @@ TEST_F(PartitionsRepositoryTest_GetPartitionById,
       .WillOnce(Return(client::ApiError::NotFound()))
       .WillOnce(Return(response_data));
   EXPECT_CALL(*cache_, Get(Eq(kCacheKeyMetadata), _))
-      .WillOnce(Return(boost::any{}));
+      .WillOnce(Return(olp::porting::any{}));
 
   EXPECT_CALL(*network_, Send(IsGetRequest(kOlpSdkUrlLookupQuery), _, _, _, _))
       .WillOnce(ReturnHttpResponse(olp::http::NetworkResponse().WithStatus(

--- a/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/VersionedLayerClientImplTest.cpp
@@ -1514,7 +1514,7 @@ TEST(VersionedLayerClientTest, PropagateAllCacheErrors) {
         .WillRepeatedly(testing::Return(olp::client::ApiError::CacheIO()));
 
     EXPECT_CALL(*cache_mock, Get(_, _))
-        .WillRepeatedly(testing::Return(boost::any()));
+        .WillRepeatedly(testing::Return(olp::porting::any()));
     EXPECT_CALL(*cache_mock, Get(_)).WillRepeatedly(testing::Return(nullptr));
     EXPECT_CALL(*cache_mock, Read(_))
         .WillRepeatedly(testing::Return(olp::client::ApiError::NotFound()));
@@ -1569,7 +1569,7 @@ TEST(VersionedLayerClientTest, PropagateAllCacheErrors) {
         .WillRepeatedly(testing::Return(olp::client::ApiError::CacheIO()));
 
     EXPECT_CALL(*cache_mock, Get(_, _))
-        .WillRepeatedly(testing::Return(boost::any()));
+        .WillRepeatedly(testing::Return(olp::porting::any()));
     EXPECT_CALL(*cache_mock, Get(_)).WillRepeatedly(testing::Return(nullptr));
     EXPECT_CALL(*cache_mock, Read(_))
         .WillRepeatedly(testing::Return(olp::client::ApiError::NotFound()));

--- a/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplPublishToBatchTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplPublishToBatchTest.cpp
@@ -202,7 +202,7 @@ TEST_F(VersionedLayerClientImplPublishToBatchTest, PublishToBatch) {
     EXPECT_CALL(*cache_, Contains(_)).Times(1);
     EXPECT_CALL(*cache_, Put(_, _, _, _))
         .WillRepeatedly([](const std::string& /*key*/,
-                           const boost::any& /*value*/,
+                           const olp::porting::any& /*value*/,
                            const olp::cache::Encoder& /*encoder*/,
                            time_t /*expiry*/) { return true; });
 
@@ -234,7 +234,7 @@ TEST_F(VersionedLayerClientImplPublishToBatchTest, PublishToBatch) {
     EXPECT_CALL(*cache_, Contains(_)).Times(1);
     EXPECT_CALL(*cache_, Put(_, _, _, _))
         .WillRepeatedly([](const std::string& /*key*/,
-                           const boost::any& /*value*/,
+                           const olp::porting::any& /*value*/,
                            const olp::cache::Encoder& /*encoder*/,
                            time_t /*expiry*/) { return true; });
 
@@ -311,7 +311,7 @@ TEST_F(VersionedLayerClientImplPublishToBatchTest, PublishToBatch) {
     EXPECT_CALL(*cache_, Contains(_)).Times(1);
     EXPECT_CALL(*cache_, Put(_, _, _, _))
         .WillRepeatedly([](const std::string& /*key*/,
-                           const boost::any& /*value*/,
+                           const olp::porting::any& /*value*/,
                            const olp::cache::Encoder& /*encoder*/,
                            time_t /*expiry*/) { return true; });
 
@@ -344,7 +344,7 @@ TEST_F(VersionedLayerClientImplPublishToBatchTest, PublishToBatch) {
     EXPECT_CALL(*cache_, Contains(_)).Times(1);
     EXPECT_CALL(*cache_, Put(_, _, _, _))
         .WillRepeatedly([](const std::string& /*key*/,
-                           const boost::any& /*value*/,
+                           const olp::porting::any& /*value*/,
                            const olp::cache::Encoder& /*encoder*/,
                            time_t /*expiry*/) { return true; });
 
@@ -368,7 +368,7 @@ TEST_F(VersionedLayerClientImplPublishToBatchTest, PublishToBatch) {
     EXPECT_CALL(*cache_, Contains(_)).Times(1);
     EXPECT_CALL(*cache_, Put(_, _, _, _))
         .WillRepeatedly([](const std::string& /*key*/,
-                           const boost::any& /*value*/,
+                           const olp::porting::any& /*value*/,
                            const olp::cache::Encoder& /*encoder*/,
                            time_t /*expiry*/) { return true; });
 
@@ -408,7 +408,7 @@ TEST_F(VersionedLayerClientImplPublishToBatchTest, NetworkErrors) {
     EXPECT_CALL(*cache_, Contains(_)).Times(1);
     EXPECT_CALL(*cache_, Put(_, _, _, _))
         .WillRepeatedly([](const std::string& /*key*/,
-                           const boost::any& /*value*/,
+                           const olp::porting::any& /*value*/,
                            const olp::cache::Encoder& /*encoder*/,
                            time_t /*expiry*/) { return true; });
 
@@ -440,7 +440,7 @@ TEST_F(VersionedLayerClientImplPublishToBatchTest, NetworkErrors) {
     EXPECT_CALL(*cache_, Contains(_)).Times(1);
     EXPECT_CALL(*cache_, Put(_, _, _, _))
         .WillRepeatedly([](const std::string& /*key*/,
-                           const boost::any& /*value*/,
+                           const olp::porting::any& /*value*/,
                            const olp::cache::Encoder& /*encoder*/,
                            time_t /*expiry*/) { return true; });
 
@@ -471,7 +471,7 @@ TEST_F(VersionedLayerClientImplPublishToBatchTest, NetworkErrors) {
     EXPECT_CALL(*cache_, Contains(_)).Times(1);
     EXPECT_CALL(*cache_, Put(_, _, _, _))
         .WillRepeatedly([](const std::string& /*key*/,
-                           const boost::any& /*value*/,
+                           const olp::porting::any& /*value*/,
                            const olp::cache::Encoder& /*encoder*/,
                            time_t /*expiry*/) { return true; });
 
@@ -502,7 +502,7 @@ TEST_F(VersionedLayerClientImplPublishToBatchTest, NetworkErrors) {
     EXPECT_CALL(*cache_, Contains(_)).Times(1);
     EXPECT_CALL(*cache_, Put(_, _, _, _))
         .WillRepeatedly([](const std::string& /*key*/,
-                           const boost::any& /*value*/,
+                           const olp::porting::any& /*value*/,
                            const olp::cache::Encoder& /*encoder*/,
                            time_t /*expiry*/) { return true; });
 
@@ -532,7 +532,7 @@ TEST_F(VersionedLayerClientImplPublishToBatchTest, NetworkErrors) {
     EXPECT_CALL(*cache_, Contains(_)).Times(1);
     EXPECT_CALL(*cache_, Put(_, _, _, _))
         .WillRepeatedly([](const std::string& /*key*/,
-                           const boost::any& /*value*/,
+                           const olp::porting::any& /*value*/,
                            const olp::cache::Encoder& /*encoder*/,
                            time_t /*expiry*/) { return true; });
 
@@ -611,7 +611,7 @@ TEST_F(VersionedLayerClientImplPublishToBatchTest, Cancel) {
     EXPECT_CALL(*cache_, Contains(_)).Times(1);
     EXPECT_CALL(*cache_, Put(_, _, _, _))
         .WillRepeatedly([](const std::string& /*key*/,
-                           const boost::any& /*value*/,
+                           const olp::porting::any& /*value*/,
                            const olp::cache::Encoder& /*encoder*/,
                            time_t /*expiry*/) { return true; });
 
@@ -668,7 +668,7 @@ TEST_F(VersionedLayerClientImplPublishToBatchTest, Cancel) {
     EXPECT_CALL(*cache_, Contains(_)).Times(1);
     EXPECT_CALL(*cache_, Put(_, _, _, _))
         .WillRepeatedly([](const std::string& /*key*/,
-                           const boost::any& /*value*/,
+                           const olp::porting::any& /*value*/,
                            const olp::cache::Encoder& /*encoder*/,
                            time_t /*expiry*/) { return true; });
 
@@ -721,7 +721,7 @@ TEST_F(VersionedLayerClientImplPublishToBatchTest, Cancel) {
     EXPECT_CALL(*cache_, Contains(_)).Times(1);
     EXPECT_CALL(*cache_, Put(_, _, _, _))
         .WillRepeatedly([](const std::string& /*key*/,
-                           const boost::any& /*value*/,
+                           const olp::porting::any& /*value*/,
                            const olp::cache::Encoder& /*encoder*/,
                            time_t /*expiry*/) { return true; });
 

--- a/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplTest.cpp
@@ -139,7 +139,8 @@ TEST_F(VersionedLayerClientImplTest, StartBatch) {
     // mock apis caching
     EXPECT_CALL(*cache_, Get(_, _)).Times(1);
     EXPECT_CALL(*cache_, Put(_, _, _, _))
-        .WillOnce([](const std::string& /*key*/, const boost::any& /*value*/,
+        .WillOnce([](const std::string& /*key*/,
+                     const olp::porting::any& /*value*/,
                      const olp::cache::Encoder& /*encoder*/,
                      time_t /*expiry*/) { return true; });
 
@@ -176,7 +177,8 @@ TEST_F(VersionedLayerClientImplTest, StartBatch) {
     // mock apis caching
     EXPECT_CALL(*cache_, Get(_, _)).Times(1);
     EXPECT_CALL(*cache_, Put(_, _, _, _))
-        .WillOnce([](const std::string& /*key*/, const boost::any& /*value*/,
+        .WillOnce([](const std::string& /*key*/,
+                     const olp::porting::any& /*value*/,
                      const olp::cache::Encoder& /*encoder*/,
                      time_t /*expiry*/) { return true; });
 
@@ -444,7 +446,8 @@ TEST_F(VersionedLayerClientImplTest, CompleteBatch) {
     // mock apis caching
     EXPECT_CALL(*cache_, Get(_, _)).Times(1);
     EXPECT_CALL(*cache_, Put(_, _, _, _))
-        .WillOnce([](const std::string& /*key*/, const boost::any& /*value*/,
+        .WillOnce([](const std::string& /*key*/,
+                     const olp::porting::any& /*value*/,
                      const olp::cache::Encoder& /*encoder*/,
                      time_t /*expiry*/) { return true; });
 
@@ -475,7 +478,8 @@ TEST_F(VersionedLayerClientImplTest, CompleteBatch) {
     // mock apis caching
     EXPECT_CALL(*cache_, Get(_, _)).Times(1);
     EXPECT_CALL(*cache_, Put(_, _, _, _))
-        .WillOnce([](const std::string& /*key*/, const boost::any& /*value*/,
+        .WillOnce([](const std::string& /*key*/,
+                     const olp::porting::any& /*value*/,
                      const olp::cache::Encoder& /*encoder*/,
                      time_t /*expiry*/) { return true; });
 

--- a/tests/common/KeyValueCacheTestable.h
+++ b/tests/common/KeyValueCacheTestable.h
@@ -27,7 +27,7 @@ class KeyValueCacheTestable : public olp::cache::KeyValueCache {
       std::shared_ptr<olp::cache::KeyValueCache> base_cache)
       : base_cache_{std::move(base_cache)} {}
 
-  bool Put(const std::string& key, const boost::any& value,
+  bool Put(const std::string& key, const olp::porting::any& value,
            const olp::cache::Encoder& encoder, time_t expiry) override {
     return base_cache_->Put(key, value, encoder, expiry);
   }
@@ -37,8 +37,8 @@ class KeyValueCacheTestable : public olp::cache::KeyValueCache {
     return base_cache_->Put(key, value, expiry);
   }
 
-  boost::any Get(const std::string& key,
-                 const olp::cache::Decoder& encoder) override {
+  olp::porting::any Get(const std::string& key,
+                        const olp::cache::Decoder& encoder) override {
     return base_cache_->Get(key, encoder);
   }
 
@@ -97,8 +97,8 @@ class KeyValueCacheTestable : public olp::cache::KeyValueCache {
 struct CacheWithPutErrors : public KeyValueCacheTestable {
   using KeyValueCacheTestable::KeyValueCacheTestable;
 
-  bool Put(const std::string&, const boost::any&, const olp::cache::Encoder&,
-           time_t) override {
+  bool Put(const std::string&, const olp::porting::any&,
+           const olp::cache::Encoder&, time_t) override {
     return false;
   }
 

--- a/tests/common/mocks/CacheMock.h
+++ b/tests/common/mocks/CacheMock.h
@@ -33,7 +33,7 @@ class CacheMock : public olp::cache::KeyValueCache {
   ~CacheMock() override;
 
   MOCK_METHOD(bool, Put,
-              (const std::string&, const boost::any&,
+              (const std::string&, const olp::porting::any&,
                const olp::cache::Encoder&, time_t),
               (override));
 
@@ -43,8 +43,8 @@ class CacheMock : public olp::cache::KeyValueCache {
                time_t expiry),
               (override));
 
-  MOCK_METHOD(boost::any, Get, (const std::string&, const olp::cache::Decoder&),
-              (override));
+  MOCK_METHOD(olp::porting::any, Get,
+              (const std::string&, const olp::cache::Decoder&), (override));
 
   MOCK_METHOD(std::shared_ptr<std::vector<unsigned char>>, Get,
               (const std::string&), (override));

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -3349,7 +3349,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, CheckLookupApiCacheExpiration) {
                           "v2::query::v1::api",
                           _))
       .Times(1)
-      .WillOnce(Return(boost::any()));
+      .WillOnce(Return(olp::porting::any()));
   EXPECT_CALL(*cache, Put("hrn:here:data::olp-here-test:hereos-internal-test-"
                           "v2::query::v1::api",
                           _, _, expiration_time))

--- a/tests/utils/mock-server-client/Expectation.h
+++ b/tests/utils/mock-server-client/Expectation.h
@@ -21,8 +21,7 @@
 
 #include <string>
 
-#include <boost/any.hpp>
-
+#include <olp/core/porting/any.h>
 #include <olp/core/porting/optional.h>
 #include "JsonHelpers.h"
 
@@ -49,8 +48,8 @@ struct Expectation {
     olp::porting::optional<ResponseDelay> delay = olp::porting::none;
     olp::porting::optional<uint16_t> status_code = olp::porting::none;
 
-    /// Any of BinaryResponse, std::string, boost::any
-    boost::any body;
+    /// Any of BinaryResponse, std::string, olp::porting::any
+    olp::porting::any body;
   };
 
   struct BinaryResponse {
@@ -140,9 +139,11 @@ inline void to_json(const Expectation::ResponseAction& x,
   serialize("statusCode", x.status_code, value, allocator);
 
   if (x.body.type() == typeid(std::string)) {
-    serialize("body", boost::any_cast<std::string>(x.body), value, allocator);
+    serialize("body", olp::porting::any_cast<std::string>(x.body), value,
+              allocator);
   } else if (x.body.type() == typeid(Expectation::BinaryResponse)) {
-    serialize("body", boost::any_cast<Expectation::BinaryResponse>(x.body),
+    serialize("body",
+              olp::porting::any_cast<Expectation::BinaryResponse>(x.body),
               value, allocator);
   }
 


### PR DESCRIPTION
Create olp::porting::any to use either boost::any or std::any for different compiler versions

Relates-To: NLAM-157