### PR TITLE
Use Boost::json in olp-cpp-sdk-dataservice-write

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/generated/parser/JsonParser.h
+++ b/olp-cpp-sdk-core/include/olp/core/generated/parser/JsonParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 
 #include <rapidjson/document.h>
 #include <rapidjson/istreamwrapper.h>
+#include <boost/json/parse.hpp>
 
 #include "ParserWrapper.h"
 
@@ -72,6 +73,53 @@ inline T parse(const std::shared_ptr<std::vector<unsigned char>>& json_bytes) {
   }
   return result;
 }
+
+namespace boost_parser {
+
+template <typename T>
+inline T parse(const std::string& json) {
+  boost::json::error_code ec;
+  auto value = boost::json::parse(json, ec);
+  T result{};
+  if (value.is_object() || value.is_array()) {
+    from_json(value, result);
+  }
+  return result;
+}
+
+template <typename T>
+inline T parse(std::stringstream& json_stream, bool& res) {
+  res = false;
+  boost::json::error_code ec;
+  auto value = boost::json::parse(json_stream, ec);
+  T result{};
+  if (value.is_object() || value.is_array()) {
+    from_json(value, result);
+    res = true;
+  }
+  return result;
+}
+
+template <typename T>
+inline T parse(std::stringstream& json_stream) {
+  bool res = true;
+  return parse<T>(json_stream, res);
+}
+
+template <typename T>
+inline T parse(const std::shared_ptr<std::vector<unsigned char>>& json_bytes) {
+  boost::json::string_view json(reinterpret_cast<char*>(json_bytes->data()),
+                                json_bytes->size());
+  boost::json::error_code ec;
+  auto value = boost::json::parse(json, ec);
+  T result{};
+  if (value.is_object() || value.is_array()) {
+    from_json(value, result);
+  }
+  return result;
+}
+
+}  // namespace boost_parser
 
 }  // namespace parser
 }  // namespace olp

--- a/olp-cpp-sdk-core/include/olp/core/generated/parser/ParserWrapper.h
+++ b/olp-cpp-sdk-core/include/olp/core/generated/parser/ParserWrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,13 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <olp/core/porting/optional.h>
+#include <rapidjson/document.h>
 #include <rapidjson/rapidjson.h>
