### PR TITLE
Add diagnostic output for CURL

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkInitializationSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkInitializationSettings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 HERE Europe B.V.
+ * Copyright (C) 2023-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,9 @@
 
 #pragma once
 
-#include "olp/core/CoreApi.h"
-#include "olp/core/http/CertificateSettings.h"
+#include <olp/core/CoreApi.h>
+#include <olp/core/http/CertificateSettings.h>
+#include <olp/core/porting/optional.h>
 
 namespace olp {
 namespace http {
@@ -38,6 +39,15 @@ struct CORE_API NetworkInitializationSettings {
    * @brief The custom certificate settings.
    */
   CertificateSettings certificate_settings;
+
+  /**
+   * @brief The path to the network diagnostic output.
+   * If not set, diagnostics will not be produced.
+   *
+   * @note Currently, only CURL-based network implementation supports this
+   * setting.
+   */
+  porting::optional<std::string> diagnostic_output_path = porting::none;
 };
 
 }  // namespace http

--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
@@ -457,6 +457,20 @@ NetworkCurl::NetworkCurl(NetworkInitializationSettings settings)
   OLP_SDK_LOG_INFO_F(
       kLogTag, "TLS backend: %s",
       version_data->ssl_version ? version_data->ssl_version : "<empty>");
+
+  if (settings.diagnostic_output_path) {
+    stderr_ = fopen(settings.diagnostic_output_path->c_str(), "a");
+    if (!stderr_) {
+      const auto* path_error = strerror(errno);
+      OLP_SDK_LOG_ERROR_F(
+          kLogTag, "Failed to open diagnostic output file, error=%s, path=%s",
+          path_error, settings.diagnostic_output_path->c_str());
+    } else {
+      OLP_SDK_LOG_INFO_F(kLogTag, "Using diagnostic output file, path=%s",
+                         settings.diagnostic_output_path->c_str());
+      verbose_ = true;
+    }
+  }
 }
 
 NetworkCurl::~NetworkCurl() {


### PR DESCRIPTION
An optional output path to the verbose logging from CURL

Relates-To: DATASDK-84