+#include <boost/json/value.hpp>
 
 namespace olp {
 namespace parser {
@@ -90,6 +93,73 @@ inline T parse(const rapidjson::Value& value, const std::string& name) {
   rapidjson::Value::ConstMemberIterator itr = value.FindMember(name.c_str());
   if (itr != value.MemberEnd()) {
     from_json(itr->value, result);
+  }
+  return result;
+}
+
+inline void from_json(const boost::json::value& value, std::string& x) {
+  const auto& str = value.get_string();
+  x.assign(str.begin(), str.end());
+}
+
+inline void from_json(const boost::json::value& value, int32_t& x) {
+  x = static_cast<int32_t>(value.to_number<int64_t>());
+}
+
+inline void from_json(const boost::json::value& value, int64_t& x) {
+  x = value.to_number<int64_t>();
+}
+
+inline void from_json(const boost::json::value& value, double& x) {
+  x = value.to_number<double>();
+}
+
+inline void from_json(const boost::json::value& value, bool& x) {
+  x = value.get_bool();
+}
+
+inline void from_json(const boost::json::value& value,
+                      std::shared_ptr<std::vector<unsigned char>>& x) {
+  const auto& s = value.get_string();
+  x = std::make_shared<std::vector<unsigned char>>(s.begin(), s.end());
+}
+
+template <typename T>
+inline void from_json(const boost::json::value& value,
+                      porting::optional<T>& x) {
+  T result = T();
+  from_json(value, result);
+  x = result;
+}
+
+template <typename T>
+inline void from_json(const boost::json::value& value,
+                      std::map<std::string, T>& results) {
+  const auto& object = value.get_object();
+  for (const auto& object_value : object) {
+    std::string key = object_value.key();
+    from_json(object_value.value(), results[key]);
+  }
+}
+
+template <typename T>
+inline void from_json(const boost::json::value& value,
+                      std::vector<T>& results) {
+  const auto& array = value.get_array();
+  for (const auto& array_value : array) {
+    T result;
+    from_json(array_value, result);
+    results.emplace_back(std::move(result));
+  }
+}
+
+template <typename T>
+inline T parse(const boost::json::value& value, const std::string& name) {
+  T result = T();
+  const auto& object = value.get_object();
+  auto itr = object.find(name);
+  if (itr != object.end()) {
+    from_json(itr->value(), result);
   }
   return result;
 }

--- a/olp-cpp-sdk-core/include/olp/core/generated/serializer/SerializerWrapper.h
+++ b/olp-cpp-sdk-core/include/olp/core/generated/serializer/SerializerWrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@
 
 #include <olp/core/porting/optional.h>
 #include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 namespace olp {
 namespace serializer {
@@ -107,6 +108,73 @@ inline void serialize(const std::string& key, const T& x,
   to_json(x, item_value, allocator);
   if (!item_value.IsNull()) {
     value.AddMember(std::move(key_value), std::move(item_value), allocator);
+  }
+}
+
+inline void to_json(const std::string& x, boost::json::value& value) {
+  value.emplace_string() = x;
+}
+
+inline void to_json(int32_t x, boost::json::value& value) {
+  value.emplace_int64() = x;
+}
+
+inline void to_json(int64_t x, boost::json::value& value) {
+  value.emplace_int64() = x;
+}
+
+inline void to_json(double x, boost::json::value& value) {
+  value.emplace_double() = x;
+}
+inline void to_json(bool x, boost::json::value& value) {
+  value.emplace_bool() = x;
+}
+
+inline void to_json(const std::shared_ptr<std::vector<unsigned char>>& x,
+                    boost::json::value& value) {
+  value.emplace_string().assign(x->begin(), x->end());
+}
+
+template <typename T>
+inline void to_json(const porting::optional<T>& x, boost::json::value& value) {
+  if (x) {
+    to_json(*x, value);
+  } else {
+    value.emplace_null();
+  }
+}
+
+template <typename T>
+inline void to_json(const std::map<std::string, T>& x,
+                    boost::json::value& value) {
+  auto& object = value.emplace_object();
+  for (auto itr = x.begin(); itr != x.end(); ++itr) {
+    const auto& key = itr->first;
+    boost::json::value item_value;
+    to_json(itr->second, item_value);
+    object.emplace(key, std::move(item_value));
+  }
+}
+
+template <typename T>
+inline void to_json(const std::vector<T>& x, boost::json::value& value) {
+  auto& array = value.emplace_array();
+  array.reserve(x.size());
+  for (typename std::vector<T>::const_iterator itr = x.begin(); itr != x.end();
+       ++itr) {
+    boost::json::value item_value;
+    to_json(*itr, item_value);
+    array.emplace_back(std::move(item_value));
+  }
+}
+
+template <typename T>
+inline void serialize(const std::string& key, const T& x,
+                      boost::json::object& value) {
+  boost::json::value item_value;
+  to_json(x, item_value);
+  if (!item_value.is_null()) {
+    value.emplace(key, std::move(item_value));
   }
 }
 

--- a/olp-cpp-sdk-dataservice-write/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-write/CMakeLists.txt
@@ -18,6 +18,8 @@
 project(olp-cpp-sdk-dataservice-write VERSION 1.24.0)
 set(DESCRIPTION "C++ API library for writing data to OLP")
 
+find_package(Boost REQUIRED)
+
 set(OLP_SDK_DATASERVICE_WRITE_API_HEADERS
     ./include/olp/dataservice/write/DataServiceWriteApi.h
     ./include/olp/dataservice/write/IndexLayerClient.h
@@ -159,16 +161,21 @@ set(OLP_SDK_DATASERVICE_WRITE_SOURCES
     ./src/generated/serializer/PublishPartitionsSerializer.h
     ./src/generated/serializer/UpdateIndexRequestSerializer.cpp
     ./src/generated/serializer/UpdateIndexRequestSerializer.h
+
+    ./src/utils/BoostJsonSrc.cpp
 )
 
 add_library(${PROJECT_NAME}
     ${OLP_SDK_DATASERVICE_WRITE_INCLUDES}
     ${OLP_SDK_DATASERVICE_WRITE_SOURCES})
 
-target_include_directories(${PROJECT_NAME} PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-    PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>)
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+    PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>
+        $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>)
 
 target_compile_definitions(${PROJECT_NAME}
     PRIVATE DATASERVICE_WRITE_LIBRARY)
@@ -176,6 +183,11 @@ if(BUILD_SHARED_LIBS)
     target_compile_definitions(${PROJECT_NAME}
         PUBLIC DATASERVICE_WRITE_SHARED_LIBRARY)
 endif()
+
+target_compile_definitions(${PROJECT_NAME}
+    PRIVATE
+        BOOST_ALL_NO_LIB
+        BOOST_JSON_NO_LIB)
 
 # Used also in the package config file
 set(PROJECT_LIBS olp-cpp-sdk-core)

--- a/olp-cpp-sdk-dataservice-write/src/CatalogSettings.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/CatalogSettings.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
  */
 
 #include "CatalogSettings.h"
+
+#include <utility>
 
 #include <olp/core/cache/CacheSettings.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
@@ -102,7 +104,7 @@ CatalogSettings::LayerSettingsResult CatalogSettings::GetLayerSettings(
 
   const auto& cached_catalog =
       cache_->Get(catalog_settings_key, [](const std::string& model) {
-        return parser::parse<model::Catalog>(model);
+        return olp::parser::boost_parser::parse<model::Catalog>(model);
       });
 
   if (cached_catalog.empty()) {

--- a/olp-cpp-sdk-dataservice-write/src/JsonResultParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/JsonResultParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ typename std::enable_if<
     OutputResult>::type
 parse_result(std::stringstream& json_stream, const AdditionalArgs&... args) {
   bool res = true;
-  auto obj = parse<ParsingType>(json_stream, res);
+  auto obj = boost_parser::parse<ParsingType>(json_stream, res);
 
   if (res) {
     return ParsingType(std::move(obj), args...);
@@ -56,7 +56,7 @@ typename std::enable_if<
     OutputResult>::type
 parse_result(std::stringstream& json_stream, const AdditionalArgs&... args) {
   bool res = true;
-  auto obj = parse<ParsingType>(json_stream, res);
+  auto obj = boost_parser::parse<ParsingType>(json_stream, res);
 
   if (res) {
     return OutputResult({std::move(obj), args...});

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,10 @@
  */
 
 #include "StreamLayerClientImpl.h"
+
+#include <memory>
+#include <string>
+#include <utility>
 
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -168,7 +172,7 @@ StreamLayerClientImpl::PopFromQueue() {
   const auto publish_data_key = uuid_list.substr(0, pos);
   auto publish_data_any =
       cache_->Get(publish_data_key, [](const std::string& s) {
-        return olp::parser::parse<model::PublishDataRequest>(s);
+        return olp::parser::boost_parser::parse<model::PublishDataRequest>(s);
       });
 
   cache_->Remove(publish_data_key);

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/ApiParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/ApiParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,13 @@
 
 #include "ApiParser.h"
 
+#include <map>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Api& x) {
   x.SetApi(parse<std::string>(value, "api"));
   x.SetVersion(parse<std::string>(value, "version"));

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/ApiParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/ApiParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,14 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 #include "generated/model/Api.h"
 
 #include <string>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Api& x);
 
 }  // namespace parser

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/CatalogParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/CatalogParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,48 +19,50 @@
 
 #include "CatalogParser.h"
 
+#include <vector>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-using namespace olp::dataservice::write;
+namespace model = olp::dataservice::write::model;
 
-void from_json(const rapidjson::Value& value, model::Coverage& x) {
+void from_json(const boost::json::value& value, model::Coverage& x) {
   x.SetAdminAreas(parse<std::vector<std::string> >(value, "adminAreas"));
 }
 
-void from_json(const rapidjson::Value& value, model::IndexDefinition& x) {
+void from_json(const boost::json::value& value, model::IndexDefinition& x) {
   x.SetName(parse<std::string>(value, "name"));
   x.SetType(parse<std::string>(value, "type"));
   x.SetDuration(parse<int64_t>(value, "duration"));
   x.SetZoomLevel(parse<int64_t>(value, "zoomLevel"));
 }
 
-void from_json(const rapidjson::Value& value, model::IndexProperties& x) {
+void from_json(const boost::json::value& value, model::IndexProperties& x) {
   x.SetTtl(parse<std::string>(value, "ttl"));
   x.SetIndexDefinitions(
       parse<std::vector<model::IndexDefinition> >(value, "indexDefinitions"));
 }
 
-void from_json(const rapidjson::Value& value, model::Creator& x) {
+void from_json(const boost::json::value& value, model::Creator& x) {
   x.SetId(parse<std::string>(value, "id"));
 }
 
-void from_json(const rapidjson::Value& value, model::Owner& x) {
+void from_json(const boost::json::value& value, model::Owner& x) {
   x.SetCreator(parse<model::Creator>(value, "creator"));
   x.SetOrganisation(parse<model::Creator>(value, "organisation"));
 }
 
-void from_json(const rapidjson::Value& value, model::Partitioning& x) {
+void from_json(const boost::json::value& value, model::Partitioning& x) {
   x.SetScheme(parse<std::string>(value, "scheme"));
   x.SetTileLevels(parse<std::vector<int64_t> >(value, "tileLevels"));
 }
 
-void from_json(const rapidjson::Value& value, model::Schema& x) {
+void from_json(const boost::json::value& value, model::Schema& x) {
   x.SetHrn(parse<std::string>(value, "hrn"));
 }
 
-void from_json(const rapidjson::Value& value, model::StreamProperties& x) {
+void from_json(const boost::json::value& value, model::StreamProperties& x) {
   // Parsing these as double even though OepnAPI sepcs says int64 because
   // Backend returns the value in decimal format (e.g. 1.0) and this triggers an
   // assert in RapidJSON when parsing.
@@ -70,18 +72,18 @@ void from_json(const rapidjson::Value& value, model::StreamProperties& x) {
       static_cast<int64_t>(parse<double>(value, "dataOutThroughputMbps")));
 }
 
-void from_json(const rapidjson::Value& value, model::Encryption& x) {
+void from_json(const boost::json::value& value, model::Encryption& x) {
   x.SetAlgorithm(parse<std::string>(value, "algorithm"));
 }
 
-void from_json(const rapidjson::Value& value, model::Volume& x) {
+void from_json(const boost::json::value& value, model::Volume& x) {
   x.SetVolumeType(parse<std::string>(value, "volumeType"));
   x.SetMaxMemoryPolicy(parse<std::string>(value, "maxMemoryPolicy"));
   x.SetPackageType(parse<std::string>(value, "packageType"));
   x.SetEncryption(parse<model::Encryption>(value, "encryption"));
 }
 
-void from_json(const rapidjson::Value& value, model::Layer& x) {
+void from_json(const boost::json::value& value, model::Layer& x) {
   x.SetId(parse<std::string>(value, "id"));
   x.SetName(parse<std::string>(value, "name"));
   x.SetSummary(parse<std::string>(value, "summary"));
@@ -103,11 +105,11 @@ void from_json(const rapidjson::Value& value, model::Layer& x) {
   x.SetVolume(parse<model::Volume>(value, "volume"));
 }
 
-void from_json(const rapidjson::Value& value, model::Notifications& x) {
+void from_json(const boost::json::value& value, model::Notifications& x) {
   x.SetEnabled(parse<bool>(value, "enabled"));
 }
 
-void from_json(const rapidjson::Value& value, model::Catalog& x) {
+void from_json(const boost::json::value& value, model::Catalog& x) {
   x.SetId(parse<std::string>(value, "id"));
   x.SetHrn(parse<std::string>(value, "hrn"));
   x.SetName(parse<std::string>(value, "name"));

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/CatalogParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/CatalogParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,49 +21,49 @@
 
 #include <string>
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <generated/model/Catalog.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Coverage& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::IndexDefinition& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::IndexProperties& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Creator& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Owner& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Partitioning& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Schema& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::StreamProperties& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Encryption& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Volume& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Layer& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Notifications& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Catalog& x);
 }  // namespace parser
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/DetailsParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/DetailsParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,13 @@
 
 #include "DetailsParser.h"
 
+#include <string>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Details& x) {
   x.SetState(parse<std::string>(value, "state"));
   x.SetMessage(parse<std::string>(value, "message"));

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/DetailsParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/DetailsParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/generated/model/Details.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::Details& x);
 }  // namespace parser
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/LayerVersionsParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/LayerVersionsParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,19 +19,21 @@
 
 #include "LayerVersionsParser.h"
 
+#include <vector>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-using namespace olp::dataservice::write;
+namespace model = olp::dataservice::write::model;
 
-void from_json(const rapidjson::Value& value, model::LayerVersion& x) {
+void from_json(const boost::json::value& value, model::LayerVersion& x) {
   x.SetLayer(parse<std::string>(value, "layer"));
   x.SetVersion(parse<int64_t>(value, "version"));
   x.SetTimestamp(parse<int64_t>(value, "timestamp"));
 }
 
-void from_json(const rapidjson::Value& value, model::LayerVersions& x) {
+void from_json(const boost::json::value& value, model::LayerVersions& x) {
   x.SetLayerVersions(
       parse<std::vector<model::LayerVersion>>(value, "layerVersions"));
   x.SetVersion(parse<int64_t>(value, "version"));

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/LayerVersionsParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/LayerVersionsParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,17 +19,17 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 #include "generated/model/LayerVersions.h"
 
 #include <string>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::LayerVersion& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::LayerVersions& x);
 
 }  // namespace parser

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PartitionParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PartitionParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,17 +19,17 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 #include "olp/dataservice/write/model/Partitions.h"
 
 #include <string>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Partition& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Partitions& x);
 
 }  // namespace parser

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PartitionsParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PartitionsParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,15 @@
 
 #include "PartitionsParser.h"
 
+#include <vector>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-namespace model = dataservice::write::model;
+namespace model = olp::dataservice::write::model;
 
-void from_json(const rapidjson::Value& value, model::Partition& x) {
+void from_json(const boost::json::value& value, model::Partition& x) {
   x.SetChecksum(parse<porting::optional<std::string>>(value, "checksum"));
   x.SetCompressedDataSize(
       parse<porting::optional<int64_t>>(value, "compressedDataSize"));
@@ -35,7 +37,7 @@ void from_json(const rapidjson::Value& value, model::Partition& x) {
   x.SetVersion(parse<porting::optional<int64_t>>(value, "version"));
 }
 
-void from_json(const rapidjson::Value& value, model::Partitions& x) {
+void from_json(const boost::json::value& value, model::Partitions& x) {
   x.SetPartitions(parse<std::vector<model::Partition>>(value, "partitions"));
 }
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublicationParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublicationParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,9 @@
 
 #include "PublicationParser.h"
 
+#include <string>
+#include <vector>
+
 // clang-format off
 #include <generated/parser/DetailsParser.h>
 #include <generated/parser/VersionDependencyParser.h>
@@ -27,7 +30,7 @@
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Publication& x) {
   x.SetId(parse<std::string>(value, "id"));
   x.SetDetails(

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublicationParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublicationParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/generated/model/Publication.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::Publication& x);
 }  // namespace parser
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishDataRequestParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishDataRequestParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,17 @@
 
 #include "PublishDataRequestParser.h"
 
+#include <memory>
+#include <string>
+#include <vector>
+
 // clang-format off
 #include <olp/core/generated/parser/ParserWrapper.h>
 // clang-format on
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::PublishDataRequest& x) {
   x.WithData(
       (parse<std::shared_ptr<std::vector<unsigned char>>>(value, "data")));

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishDataRequestParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishDataRequestParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/model/PublishDataRequest.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::PublishDataRequest& x);
 }  // namespace parser
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,15 @@
 
 #include "PublishPartitionParser.h"
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::PublishPartition& x) {
   x.SetPartition(parse<std::string>(value, "partition"));
   x.SetChecksum(parse<std::string>(value, "checksum"));

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include "generated/model/PublishPartition.h"
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::PublishPartition& x);
 }  // namespace parser
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionsParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionsParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 
 #include "PublishPartitionsParser.h"
 
+#include <vector>
+
 // clang-format off
 #include <generated/parser/PublishPartitionParser.h>
 #include <olp/core/generated/parser/ParserWrapper.h>
@@ -26,7 +28,7 @@
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::PublishPartitions& x) {
   x.SetPartitions(
       parse<std::vector<olp::dataservice::write::model::PublishPartition>>(

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionsParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionsParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include "generated/model/PublishPartitions.h"
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::PublishPartitions& x);
 }  // namespace parser
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,19 +19,22 @@
 
 #include "ResponseOkParser.h"
 
+#include <string>
+#include <vector>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
-using namespace olp::dataservice::write::model;
+namespace model = olp::dataservice::write::model;
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value, TraceID& x) {
+void from_json(const boost::json::value& value, model::TraceID& x) {
   x.SetParentID(parse<std::string>(value, "ParentID"));
   x.SetGeneratedIDs(parse<std::vector<std::string> >(value, "GeneratedIDs"));
 }
 
-void from_json(const rapidjson::Value& value, ResponseOk& x) {
-  x.SetTraceID(parse<TraceID>(value, "TraceID"));
+void from_json(const boost::json::value& value, model::ResponseOk& x) {
+  x.SetTraceID(parse<model::TraceID>(value, "TraceID"));
 }
 
 }  // namespace parser

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,16 +19,16 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/generated/model/ResponseOk.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::TraceID& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::ResponseOk& x);
 
 }  // namespace parser

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkSingleParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkSingleParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,13 @@
 
 #include "ResponseOkSingleParser.h"
 
+#include <string>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::ResponseOkSingle& x) {
   x.SetTraceID(parse<std::string>(value, "TraceID"));
 }

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkSingleParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkSingleParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/generated/model/ResponseOkSingle.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::ResponseOkSingle& x);
 
 }  // namespace parser

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionDependencyParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionDependencyParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,13 @@
 
 #include "VersionDependencyParser.h"
 
+#include <string>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::VersionDependency& x) {
   x.SetDirect(parse<bool>(value, "direct"));
   x.SetHrn(parse<std::string>(value, "hrn"));

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionDependencyParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionDependencyParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/generated/model/VersionDependency.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::VersionDependency& x);
 }  // namespace parser
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionResponseParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionResponseParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,9 @@
 
 namespace olp {
 namespace parser {
-using namespace olp::dataservice::write;
+namespace model = olp::dataservice::write::model;
 
-void from_json(const rapidjson::Value& value, model::VersionResponse& x) {
+void from_json(const boost::json::value& value, model::VersionResponse& x) {
   x.SetVersion(parse<int64_t>(value, "version"));
 }
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionResponseParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionResponseParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,14 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 #include "olp/dataservice/write/model/VersionResponse.h"
 
 #include <string>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::VersionResponse& x);
 
 }  // namespace parser

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/ApiSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/ApiSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include "ApiSerializer.h"
 
@@ -25,13 +25,13 @@
 
 namespace olp {
 namespace serializer {
-void to_json(const dataservice::write::model::Api& x, rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("api", x.GetApi(), value, allocator);
-  serialize("version", x.GetVersion(), value, allocator);
-  serialize("baseURL", x.GetBaseUrl(), value, allocator);
-  serialize("parameters", x.GetParameters(), value, allocator);
+void to_json(const dataservice::write::model::Api& x,
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("api", x.GetApi(), object);
+  serialize("version", x.GetVersion(), object);
+  serialize("baseURL", x.GetBaseUrl(), object);
+  serialize("parameters", x.GetParameters(), object);
 }
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/ApiSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/ApiSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,14 +21,13 @@
 
 #include <string>
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 #include "generated/model/Api.h"
 
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::Api& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/CatalogSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/CatalogSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include "CatalogSerializer.h"
 
@@ -26,133 +26,120 @@
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::Coverage& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("adminAreas", x.GetAdminAreas(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("adminAreas", x.GetAdminAreas(), object);
 }
 
 void to_json(const dataservice::write::model::IndexDefinition& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("name", x.GetName(), value, allocator);
-  serialize("type", x.GetType(), value, allocator);
-  serialize("duration", x.GetDuration(), value, allocator);
-  serialize("zoomLevel", x.GetZoomLevel(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("name", x.GetName(), object);
+  serialize("type", x.GetType(), object);
+  serialize("duration", x.GetDuration(), object);
+  serialize("zoomLevel", x.GetZoomLevel(), object);
 }
 
 void to_json(const dataservice::write::model::IndexProperties& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("ttl", x.GetTtl(), value, allocator);
-  serialize("indexDefinitions", x.GetIndexDefinitions(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("ttl", x.GetTtl(), object);
+  serialize("indexDefinitions", x.GetIndexDefinitions(), object);
 }
 
 void to_json(const dataservice::write::model::Creator& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("id", x.GetId(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("id", x.GetId(), object);
 }
 
-void to_json(const dataservice::write::model::Owner& x, rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("creator", x.GetCreator(), value, allocator);
-  serialize("organisation", x.GetOrganisation(), value, allocator);
+void to_json(const dataservice::write::model::Owner& x,
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("creator", x.GetCreator(), object);
+  serialize("organisation", x.GetOrganisation(), object);
 }
 
 void to_json(const dataservice::write::model::Partitioning& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("scheme", x.GetScheme(), value, allocator);
-  serialize("tileLevels", x.GetTileLevels(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("scheme", x.GetScheme(), object);
+  serialize("tileLevels", x.GetTileLevels(), object);
 }
 
 void to_json(const dataservice::write::model::Schema& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("hrn", x.GetHrn(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("hrn", x.GetHrn(), object);
 }
 
 void to_json(const dataservice::write::model::StreamProperties& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("dataInThroughputMbps", x.GetDataInThroughputMbps(), value,
-            allocator);
-  serialize("dataOutThroughputMbps", x.GetDataOutThroughputMbps(), value,
-            allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("dataInThroughputMbps", x.GetDataInThroughputMbps(), object);
+  serialize("dataOutThroughputMbps", x.GetDataOutThroughputMbps(), object);
 }
 
 void to_json(const dataservice::write::model::Encryption& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("algorithm", x.GetAlgorithm(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("algorithm", x.GetAlgorithm(), object);
 }
 
 void to_json(const dataservice::write::model::Volume& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("volumeType", x.GetVolumeType(), value, allocator);
-  serialize("maxMemoryPolicy", x.GetMaxMemoryPolicy(), value, allocator);
-  serialize("packageType", x.GetPackageType(), value, allocator);
-  serialize("encryption", x.GetEncryption(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("volumeType", x.GetVolumeType(), object);
+  serialize("maxMemoryPolicy", x.GetMaxMemoryPolicy(), object);
+  serialize("packageType", x.GetPackageType(), object);
+  serialize("encryption", x.GetEncryption(), object);
 }
 
-void to_json(const dataservice::write::model::Layer& x, rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("id", x.GetId(), value, allocator);
-  serialize("name", x.GetName(), value, allocator);
-  serialize("summary", x.GetSummary(), value, allocator);
-  serialize("description", x.GetDescription(), value, allocator);
-  serialize("owner", x.GetOwner(), value, allocator);
-  serialize("coverage", x.GetCoverage(), value, allocator);
-  serialize("schema", x.GetSchema(), value, allocator);
-  serialize("contentType", x.GetContentType(), value, allocator);
-  serialize("contentEncoding", x.GetContentEncoding(), value, allocator);
-  serialize("partitioning", x.GetPartitioning(), value, allocator);
-  serialize("layerType", x.GetLayerType(), value, allocator);
-  serialize("digest", x.GetDigest(), value, allocator);
-  serialize("tags", x.GetTags(), value, allocator);
-  serialize("billingTags", x.GetBillingTags(), value, allocator);
-  serialize("ttl", x.GetTtl(), value, allocator);
-  serialize("indexProperties", x.GetIndexProperties(), value, allocator);
-  serialize("streamProperties", x.GetStreamProperties(), value, allocator);
-  serialize("volume", x.GetVolume(), value, allocator);
+void to_json(const dataservice::write::model::Layer& x,
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("id", x.GetId(), object);
+  serialize("name", x.GetName(), object);
+  serialize("summary", x.GetSummary(), object);
+  serialize("description", x.GetDescription(), object);
+  serialize("owner", x.GetOwner(), object);
+  serialize("coverage", x.GetCoverage(), object);
+  serialize("schema", x.GetSchema(), object);
+  serialize("contentType", x.GetContentType(), object);
+  serialize("contentEncoding", x.GetContentEncoding(), object);
+  serialize("partitioning", x.GetPartitioning(), object);
+  serialize("layerType", x.GetLayerType(), object);
+  serialize("digest", x.GetDigest(), object);
+  serialize("tags", x.GetTags(), object);
+  serialize("billingTags", x.GetBillingTags(), object);
+  serialize("ttl", x.GetTtl(), object);
+  serialize("indexProperties", x.GetIndexProperties(), object);
+  serialize("streamProperties", x.GetStreamProperties(), object);
+  serialize("volume", x.GetVolume(), object);
 }
 
 void to_json(const dataservice::write::model::Notifications& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("enabled", x.GetEnabled(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("enabled", x.GetEnabled(), object);
 }
 
 void to_json(const dataservice::write::model::Catalog& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("id", x.GetId(), value, allocator);
-  serialize("hrn", x.GetHrn(), value, allocator);
-  serialize("name", x.GetName(), value, allocator);
-  serialize("summary", x.GetSummary(), value, allocator);
-  serialize("description", x.GetDescription(), value, allocator);
-  serialize("coverage", x.GetCoverage(), value, allocator);
-  serialize("owner", x.GetOwner(), value, allocator);
-  serialize("tags", x.GetTags(), value, allocator);
-  serialize("billingTags", x.GetBillingTags(), value, allocator);
-  serialize("created", x.GetCreated(), value, allocator);
-  serialize("layers", x.GetLayers(), value, allocator);
-  serialize("version", x.GetVersion(), value, allocator);
-  serialize("notifications", x.GetNotifications(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("id", x.GetId(), object);
+  serialize("hrn", x.GetHrn(), object);
+  serialize("name", x.GetName(), object);
+  serialize("summary", x.GetSummary(), object);
+  serialize("description", x.GetDescription(), object);
+  serialize("coverage", x.GetCoverage(), object);
+  serialize("owner", x.GetOwner(), object);
+  serialize("tags", x.GetTags(), object);
+  serialize("billingTags", x.GetBillingTags(), object);
+  serialize("created", x.GetCreated(), object);
+  serialize("layers", x.GetLayers(), object);
+  serialize("version", x.GetVersion(), object);
+  serialize("notifications", x.GetNotifications(), object);
 }
 
 }  // namespace serializer

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/CatalogSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/CatalogSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,61 +19,50 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include "../model/Catalog.h"
 
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::Coverage& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::IndexDefinition& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::IndexProperties& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::Creator& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
-void to_json(const dataservice::write::model::Owner& x, rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+void to_json(const dataservice::write::model::Owner& x,
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::Partitioning& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::Schema& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::StreamProperties& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::Encryption& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::Volume& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
-void to_json(const dataservice::write::model::Layer& x, rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+void to_json(const dataservice::write::model::Layer& x,
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::Notifications& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::Catalog& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/IndexInfoSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/IndexInfoSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,71 +19,59 @@
 
 #include "IndexInfoSerializer.h"
 
+#include <utility>
+
 namespace olp {
 namespace serializer {
-void to_json(const dataservice::write::model::Index &x, rapidjson::Value &value,
-             rapidjson::Document::AllocatorType &allocator) {
-  rapidjson::Value jsonValue(rapidjson::kObjectType);
-  value.SetArray();
-  jsonValue.AddMember("id", rapidjson::StringRef(x.GetId().c_str()), allocator);
+void to_json(const dataservice::write::model::Index &x,
+             boost::json::value &value) {
+  boost::json::object jsonValue;
+  value.emplace_array();
+  jsonValue.emplace("id", x.GetId());
 
-  rapidjson::Value indexFields(rapidjson::kObjectType);
+  boost::json::object indexFields;
   for (auto &field_pair : x.GetIndexFields()) {
-    using dataservice::write::model::BooleanIndexValue;
-    using dataservice::write::model::HereTileIndexValue;
-    using dataservice::write::model::IndexType;
-    using dataservice::write::model::IntIndexValue;
-    using dataservice::write::model::StringIndexValue;
-    using dataservice::write::model::TimeWindowIndexValue;
-
+    namespace model = dataservice::write::model;
     const auto &field = field_pair.second;
-    const auto key = rapidjson::StringRef(field_pair.first.c_str());
+    const auto &key = field_pair.first;
     auto index_type = field->getIndexType();
-    if (index_type == IndexType::String) {
-      auto s = std::static_pointer_cast<StringIndexValue>(field);
-      rapidjson::Value str_val;
-      const auto &str = s->GetValue();
-      str_val.SetString(
-          str.c_str(), static_cast<rapidjson::SizeType>(str.size()), allocator);
-      indexFields.AddMember(key, str_val, allocator);
-    } else if (index_type == IndexType::Int) {
-      auto s = std::static_pointer_cast<IntIndexValue>(field);
-      indexFields.AddMember(key, s->GetValue(), allocator);
-    } else if (index_type == IndexType::Bool) {
-      auto s = std::static_pointer_cast<BooleanIndexValue>(field);
-      indexFields.AddMember(key, s->GetValue(), allocator);
-    } else if (index_type == IndexType::Heretile) {
-      auto s = std::static_pointer_cast<HereTileIndexValue>(field);
-      indexFields.AddMember(key, s->GetValue(), allocator);
-    } else if (index_type == IndexType::TimeWindow) {
-      auto s = std::static_pointer_cast<TimeWindowIndexValue>(field);
-      indexFields.AddMember(key, s->GetValue(), allocator);
+    if (index_type == model::IndexType::String) {
+      auto s = std::static_pointer_cast<model::StringIndexValue>(field);
+      boost::json::string str_val{s->GetValue()};
+      indexFields.emplace(key, std::move(str_val));
+    } else if (index_type == model::IndexType::Int) {
+      auto s = std::static_pointer_cast<model::IntIndexValue>(field);
+      indexFields.emplace(key, s->GetValue());
+    } else if (index_type == model::IndexType::Bool) {
+      auto s = std::static_pointer_cast<model::BooleanIndexValue>(field);
+      indexFields.emplace(key, s->GetValue());
+    } else if (index_type == model::IndexType::Heretile) {
+      auto s = std::static_pointer_cast<model::HereTileIndexValue>(field);
+      indexFields.emplace(key, s->GetValue());
+    } else if (index_type == model::IndexType::TimeWindow) {
+      auto s = std::static_pointer_cast<model::TimeWindowIndexValue>(field);
+      indexFields.emplace(key, s->GetValue());
     }
   }
-  jsonValue.AddMember("fields", indexFields, allocator);
+  jsonValue.emplace("fields", std::move(indexFields));
   // TODO: Separate Metadata Model serialization into its own file when needed
   // by another model.
   if (x.GetMetadata()) {
-    rapidjson::Value metadatas(rapidjson::kObjectType);
-    for (const auto &metadata : *x.GetMetadata()) {
-      auto metadata_value = metadata.second;
-      auto metadata_key = metadata.first.c_str();
-      indexFields.AddMember(
-          rapidjson::StringRef(metadata_key),
-          rapidjson::StringRef(metadata_value.c_str(), metadata_value.size()),
-          allocator);
+    for (auto &metadata : x.GetMetadata().get()) {
+      auto &metadata_value = metadata.second;
+      auto &metadata_key = metadata.first;
+      indexFields.emplace(metadata_key, metadata_value);
     }
   }
 
   if (x.GetCheckSum()) {
-    jsonValue.AddMember(
-        "checksum", rapidjson::StringRef(x.GetCheckSum()->c_str()), allocator);
+    jsonValue.emplace("checksum", x.GetCheckSum().get());
   }
 
   if (x.GetSize()) {
-    jsonValue.AddMember("size", *x.GetSize(), allocator);
+    jsonValue.emplace("size", x.GetSize().get());
   }
-  value.PushBack(jsonValue, allocator);
+  value.as_array().emplace_back(std::move(jsonValue));
 }
 
 }  // namespace serializer

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/IndexInfoSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/IndexInfoSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/generated/model/Index.h>
 
 namespace olp {
 namespace serializer {
-void to_json(const dataservice::write::model::Index& x, rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+void to_json(const dataservice::write::model::Index& x,
+             boost::json::value& value);
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/JsonSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/JsonSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,24 +19,19 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
+#include <string>
+
+#include <boost/json/serialize.hpp>
+#include <boost/json/value.hpp>
 
 namespace olp {
 namespace serializer {
 template <typename T>
 inline std::string serialize(const T& object) {
-  rapidjson::Document doc;
-  auto& allocator = doc.GetAllocator();
-
-  doc.SetObject();
-  to_json(object, doc, allocator);
-
-  rapidjson::StringBuffer buffer;
-  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-  doc.Accept(writer);
-  return buffer.GetString();
+  boost::json::value value;
+  value.emplace_object();
+  to_json(object, value);
+  return boost::json::serialize(value);
 }
 
 }  // namespace serializer

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublicationSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublicationSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,59 +19,54 @@
 
 #include "PublicationSerializer.h"
 
+#include <utility>
+
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::Publication& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
   if (x.GetId()) {
-    value.AddMember("id", rapidjson::StringRef(x.GetId()->c_str()), allocator);
+    object.emplace("id", x.GetId().get());
   }
 
   // TODO: Separate Details Model serializtion into it's own file when needed by
   // another model.
   if (x.GetDetails()) {
-    rapidjson::Value details(rapidjson::kObjectType);
-    details.AddMember("state",
-                      rapidjson::StringRef(x.GetDetails()->GetState().c_str()),
-                      allocator);
-    details.AddMember(
-        "message", rapidjson::StringRef(x.GetDetails()->GetMessage().c_str()),
-        allocator);
-    details.AddMember("started", x.GetDetails()->GetStarted(), allocator);
-    details.AddMember("modified", x.GetDetails()->GetModified(), allocator);
-    details.AddMember("expires", x.GetDetails()->GetExpires(), allocator);
-    value.AddMember("details", details, allocator);
+    boost::json::object details;
+    details.emplace("state", x.GetDetails()->GetState());
+    details.emplace("message", x.GetDetails()->GetMessage());
+    details.emplace("started", x.GetDetails()->GetStarted());
+    details.emplace("modified", x.GetDetails()->GetModified());
+    details.emplace("expires", x.GetDetails()->GetExpires());
+    object.emplace("details", std::move(details));
   }
 
   if (x.GetLayerIds()) {
-    rapidjson::Value layer_ids(rapidjson::kArrayType);
-    for (auto& layer_id : *x.GetLayerIds()) {
-      layer_ids.PushBack(rapidjson::StringRef(layer_id.c_str()), allocator);
+    boost::json::array layer_ids;
+    for (auto& layer_id : x.GetLayerIds().get()) {
+      layer_ids.emplace_back(layer_id);
     }
-    value.AddMember("layerIds", layer_ids, allocator);
+    object.emplace("layerIds", std::move(layer_ids));
   }
 
   if (x.GetCatalogVersion()) {
-    value.AddMember("catalogVersion", *x.GetCatalogVersion(), allocator);
+    object.emplace("catalogVersion", x.GetCatalogVersion().get());
   }
 
   if (x.GetVersionDependencies()) {
-    rapidjson::Value version_dependencies(rapidjson::kArrayType);
-    for (auto& version_dependency : *x.GetVersionDependencies()) {
+    boost::json::array version_dependencies;
+    for (auto& version_dependency : x.GetVersionDependencies().get()) {
       // TODO: Separate VersionDependency Model serializtion into it's own file
       // when needed by another model.
-      rapidjson::Value version_dependency_json(rapidjson::kObjectType);
-      version_dependency_json.AddMember(
-          "direct", version_dependency.GetDirect(), allocator);
-      version_dependency_json.AddMember(
-          "hrn", rapidjson::StringRef(version_dependency.GetHrn().c_str()),
-          allocator);
-      version_dependency_json.AddMember(
-          "version", version_dependency.GetVersion(), allocator);
-      version_dependencies.PushBack(version_dependency_json, allocator);
+      boost::json::object version_dependency_json;
+      version_dependency_json.emplace("direct", version_dependency.GetDirect());
+      version_dependency_json.emplace("hrn", version_dependency.GetHrn());
+      version_dependency_json.emplace("version",
+                                      version_dependency.GetVersion());
+      version_dependencies.emplace_back(std::move(version_dependency_json));
     }
-    value.AddMember("versionDependencies", version_dependencies, allocator);
+    object.emplace("versionDependencies", std::move(version_dependencies));
   }
 }
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublicationSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublicationSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/generated/model/Publication.h>
 
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::Publication& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishDataRequestSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishDataRequestSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,32 +22,27 @@
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::PublishDataRequest& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
   if (x.GetData()) {
     const auto& data = x.GetData().get();
-    auto data_stringref = rapidjson::StringRef(
+    auto data_stringref = boost::json::string_view(
         reinterpret_cast<char*>(data->data()), data->size());
-    value.AddMember("data", std::move(data_stringref), allocator);
+    object.emplace("data", data_stringref);
   }
 
-  value.AddMember("layerId", rapidjson::StringRef(x.GetLayerId().c_str()),
-                  allocator);
+  object.emplace("layerId", x.GetLayerId());
 
   if (x.GetTraceId()) {
-    value.AddMember("traceId", rapidjson::StringRef(x.GetTraceId()->c_str()),
-                    allocator);
+    object.emplace("traceId", x.GetTraceId().get());
   }
 
   if (x.GetBillingTag()) {
-    value.AddMember("billingTag",
-                    rapidjson::StringRef(x.GetBillingTag()->c_str()),
-                    allocator);
+    object.emplace("billingTag", x.GetBillingTag().get());
   }
 
   if (x.GetChecksum()) {
-    value.AddMember("checksum", rapidjson::StringRef(x.GetChecksum()->c_str()),
-                    allocator);
+    object.emplace("checksum", x.GetChecksum().get());
   }
 }
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishDataRequestSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishDataRequestSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/model/PublishDataRequest.h>
 
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::PublishDataRequest& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,42 +22,37 @@
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::PublishPartition& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
   if (x.GetPartition()) {
-    value.AddMember("partition",
-                    rapidjson::StringRef(x.GetPartition()->c_str()), allocator);
+    object.emplace("partition", x.GetPartition().get());
   }
 
   if (x.GetChecksum()) {
-    value.AddMember("checksum", rapidjson::StringRef(x.GetChecksum()->c_str()),
-                    allocator);
+    object.emplace("checksum", x.GetChecksum().get());
   }
 
   if (x.GetCompressedDataSize()) {
-    value.AddMember("compressedDataSize", *x.GetCompressedDataSize(),
-                    allocator);
+    object.emplace("compressedDataSize", x.GetCompressedDataSize().get());
   }
 
   if (x.GetDataSize()) {
-    value.AddMember("dataSize", *x.GetDataSize(), allocator);
+    object.emplace("dataSize", x.GetDataSize().get());
   }
 
   if (x.GetData()) {
     const auto& data = x.GetData().get();
-    auto data_stringref = rapidjson::StringRef(
+    auto data_stringref = boost::json::string_view(
         reinterpret_cast<char*>(data->data()), data->size());
-    value.AddMember("data", std::move(data_stringref), allocator);
+    object.emplace("data", data_stringref);
   }
 
   if (x.GetDataHandle()) {
-    value.AddMember("dataHandle",
-                    rapidjson::StringRef(x.GetDataHandle()->c_str()),
-                    allocator);
+    object.emplace("dataHandle", x.GetDataHandle().get());
   }
 
   if (x.GetTimestamp()) {
-    value.AddMember("timestamp", *x.GetTimestamp(), allocator);
+    object.emplace("timestamp", x.GetTimestamp().get());
   }
 }
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include "generated/model/PublishPartition.h"
 
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::PublishPartition& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionsSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionsSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,21 +19,22 @@
 
 #include "PublishPartitionsSerializer.h"
 
+#include <utility>
+
 #include "PublishPartitionSerializer.h"
 
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::PublishPartitions& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
+             boost::json::value& value) {
   if (x.GetPartitions()) {
-    rapidjson::Value partitions(rapidjson::kArrayType);
-    for (auto& partition : *x.GetPartitions()) {
-      rapidjson::Value partition_value(rapidjson::kObjectType);
-      to_json(partition, partition_value, allocator);
-      partitions.PushBack(partition_value, allocator);
+    boost::json::array partitions;
+    for (auto& partition : x.GetPartitions().get()) {
+      boost::json::value partition_value(boost::json::object_kind_t{});
+      to_json(partition, partition_value);
+      partitions.emplace_back(std::move(partition_value));
     }
-    value.AddMember("partitions", partitions, allocator);
+    value.as_object().emplace("partitions", std::move(partitions));
   }
 }
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionsSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionsSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include "generated/model/PublishPartitions.h"
 
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::PublishPartitions& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/UpdateIndexRequestSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/UpdateIndexRequestSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,84 +19,69 @@
 
 #include "UpdateIndexRequestSerializer.h"
 
+#include <utility>
+
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::UpdateIndexRequest &x,
-             rapidjson::Value &value,
-             rapidjson::Document::AllocatorType &allocator) {
-  rapidjson::Value additions(rapidjson::kArrayType);
+             boost::json::value &value) {
+  boost::json::array additions;
+  value.emplace_object();
   for (auto &addition : x.GetIndexAdditions()) {
-    rapidjson::Value additionValue(rapidjson::kObjectType);
-    additionValue.AddMember(
-        "id", rapidjson::StringRef(addition.GetId().c_str()), allocator);
+    boost::json::object additionValue;
+    additionValue.emplace("id", addition.GetId());
 
-    rapidjson::Value indexFields(rapidjson::kObjectType);
+    boost::json::object indexFields;
     for (const auto &field_pair : addition.GetIndexFields()) {
-      using dataservice::write::model::BooleanIndexValue;
-      using dataservice::write::model::HereTileIndexValue;
-      using dataservice::write::model::IndexType;
-      using dataservice::write::model::IntIndexValue;
-      using dataservice::write::model::StringIndexValue;
-      using dataservice::write::model::TimeWindowIndexValue;
-
+      namespace model = dataservice::write::model;
       const auto &field = field_pair.second;
-      const auto key = rapidjson::StringRef(field_pair.first.c_str());
+      const auto &key = field_pair.first;
       auto index_type = field->getIndexType();
-      if (index_type == IndexType::String) {
-        auto s = std::static_pointer_cast<StringIndexValue>(field);
-        rapidjson::Value str_val;
-        const auto &str = s->GetValue();
-        str_val.SetString(str.c_str(),
-                          static_cast<rapidjson::SizeType>(str.size()),
-                          allocator);
-        indexFields.AddMember(key, str_val, allocator);
-      } else if (index_type == IndexType::Int) {
-        auto s = std::static_pointer_cast<IntIndexValue>(field);
-        indexFields.AddMember(key, s->GetValue(), allocator);
-      } else if (index_type == IndexType::Bool) {
-        auto s = std::static_pointer_cast<BooleanIndexValue>(field);
-        indexFields.AddMember(key, s->GetValue(), allocator);
-      } else if (index_type == IndexType::Heretile) {
-        auto s = std::static_pointer_cast<HereTileIndexValue>(field);
-        indexFields.AddMember(key, s->GetValue(), allocator);
-      } else if (index_type == IndexType::TimeWindow) {
-        auto s = std::static_pointer_cast<TimeWindowIndexValue>(field);
-        indexFields.AddMember(key, s->GetValue(), allocator);
+      if (index_type == model::IndexType::String) {
+        auto s = std::static_pointer_cast<model::StringIndexValue>(field);
+        boost::json::value str_val{s->GetValue()};
+        indexFields.emplace(key, std::move(str_val));
+      } else if (index_type == model::IndexType::Int) {
+        auto s = std::static_pointer_cast<model::IntIndexValue>(field);
+        indexFields.emplace(key, s->GetValue());
+      } else if (index_type == model::IndexType::Bool) {
+        auto s = std::static_pointer_cast<model::BooleanIndexValue>(field);
+        indexFields.emplace(key, s->GetValue());
+      } else if (index_type == model::IndexType::Heretile) {
+        auto s = std::static_pointer_cast<model::HereTileIndexValue>(field);
+        indexFields.emplace(key, s->GetValue());
+      } else if (index_type == model::IndexType::TimeWindow) {
+        auto s = std::static_pointer_cast<model::TimeWindowIndexValue>(field);
+        indexFields.emplace(key, s->GetValue());
       }
     }
-    additionValue.AddMember("fields", indexFields, allocator);
+    additionValue.emplace("fields", indexFields);
     // TODO: Separate Details Model serializtion into it's own file when needed
     // by another model.
     if (addition.GetMetadata()) {
-      rapidjson::Value metadatas(rapidjson::kObjectType);
-      for (const auto &metadata : *addition.GetMetadata()) {
+      for (const auto &metadata : addition.GetMetadata().get()) {
         const auto &metadata_value = metadata.second;
-        const auto &metadata_key = metadata.first.c_str();
-        indexFields.AddMember(
-            rapidjson::StringRef(metadata_key),
-            rapidjson::StringRef(metadata_value.c_str(), metadata_value.size()),
-            allocator);
+        const auto &metadata_key = metadata.first;
+        indexFields.emplace(metadata_key, metadata_value);
       }
     }
 
     if (addition.GetCheckSum()) {
-      additionValue.AddMember(
-          "checksum", rapidjson::StringRef(addition.GetCheckSum()->c_str()),
-          allocator);
+      additionValue.emplace("checksum", addition.GetCheckSum().get());
     }
 
     if (addition.GetSize()) {
-      additionValue.AddMember("size", *addition.GetSize(), allocator);
+      additionValue.emplace("size", addition.GetSize().get());
     }
 
-    additions.PushBack(additionValue, allocator);
+    additions.emplace_back(additionValue);
   }
-  value.AddMember("additions", additions, allocator);
-  rapidjson::Value removals(rapidjson::kArrayType);
+  value.as_object().emplace("additions", std::move(additions));
+  boost::json::array removals;
   for (auto &removal : x.GetIndexRemovals()) {
-    removals.PushBack(rapidjson::StringRef(removal.c_str()), allocator);
+    removals.emplace_back(removal);
   }
-  value.AddMember("removals", removals, allocator);
+  value.as_object().emplace("removals", std::move(removals));
 }
 
 }  // namespace serializer

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/UpdateIndexRequestSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/UpdateIndexRequestSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,15 +19,14 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/model/UpdateIndexRequest.h>
 
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::UpdateIndexRequest& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/utils/BoostJsonSrc.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/utils/BoostJsonSrc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2026 HERE Europe B.V.
+ * Copyright (C) 2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,20 +17,4 @@
  * License-Filename: LICENSE
  */
 
-#pragma once
-
-#include <boost/json/value.hpp>
-#include "generated/model/Partitions.h"
-
-#include <string>
-
-namespace olp {
-namespace parser {
-void from_json(const boost::json::value& value,
-               olp::dataservice::write::model::Partition& x);
-
-void from_json(const boost::json::value& value,
-               olp::dataservice::write::model::Partitions& x);
-
-}  // namespace parser
-}  // namespace olp
+#include <boost/json/src.hpp>

--- a/olp-cpp-sdk-dataservice-write/tests/ParserTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/ParserTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,8 @@ using olp::dataservice::write::model::ResponseOk;
 using olp::dataservice::write::model::ResponseOkSingle;
 using olp::dataservice::write::model::VersionDependency;
 
+namespace parser = olp::parser::boost_parser;
+
 TEST(ParserTest, ResponseOkSingle) {
   auto json = R"(
         {
@@ -56,7 +58,7 @@ TEST(ParserTest, ResponseOkSingle) {
         }
     )";
 
-  auto response = olp::parser::parse<ResponseOkSingle>(json);
+  auto response = parser::parse<ResponseOkSingle>(json);
 
   EXPECT_STREQ(response.GetTraceID().c_str(),
                "835eb107-7a35-478f-b41c-dd8e750affe0");
@@ -74,7 +76,7 @@ TEST(ParserTest, ResponseOkOneGeneratedId) {
         }
     )";
 
-  auto response = olp::parser::parse<ResponseOk>(json);
+  auto response = parser::parse<ResponseOk>(json);
 
   EXPECT_STREQ(response.GetTraceID().GetParentID().c_str(),
                "66cab713-4576-4eef-b01b-ad088a1e3b82");
@@ -98,7 +100,7 @@ TEST(ParserTest, ResponseOkMultipleGeneratedIds) {
         }
     )";
 
-  auto response = olp::parser::parse<ResponseOk>(json);
+  auto response = parser::parse<ResponseOk>(json);
 
   EXPECT_STREQ(response.GetTraceID().GetParentID().c_str(),
                "2e05aaee-4c02-4735-9dbf-27eba9a47639");
@@ -216,7 +218,7 @@ TEST(ParserTest, Catalog) {
 
   auto start_time = std::chrono::high_resolution_clock::now();
   auto catalog =
-      olp::parser::parse<olp::dataservice::write::model::Catalog>(json_input);
+      parser::parse<olp::dataservice::write::model::Catalog>(json_input);
   auto end = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> time = end - start_time;
   std::cout << "duration: " << time.count() * 1000000 << " us" << std::endl;
@@ -423,7 +425,7 @@ TEST(ParserTest, CatalogCrash) {
       "\"marketplaceReady\":false,\"version\":3}";
 
   auto catalog =
-      olp::parser::parse<olp::dataservice::write::model::Catalog>(json_input);
+      parser::parse<olp::dataservice::write::model::Catalog>(json_input);
 
   ASSERT_EQ(1, catalog.GetLayers()
                    .at(1)
@@ -450,8 +452,7 @@ TEST(ParserTest, Apis) {
     }\
     ]";
 
-  auto apis =
-      olp::parser::parse<olp::dataservice::write::model::Apis>(json_input);
+  auto apis = parser::parse<olp::dataservice::write::model::Apis>(json_input);
   ASSERT_EQ(1u, apis.size());
   ASSERT_EQ("config", apis.at(0).GetApi());
   ASSERT_EQ("v1", apis.at(0).GetVersion());
@@ -476,7 +477,7 @@ TEST(ParserTest, PublishPartition) {
       }
   )";
 
-  auto response = olp::parser::parse<PublishPartition>(json);
+  auto response = parser::parse<PublishPartition>(json);
 
   EXPECT_STREQ("314010583", response.GetPartition()->c_str());
   EXPECT_STREQ("ff7494d6f17da702862e550c907c0a91",
@@ -512,7 +513,7 @@ TEST(ParserTest, PublishPartitions) {
       }
   )";
 
-  auto response = olp::parser::parse<PublishPartitions>(json);
+  auto response = parser::parse<PublishPartitions>(json);
   ASSERT_EQ(1, response.GetPartitions()->size());
 
   auto partition = response.GetPartitions()->at(0);
@@ -545,7 +546,7 @@ TEST(ParserTest, Details) {
       }
   )";
 
-  auto response = olp::parser::parse<Details>(json);
+  auto response = parser::parse<Details>(json);
 
   EXPECT_STREQ("initialized", response.GetState().c_str());
   EXPECT_STREQ("Publication initialized", response.GetMessage().c_str());
@@ -563,7 +564,7 @@ TEST(ParserTest, VersionDependency) {
       }
 )";
 
-  auto response = olp::parser::parse<VersionDependency>(json);
+  auto response = parser::parse<VersionDependency>(json);
 
   EXPECT_TRUE(response.GetDirect());
   EXPECT_STREQ("hrn:here:data::olp-here-test:my-catalog",
@@ -596,7 +597,7 @@ TEST(ParserTest, Publication) {
       }
 )";
 
-  auto response = olp::parser::parse<Publication>(json);
+  auto response = parser::parse<Publication>(json);
 
   EXPECT_STREQ("34bc2a16-0373-4157-8ccc-19ba08a6672b",
                response.GetId()->c_str());
@@ -640,8 +641,7 @@ TEST(ParserTest, Partitions) {
 
   auto start_time = std::chrono::high_resolution_clock::now();
   auto partitions =
-      olp::parser::parse<olp::dataservice::write::model::Partitions>(
-          json_input);
+      parser::parse<olp::dataservice::write::model::Partitions>(json_input);
   auto end = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> time = end - start_time;
   std::cout << "duration: " << time.count() * 1000000 << " us" << std::endl;
@@ -676,8 +676,7 @@ TEST(ParserTest, LayerVersions) {
 
   auto start_time = std::chrono::high_resolution_clock::now();
   auto layer_versions =
-      olp::parser::parse<olp::dataservice::write::model::LayerVersions>(
-          json_input);
+      parser::parse<olp::dataservice::write::model::LayerVersions>(json_input);
   auto end = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> time = end - start_time;
   std::cout << "duration: " << time.count() * 1000000 << " us" << std::endl;
@@ -703,7 +702,7 @@ TEST(ParserTest, PublishDataRequest) {
 )";
 
   auto publish_data_request =
-      olp::parser::parse<olp::dataservice::write::model::PublishDataRequest>(
+      parser::parse<olp::dataservice::write::model::PublishDataRequest>(
           json_input);
 
   std::string data_string = "payload";


### PR DESCRIPTION
Migrating from RapidJSON
Temporary introduced boost_parser to keep same names and replace rapidjson based parser with this boost based when core is done

Relates-To: OCMAM-445