### PR TITLE
Use Boost::json in olp-cpp-sdk-dataservice-write

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 # Save root sdk folder path
 get_filename_component(OLP_CPP_SDK_ROOT "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
 
+set(INTERNAL_INCLUDE_DIR "${OLP_CPP_SDK_ROOT}/internal/include")
+
 # Include common scripts
 include(common)
 

--- a/internal/include/generated/parser/JsonParser.h
+++ b/internal/include/generated/parser/JsonParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/include/generated/parser/ParserWrapper.h
+++ b/internal/include/generated/parser/ParserWrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <olp/core/porting/optional.h>

--- a/internal/include/generated/serializer/SerializerWrapper.h
+++ b/internal/include/generated/serializer/SerializerWrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/include/json_boost/parser/JsonParser.h
+++ b/internal/include/json_boost/parser/JsonParser.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2019-2026 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <boost/json/parse.hpp>
+
+#include "ParserWrapper.h"
+
+namespace olp {
+namespace parser {
+
+template <typename T>
+inline T parse(const std::string& json) {
+  boost::json::error_code ec;
+  auto value = boost::json::parse(json, ec);
+  T result{};
+  if (value.is_object() || value.is_array()) {
+    from_json(value, result);
+  }
+  return result;
+}
+
+template <typename T>
+inline T parse(std::stringstream& json_stream, bool& res) {
+  res = false;
+  boost::json::error_code ec;
+  auto value = boost::json::parse(json_stream, ec);
+  T result{};
+  if (value.is_object() || value.is_array()) {
+    from_json(value, result);
+    res = true;
+  }
+  return result;
+}
+
+template <typename T>
+inline T parse(std::stringstream& json_stream) {
+  bool res = true;
+  return parse<T>(json_stream, res);
+}
+
+template <typename T>
+inline T parse(const std::shared_ptr<std::vector<unsigned char>>& json_bytes) {
+  boost::json::string_view json(reinterpret_cast<char*>(json_bytes->data()),
+                                json_bytes->size());
+  boost::json::error_code ec;
+  auto value = boost::json::parse(json, ec);
+  T result{};
+  if (value.is_object() || value.is_array()) {
+    from_json(value, result);
+  }
+  return result;
+}
+
+}  // namespace parser
+}  // namespace olp

--- a/internal/include/json_boost/parser/ParserWrapper.h
+++ b/internal/include/json_boost/parser/ParserWrapper.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2019-2026 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <olp/core/porting/optional.h>
+#include <boost/json/value.hpp>
+
+namespace olp {
+namespace parser {
+
+inline void from_json(const boost::json::value& value, std::string& x) {
+  const auto& str = value.get_string();
+  x.assign(str.begin(), str.end());
+}
+
+inline void from_json(const boost::json::value& value, int32_t& x) {
+  x = static_cast<int32_t>(value.to_number<int64_t>());
+}
+
+inline void from_json(const boost::json::value& value, int64_t& x) {
+  x = value.to_number<int64_t>();
+}
+
+inline void from_json(const boost::json::value& value, double& x) {
+  x = value.to_number<double>();
+}
+
+inline void from_json(const boost::json::value& value, bool& x) {
+  x = value.get_bool();
+}
+
+inline void from_json(const boost::json::value& value,
+                      std::shared_ptr<std::vector<unsigned char>>& x) {
+  const auto& s = value.get_string();
+  x = std::make_shared<std::vector<unsigned char>>(s.begin(), s.end());
+}
+
+template <typename T>
+inline void from_json(const boost::json::value& value,
+                      porting::optional<T>& x) {
+  T result = T();
+  from_json(value, result);
+  x = result;
+}
+
+template <typename T>
+inline void from_json(const boost::json::value& value,
+                      std::map<std::string, T>& results) {
+  const auto& object = value.get_object();
+  for (const auto& object_value : object) {
+    std::string key = object_value.key();
+    from_json(object_value.value(), results[key]);
+  }
+}
+
+template <typename T>
+inline void from_json(const boost::json::value& value,
+                      std::vector<T>& results) {
+  const auto& array = value.get_array();
+  for (const auto& array_value : array) {
+    T result;
+    from_json(array_value, result);
+    results.emplace_back(std::move(result));
+  }
+}
+
+template <typename T>
+inline T parse(const boost::json::value& value, const std::string& name) {
+  T result = T();
+  const auto& object = value.get_object();
+  auto itr = object.find(name);
+  if (itr != object.end()) {
+    from_json(itr->value(), result);
+  }
+  return result;
+}
+
+}  // namespace parser
+}  // namespace olp

--- a/internal/include/json_boost/serializer/SerializerWrapper.h
+++ b/internal/include/json_boost/serializer/SerializerWrapper.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2019-2026 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <olp/core/porting/optional.h>
+#include <boost/json/value.hpp>
+
+namespace olp {
+namespace serializer {
+
+inline void to_json(const std::string& x, boost::json::value& value) {
+  value.emplace_string() = x;
+}
+
+inline void to_json(int32_t x, boost::json::value& value) {
+  value.emplace_int64() = x;
+}
+
+inline void to_json(int64_t x, boost::json::value& value) {
+  value.emplace_int64() = x;
+}
+
+inline void to_json(double x, boost::json::value& value) {
+  value.emplace_double() = x;
+}
+inline void to_json(bool x, boost::json::value& value) {
+  value.emplace_bool() = x;
+}
+
+inline void to_json(const std::shared_ptr<std::vector<unsigned char>>& x,
+                    boost::json::value& value) {
+  value.emplace_string().assign(x->begin(), x->end());
+}
+
+template <typename T>
+inline void to_json(const porting::optional<T>& x, boost::json::value& value) {
+  if (x) {
+    to_json(*x, value);
+  } else {
+    value.emplace_null();
+  }
+}
+
+template <typename T>
+inline void to_json(const std::map<std::string, T>& x,
+                    boost::json::value& value) {
+  auto& object = value.emplace_object();
+  for (auto itr = x.begin(); itr != x.end(); ++itr) {
+    const auto& key = itr->first;
+    boost::json::value item_value;
+    to_json(itr->second, item_value);
+    object.emplace(key, std::move(item_value));
+  }
+}
+
+template <typename T>
+inline void to_json(const std::vector<T>& x, boost::json::value& value) {
+  auto& array = value.emplace_array();
+  array.reserve(x.size());
+  for (typename std::vector<T>::const_iterator itr = x.begin(); itr != x.end();
+       ++itr) {
+    boost::json::value item_value;
+    to_json(*itr, item_value);
+    array.emplace_back(std::move(item_value));
+  }
+}
+
+template <typename T>
+inline void serialize(const std::string& key, const T& x,
+                      boost::json::object& value) {
+  boost::json::value item_value;
+  to_json(x, item_value);
+  if (!item_value.is_null()) {
+    value.emplace(key, std::move(item_value));
+  }
+}
+
+}  // namespace serializer
+}  // namespace olp

--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -97,12 +97,6 @@ set(OLP_SDK_CLIENT_HEADERS
     ./include/olp/core/client/TaskContext.h
 )
 
-set(OLP_SDK_GENERATED_HEADERS
-    ./include/olp/core/generated/parser/JsonParser.h
-    ./include/olp/core/generated/parser/ParserWrapper.h
-    ./include/olp/core/generated/serializer/SerializerWrapper.h
-)
-
 set(OLP_SDK_HTTP_HEADERS
     ./include/olp/core/http/adapters/HarCaptureAdapter.h
     ./include/olp/core/http/CertificateSettings.h
@@ -390,7 +384,6 @@ set(OLP_SDK_THREAD_SOURCES
 set(OLP_SDK_CORE_HEADERS
     ${OLP_SDK_CACHE_HEADERS}
     ${OLP_SDK_CLIENT_HEADERS}
-    ${OLP_SDK_GENERATED_HEADERS}
     ${OLP_SDK_HTTP_HEADERS}
     ${OLP_SDK_MODEL_HEADERS}
     ${OLP_SDK_PLATFORM_HEADERS}
@@ -469,6 +462,9 @@ target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${RapidJSON_INCLUDE_DIRS}/..>
 
     $<INSTALL_INTERFACE:include>)
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+    $<BUILD_INTERFACE:${INTERNAL_INCLUDE_DIR}>)
 
 if (ANDROID)
     set(ADDITIONAL_LIBRARIES log)

--- a/olp-cpp-sdk-core/src/client/api/JsonResultParser.h
+++ b/olp-cpp-sdk-core/src/client/api/JsonResultParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@
 #include <string>
 #include <utility>
 
+#include <generated/parser/JsonParser.h>
 #include <olp/core/client/ApiError.h>
-#include <olp/core/generated/parser/JsonParser.h>
 #include <olp/core/logging/Log.h>
 
 namespace olp {

--- a/olp-cpp-sdk-core/src/client/parser/ApiParser.cpp
+++ b/olp-cpp-sdk-core/src/client/parser/ApiParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,10 @@
 
 #include "ApiParser.h"
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <map>
+#include <string>
+
+#include <generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {

--- a/olp-cpp-sdk-dataservice-read/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-read/CMakeLists.txt
@@ -41,6 +41,9 @@ target_include_directories(${PROJECT_NAME}
     $<BUILD_INTERFACE:${Boost_INCLUDE_DIR}>
     PRIVATE ${olp-cpp-sdk-core_INCLUDE_DIRS})
 
+target_include_directories(${PROJECT_NAME} PRIVATE
+    $<BUILD_INTERFACE:${INTERNAL_INCLUDE_DIR}>)
+
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
         olp-cpp-sdk-core

--- a/olp-cpp-sdk-dataservice-read/src/JsonResultParser.h
+++ b/olp-cpp-sdk-dataservice-read/src/JsonResultParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@
 #include <string>
 #include <utility>
 
+#include <generated/parser/JsonParser.h>
 #include <olp/core/client/ApiError.h>
-#include <olp/core/generated/parser/JsonParser.h>
 #include <olp/core/logging/Log.h>
 
 namespace olp {

--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/ApiParser.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/ApiParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@
 
 #include "ApiParser.h"
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <map>
+
+#include <generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {

--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/CatalogParser.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/CatalogParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@
 
 #include "CatalogParser.h"
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <vector>
+
+#include <generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {

--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/IndexParser.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/IndexParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,10 @@
 
 #include "IndexParser.h"
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <memory>
+#include <vector>
+
+#include <generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {

--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/LayerVersionsParser.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/LayerVersionsParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,13 @@
 
 #include "LayerVersionsParser.h"
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <vector>
+
+#include <generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-using namespace olp::dataservice::read;
+namespace model = olp::dataservice::read::model;
 
 void from_json(const rapidjson::Value& value, model::LayerVersion& x) {
   x.SetLayer(parse<std::string>(value, "layer"));

--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/MessagesParser.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/MessagesParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,12 @@
 
 #include "MessagesParser.h"
 
+#include <string>
+#include <vector>
+
 // clang-format off
 #include "generated/parser/StreamOffsetParser.h"
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <generated/parser/ParserWrapper.h>
 // clang-format on
 
 namespace olp {

--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/PartitionsParser.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/PartitionsParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@
 
 #include "PartitionsParser.h"
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <vector>
+
+#include <generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {

--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/StreamOffsetParser.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/StreamOffsetParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@
 
 #include "StreamOffsetParser.h"
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-using namespace olp::dataservice::read;
+namespace model = olp::dataservice::read::model;
 
 void from_json(const rapidjson::Value& value, model::StreamOffset& x) {
   x.SetPartition(parse<int32_t>(value, "partition"));

--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/SubscribeResponseParser.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/SubscribeResponseParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,13 @@
 
 #include "SubscribeResponseParser.h"
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <string>
+
+#include <generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-using namespace olp::dataservice::read;
+namespace model = olp::dataservice::read::model;
 
 void from_json(const rapidjson::Value& value, model::SubscribeResponse& x) {
   x.SetNodeBaseURL(parse<std::string>(value, "nodeBaseURL"));

--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/VersionInfosParser.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/VersionInfosParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,10 @@
 #include "VersionInfosParser.h"
 
 #include <map>
+#include <string>
 #include <vector>
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {

--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/VersionResponseParser.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/VersionResponseParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@
 
 #include "VersionResponseParser.h"
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-using namespace olp::dataservice::read;
+namespace model = olp::dataservice::read::model;
 
 void from_json(const rapidjson::Value& value, model::VersionResponse& x) {
   x.SetVersion(parse<int64_t>(value, "version"));

--- a/olp-cpp-sdk-dataservice-read/src/generated/parser/VersionsResponseParser.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/parser/VersionsResponseParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 HERE Europe B.V.
+ * Copyright (C) 2022-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@
 
 #include "VersionsResponseParser.h"
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <vector>
+
+#include <generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {

--- a/olp-cpp-sdk-dataservice-read/src/generated/serializer/ApiSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/serializer/ApiSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 
 #include "ApiSerializer.h"
 
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <generated/serializer/SerializerWrapper.h>
 
 namespace olp {
 namespace serializer {

--- a/olp-cpp-sdk-dataservice-read/src/generated/serializer/CatalogSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/serializer/CatalogSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 
 #include "CatalogSerializer.h"
 
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <generated/serializer/SerializerWrapper.h>
 
 namespace olp {
 namespace serializer {

--- a/olp-cpp-sdk-dataservice-read/src/generated/serializer/CatalogVersionsSerializer.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/serializer/CatalogVersionsSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 HERE Europe B.V.
+ * Copyright (C) 2022-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,10 @@
 
 #pragma once
 
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <utility>
+#include <vector>
+
+#include <generated/serializer/SerializerWrapper.h>
 #include <olp/dataservice/read/model/CatalogVersion.h>
 #include <rapidjson/document.h>
 

--- a/olp-cpp-sdk-dataservice-read/src/generated/serializer/ConsumerPropertiesSerializer.h
+++ b/olp-cpp-sdk-dataservice-read/src/generated/serializer/ConsumerPropertiesSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,11 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <vector>
+
+#include <generated/serializer/SerializerWrapper.h>
 #include <olp/dataservice/read/ConsumerProperties.h>
+#include <rapidjson/document.h>
 
 namespace olp {
 namespace serializer {

--- a/olp-cpp-sdk-dataservice-read/src/generated/serializer/LayerVersionsSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/serializer/LayerVersionsSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 
 #include "LayerVersionsSerializer.h"
 
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <generated/serializer/SerializerWrapper.h>
 
 namespace olp {
 namespace serializer {

--- a/olp-cpp-sdk-dataservice-read/src/generated/serializer/PartitionsSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/serializer/PartitionsSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 
 #include "PartitionsSerializer.h"
 
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <generated/serializer/SerializerWrapper.h>
 
 namespace olp {
 namespace serializer {

--- a/olp-cpp-sdk-dataservice-read/src/generated/serializer/StreamOffsetsSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/serializer/StreamOffsetsSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 #include "StreamOffsetsSerializer.h"
 
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <generated/serializer/SerializerWrapper.h>
 
 namespace olp {
 namespace serializer {

--- a/olp-cpp-sdk-dataservice-read/src/generated/serializer/VersionInfosSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/serializer/VersionInfosSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 #include "VersionInfosSerializer.h"
 
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <generated/serializer/SerializerWrapper.h>
 
 namespace olp {
 namespace serializer {

--- a/olp-cpp-sdk-dataservice-read/src/generated/serializer/VersionResponseSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/serializer/VersionResponseSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 
 #include "VersionResponseSerializer.h"
 
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <generated/serializer/SerializerWrapper.h>
 
 namespace olp {
 namespace serializer {

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,8 @@
 #include "generated/parser/PartitionsParser.h"
 #include "generated/parser/LayerVersionsParser.h"
 #include "JsonResultParser.h"
-#include <olp/core/generated/parser/JsonParser.h>
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <generated/parser/JsonParser.h>
+#include <generated/serializer/SerializerWrapper.h>
 #include "generated/serializer/PartitionsSerializer.h"
 #include "generated/serializer/LayerVersionsSerializer.h"
 #include "generated/serializer/JsonSerializer.h"

--- a/olp-cpp-sdk-dataservice-read/tests/ParserTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/ParserTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@
 #include "generated/parser/MessagesParser.h"
 #include "generated/parser/SubscribeResponseParser.h"
 #include "generated/parser/VersionInfosParser.h"
-#include <olp/core/generated/parser/JsonParser.h>
+#include <generated/parser/JsonParser.h>
 #include "generated/serializer/VersionInfosSerializer.h"
 #include "generated/serializer/JsonSerializer.h"
 // clang-format on

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsCacheRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsCacheRepositoryTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 
 #include "repositories/DataCacheRepository.h"
 // clang-format off
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <generated/serializer/SerializerWrapper.h>
 #include "generated/serializer/PartitionsSerializer.h"
 #include "generated/serializer/JsonSerializer.h"
 // clang-format on

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@
 
 // clang-format off
 #include "generated/parser/PartitionsParser.h"
-#include <olp/core/generated/parser/JsonParser.h>
+#include <generated/parser/JsonParser.h>
 // clang-format on
 
 namespace {

--- a/olp-cpp-sdk-dataservice-write/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-write/CMakeLists.txt
@@ -18,6 +18,8 @@
 project(olp-cpp-sdk-dataservice-write VERSION 1.24.0)
 set(DESCRIPTION "C++ API library for writing data to OLP")
 
+find_package(Boost REQUIRED)
+
 set(OLP_SDK_DATASERVICE_WRITE_API_HEADERS
     ./include/olp/dataservice/write/DataServiceWriteApi.h
     ./include/olp/dataservice/write/IndexLayerClient.h
@@ -159,16 +161,21 @@ set(OLP_SDK_DATASERVICE_WRITE_SOURCES
     ./src/generated/serializer/PublishPartitionsSerializer.h
     ./src/generated/serializer/UpdateIndexRequestSerializer.cpp
     ./src/generated/serializer/UpdateIndexRequestSerializer.h
+
+    ./src/utils/BoostJsonSrc.cpp
 )
 
 add_library(${PROJECT_NAME}
     ${OLP_SDK_DATASERVICE_WRITE_INCLUDES}
     ${OLP_SDK_DATASERVICE_WRITE_SOURCES})
 
-target_include_directories(${PROJECT_NAME} PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-    PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>)
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+    PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>
+        $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>)
 
 target_compile_definitions(${PROJECT_NAME}
     PRIVATE DATASERVICE_WRITE_LIBRARY)
@@ -176,6 +183,11 @@ if(BUILD_SHARED_LIBS)
     target_compile_definitions(${PROJECT_NAME}
         PUBLIC DATASERVICE_WRITE_SHARED_LIBRARY)
 endif()
+
+target_compile_definitions(${PROJECT_NAME}
+    PRIVATE
+        BOOST_ALL_NO_LIB
+        BOOST_JSON_NO_LIB)
 
 # Used also in the package config file
 set(PROJECT_LIBS olp-cpp-sdk-core)

--- a/olp-cpp-sdk-dataservice-write/CMakeLists.txt
+++ b/olp-cpp-sdk-dataservice-write/CMakeLists.txt
@@ -177,6 +177,9 @@ target_include_directories(${PROJECT_NAME}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>
         $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>)
 
+target_include_directories(${PROJECT_NAME} PRIVATE
+    $<BUILD_INTERFACE:${INTERNAL_INCLUDE_DIR}>)
+
 target_compile_definitions(${PROJECT_NAME}
     PRIVATE DATASERVICE_WRITE_LIBRARY)
 if(BUILD_SHARED_LIBS)

--- a/olp-cpp-sdk-dataservice-write/src/CatalogSettings.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/CatalogSettings.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 
 #include "CatalogSettings.h"
 
+#include <utility>
+
 #include <olp/core/cache/CacheSettings.h>
 #include <olp/core/client/OlpClientSettingsFactory.h>
 #include <boost/format.hpp>
@@ -29,7 +31,7 @@
 #include <generated/serializer/CatalogSerializer.h>
 #include <generated/serializer/JsonSerializer.h>
 #include <generated/parser/CatalogParser.h>
-#include <olp/core/generated/parser/JsonParser.h>
+#include <json_boost/parser/JsonParser.h>
 // clang-format on
 
 namespace olp {

--- a/olp-cpp-sdk-dataservice-write/src/JsonResultParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/JsonResultParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@
 #include <string>
 #include <utility>
 
+#include <json_boost/parser/JsonParser.h>
 #include <olp/core/client/ApiError.h>
-#include <olp/core/generated/parser/JsonParser.h>
 #include <olp/core/logging/Log.h>
 
 namespace olp {

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/ApiParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/ApiParser.cpp
@@ -21,7 +21,7 @@
 
 #include <map>
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <json_boost/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/ApiParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/ApiParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,13 @@
 
 #include "ApiParser.h"
 
+#include <map>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Api& x) {
   x.SetApi(parse<std::string>(value, "api"));
   x.SetVersion(parse<std::string>(value, "version"));

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/ApiParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/ApiParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,14 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 #include "generated/model/Api.h"
 
 #include <string>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Api& x);
 
 }  // namespace parser

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/CatalogParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/CatalogParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,48 +19,50 @@
 
 #include "CatalogParser.h"
 
+#include <vector>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-using namespace olp::dataservice::write;
+namespace model = olp::dataservice::write::model;
 
-void from_json(const rapidjson::Value& value, model::Coverage& x) {
+void from_json(const boost::json::value& value, model::Coverage& x) {
   x.SetAdminAreas(parse<std::vector<std::string> >(value, "adminAreas"));
 }
 
-void from_json(const rapidjson::Value& value, model::IndexDefinition& x) {
+void from_json(const boost::json::value& value, model::IndexDefinition& x) {
   x.SetName(parse<std::string>(value, "name"));
   x.SetType(parse<std::string>(value, "type"));
   x.SetDuration(parse<int64_t>(value, "duration"));
   x.SetZoomLevel(parse<int64_t>(value, "zoomLevel"));
 }
 
-void from_json(const rapidjson::Value& value, model::IndexProperties& x) {
+void from_json(const boost::json::value& value, model::IndexProperties& x) {
   x.SetTtl(parse<std::string>(value, "ttl"));
   x.SetIndexDefinitions(
       parse<std::vector<model::IndexDefinition> >(value, "indexDefinitions"));
 }
 
-void from_json(const rapidjson::Value& value, model::Creator& x) {
+void from_json(const boost::json::value& value, model::Creator& x) {
   x.SetId(parse<std::string>(value, "id"));
 }
 
-void from_json(const rapidjson::Value& value, model::Owner& x) {
+void from_json(const boost::json::value& value, model::Owner& x) {
   x.SetCreator(parse<model::Creator>(value, "creator"));
   x.SetOrganisation(parse<model::Creator>(value, "organisation"));
 }
 
-void from_json(const rapidjson::Value& value, model::Partitioning& x) {
+void from_json(const boost::json::value& value, model::Partitioning& x) {
   x.SetScheme(parse<std::string>(value, "scheme"));
   x.SetTileLevels(parse<std::vector<int64_t> >(value, "tileLevels"));
 }
 
-void from_json(const rapidjson::Value& value, model::Schema& x) {
+void from_json(const boost::json::value& value, model::Schema& x) {
   x.SetHrn(parse<std::string>(value, "hrn"));
 }
 
-void from_json(const rapidjson::Value& value, model::StreamProperties& x) {
+void from_json(const boost::json::value& value, model::StreamProperties& x) {
   // Parsing these as double even though OepnAPI sepcs says int64 because
   // Backend returns the value in decimal format (e.g. 1.0) and this triggers an
   // assert in RapidJSON when parsing.
@@ -70,18 +72,18 @@ void from_json(const rapidjson::Value& value, model::StreamProperties& x) {
       static_cast<int64_t>(parse<double>(value, "dataOutThroughputMbps")));
 }
 
-void from_json(const rapidjson::Value& value, model::Encryption& x) {
+void from_json(const boost::json::value& value, model::Encryption& x) {
   x.SetAlgorithm(parse<std::string>(value, "algorithm"));
 }
 
-void from_json(const rapidjson::Value& value, model::Volume& x) {
+void from_json(const boost::json::value& value, model::Volume& x) {
   x.SetVolumeType(parse<std::string>(value, "volumeType"));
   x.SetMaxMemoryPolicy(parse<std::string>(value, "maxMemoryPolicy"));
   x.SetPackageType(parse<std::string>(value, "packageType"));
   x.SetEncryption(parse<model::Encryption>(value, "encryption"));
 }
 
-void from_json(const rapidjson::Value& value, model::Layer& x) {
+void from_json(const boost::json::value& value, model::Layer& x) {
   x.SetId(parse<std::string>(value, "id"));
   x.SetName(parse<std::string>(value, "name"));
   x.SetSummary(parse<std::string>(value, "summary"));
@@ -103,11 +105,11 @@ void from_json(const rapidjson::Value& value, model::Layer& x) {
   x.SetVolume(parse<model::Volume>(value, "volume"));
 }
 
-void from_json(const rapidjson::Value& value, model::Notifications& x) {
+void from_json(const boost::json::value& value, model::Notifications& x) {
   x.SetEnabled(parse<bool>(value, "enabled"));
 }
 
-void from_json(const rapidjson::Value& value, model::Catalog& x) {
+void from_json(const boost::json::value& value, model::Catalog& x) {
   x.SetId(parse<std::string>(value, "id"));
   x.SetHrn(parse<std::string>(value, "hrn"));
   x.SetName(parse<std::string>(value, "name"));

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/CatalogParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/CatalogParser.cpp
@@ -21,7 +21,7 @@
 
 #include <vector>
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <json_boost/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/CatalogParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/CatalogParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,49 +21,49 @@
 
 #include <string>
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <generated/model/Catalog.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Coverage& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::IndexDefinition& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::IndexProperties& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Creator& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Owner& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Partitioning& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Schema& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::StreamProperties& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Encryption& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Volume& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Layer& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Notifications& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Catalog& x);
 }  // namespace parser
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/DetailsParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/DetailsParser.cpp
@@ -21,7 +21,7 @@
 
 #include <string>
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <json_boost/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/DetailsParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/DetailsParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,13 @@
 
 #include "DetailsParser.h"
 
+#include <string>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Details& x) {
   x.SetState(parse<std::string>(value, "state"));
   x.SetMessage(parse<std::string>(value, "message"));

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/DetailsParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/DetailsParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/generated/model/Details.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::Details& x);
 }  // namespace parser
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/LayerVersionsParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/LayerVersionsParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,19 +19,21 @@
 
 #include "LayerVersionsParser.h"
 
+#include <vector>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-using namespace olp::dataservice::write;
+namespace model = olp::dataservice::write::model;
 
-void from_json(const rapidjson::Value& value, model::LayerVersion& x) {
+void from_json(const boost::json::value& value, model::LayerVersion& x) {
   x.SetLayer(parse<std::string>(value, "layer"));
   x.SetVersion(parse<int64_t>(value, "version"));
   x.SetTimestamp(parse<int64_t>(value, "timestamp"));
 }
 
-void from_json(const rapidjson::Value& value, model::LayerVersions& x) {
+void from_json(const boost::json::value& value, model::LayerVersions& x) {
   x.SetLayerVersions(
       parse<std::vector<model::LayerVersion>>(value, "layerVersions"));
   x.SetVersion(parse<int64_t>(value, "version"));

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/LayerVersionsParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/LayerVersionsParser.cpp
@@ -21,7 +21,7 @@
 
 #include <vector>
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <json_boost/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/LayerVersionsParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/LayerVersionsParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,17 +19,17 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 #include "generated/model/LayerVersions.h"
 
 #include <string>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::LayerVersion& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::LayerVersions& x);
 
 }  // namespace parser

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PartitionParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PartitionParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,17 +19,17 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 #include "olp/dataservice/write/model/Partitions.h"
 
 #include <string>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Partition& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Partitions& x);
 
 }  // namespace parser

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PartitionsParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PartitionsParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,15 @@
 
 #include "PartitionsParser.h"
 
+#include <vector>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-namespace model = dataservice::write::model;
+namespace model = olp::dataservice::write::model;
 
-void from_json(const rapidjson::Value& value, model::Partition& x) {
+void from_json(const boost::json::value& value, model::Partition& x) {
   x.SetChecksum(parse<porting::optional<std::string>>(value, "checksum"));
   x.SetCompressedDataSize(
       parse<porting::optional<int64_t>>(value, "compressedDataSize"));
@@ -35,7 +37,7 @@ void from_json(const rapidjson::Value& value, model::Partition& x) {
   x.SetVersion(parse<porting::optional<int64_t>>(value, "version"));
 }
 
-void from_json(const rapidjson::Value& value, model::Partitions& x) {
+void from_json(const boost::json::value& value, model::Partitions& x) {
   x.SetPartitions(parse<std::vector<model::Partition>>(value, "partitions"));
 }
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PartitionsParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PartitionsParser.cpp
@@ -21,7 +21,7 @@
 
 #include <vector>
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <json_boost/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublicationParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublicationParser.cpp
@@ -25,7 +25,7 @@
 // clang-format off
 #include <generated/parser/DetailsParser.h>
 #include <generated/parser/VersionDependencyParser.h>
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <json_boost/parser/ParserWrapper.h>
 // clang-format on
 
 namespace olp {

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublicationParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublicationParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,9 @@
 
 #include "PublicationParser.h"
 
+#include <string>
+#include <vector>
+
 // clang-format off
 #include <generated/parser/DetailsParser.h>
 #include <generated/parser/VersionDependencyParser.h>
@@ -27,7 +30,7 @@
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::Publication& x) {
   x.SetId(parse<std::string>(value, "id"));
   x.SetDetails(

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublicationParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublicationParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/generated/model/Publication.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::Publication& x);
 }  // namespace parser
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishDataRequestParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishDataRequestParser.cpp
@@ -24,7 +24,7 @@
 #include <vector>
 
 // clang-format off
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <json_boost/parser/ParserWrapper.h>
 // clang-format on
 
 namespace olp {

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishDataRequestParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishDataRequestParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,17 @@
 
 #include "PublishDataRequestParser.h"
 
+#include <memory>
+#include <string>
+#include <vector>
+
 // clang-format off
 #include <olp/core/generated/parser/ParserWrapper.h>
 // clang-format on
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::PublishDataRequest& x) {
   x.WithData(
       (parse<std::shared_ptr<std::vector<unsigned char>>>(value, "data")));

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishDataRequestParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishDataRequestParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/model/PublishDataRequest.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::PublishDataRequest& x);
 }  // namespace parser
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,15 @@
 
 #include "PublishPartitionParser.h"
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::PublishPartition& x) {
   x.SetPartition(parse<std::string>(value, "partition"));
   x.SetChecksum(parse<std::string>(value, "checksum"));

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionParser.cpp
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <json_boost/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include "generated/model/PublishPartition.h"
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::PublishPartition& x);
 }  // namespace parser
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionsParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionsParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 
 #include "PublishPartitionsParser.h"
 
+#include <vector>
+
 // clang-format off
 #include <generated/parser/PublishPartitionParser.h>
 #include <olp/core/generated/parser/ParserWrapper.h>
@@ -26,7 +28,7 @@
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::PublishPartitions& x) {
   x.SetPartitions(
       parse<std::vector<olp::dataservice::write::model::PublishPartition>>(

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionsParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionsParser.cpp
@@ -23,7 +23,7 @@
 
 // clang-format off
 #include <generated/parser/PublishPartitionParser.h>
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <json_boost/parser/ParserWrapper.h>
 // clang-format on
 
 namespace olp {

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionsParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/PublishPartitionsParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include "generated/model/PublishPartitions.h"
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::PublishPartitions& x);
 }  // namespace parser
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkParser.cpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <json_boost/parser/ParserWrapper.h>
 
 namespace model = olp::dataservice::write::model;
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,19 +19,22 @@
 
 #include "ResponseOkParser.h"
 
+#include <string>
+#include <vector>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
-using namespace olp::dataservice::write::model;
+namespace model = olp::dataservice::write::model;
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value, TraceID& x) {
+void from_json(const boost::json::value& value, model::TraceID& x) {
   x.SetParentID(parse<std::string>(value, "ParentID"));
   x.SetGeneratedIDs(parse<std::vector<std::string> >(value, "GeneratedIDs"));
 }
 
-void from_json(const rapidjson::Value& value, ResponseOk& x) {
-  x.SetTraceID(parse<TraceID>(value, "TraceID"));
+void from_json(const boost::json::value& value, model::ResponseOk& x) {
+  x.SetTraceID(parse<model::TraceID>(value, "TraceID"));
 }
 
 }  // namespace parser

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,16 +19,16 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/generated/model/ResponseOk.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::TraceID& x);
 
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::ResponseOk& x);
 
 }  // namespace parser

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkSingleParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkSingleParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,13 @@
 
 #include "ResponseOkSingleParser.h"
 
+#include <string>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::ResponseOkSingle& x) {
   x.SetTraceID(parse<std::string>(value, "TraceID"));
 }

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkSingleParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkSingleParser.cpp
@@ -21,7 +21,7 @@
 
 #include <string>
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <json_boost/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkSingleParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/ResponseOkSingleParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/generated/model/ResponseOkSingle.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::ResponseOkSingle& x);
 
 }  // namespace parser

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionDependencyParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionDependencyParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,13 @@
 
 #include "VersionDependencyParser.h"
 
+#include <string>
+
 #include <olp/core/generated/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::VersionDependency& x) {
   x.SetDirect(parse<bool>(value, "direct"));
   x.SetHrn(parse<std::string>(value, "hrn"));

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionDependencyParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionDependencyParser.cpp
@@ -21,7 +21,7 @@
 
 #include <string>
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <json_boost/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionDependencyParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionDependencyParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/generated/model/VersionDependency.h>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                dataservice::write::model::VersionDependency& x);
 }  // namespace parser
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionResponseParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionResponseParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,9 @@
 
 namespace olp {
 namespace parser {
-using namespace olp::dataservice::write;
+namespace model = olp::dataservice::write::model;
 
-void from_json(const rapidjson::Value& value, model::VersionResponse& x) {
+void from_json(const boost::json::value& value, model::VersionResponse& x) {
   x.SetVersion(parse<int64_t>(value, "version"));
 }
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionResponseParser.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionResponseParser.cpp
@@ -19,7 +19,7 @@
 
 #include "VersionResponseParser.h"
 
-#include <olp/core/generated/parser/ParserWrapper.h>
+#include <json_boost/parser/ParserWrapper.h>
 
 namespace olp {
 namespace parser {

--- a/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionResponseParser.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/parser/VersionResponseParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,14 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 #include "olp/dataservice/write/model/VersionResponse.h"
 
 #include <string>
 
 namespace olp {
 namespace parser {
-void from_json(const rapidjson::Value& value,
+void from_json(const boost::json::value& value,
                olp::dataservice::write::model::VersionResponse& x);
 
 }  // namespace parser

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/ApiSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/ApiSerializer.cpp
@@ -21,7 +21,7 @@
 
 #include "ApiSerializer.h"
 
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <json_boost/serializer/SerializerWrapper.h>
 
 namespace olp {
 namespace serializer {

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/ApiSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/ApiSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include "ApiSerializer.h"
 
@@ -25,13 +25,13 @@
 
 namespace olp {
 namespace serializer {
-void to_json(const dataservice::write::model::Api& x, rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("api", x.GetApi(), value, allocator);
-  serialize("version", x.GetVersion(), value, allocator);
-  serialize("baseURL", x.GetBaseUrl(), value, allocator);
-  serialize("parameters", x.GetParameters(), value, allocator);
+void to_json(const dataservice::write::model::Api& x,
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("api", x.GetApi(), object);
+  serialize("version", x.GetVersion(), object);
+  serialize("baseURL", x.GetBaseUrl(), object);
+  serialize("parameters", x.GetParameters(), object);
 }
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/ApiSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/ApiSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,14 +21,13 @@
 
 #include <string>
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 #include "generated/model/Api.h"
 
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::Api& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/CatalogSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/CatalogSerializer.cpp
@@ -21,7 +21,7 @@
 
 #include "CatalogSerializer.h"
 
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <json_boost/serializer/SerializerWrapper.h>
 
 namespace olp {
 namespace serializer {

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/CatalogSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/CatalogSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include "CatalogSerializer.h"
 
@@ -26,133 +26,120 @@
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::Coverage& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("adminAreas", x.GetAdminAreas(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("adminAreas", x.GetAdminAreas(), object);
 }
 
 void to_json(const dataservice::write::model::IndexDefinition& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("name", x.GetName(), value, allocator);
-  serialize("type", x.GetType(), value, allocator);
-  serialize("duration", x.GetDuration(), value, allocator);
-  serialize("zoomLevel", x.GetZoomLevel(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("name", x.GetName(), object);
+  serialize("type", x.GetType(), object);
+  serialize("duration", x.GetDuration(), object);
+  serialize("zoomLevel", x.GetZoomLevel(), object);
 }
 
 void to_json(const dataservice::write::model::IndexProperties& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("ttl", x.GetTtl(), value, allocator);
-  serialize("indexDefinitions", x.GetIndexDefinitions(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("ttl", x.GetTtl(), object);
+  serialize("indexDefinitions", x.GetIndexDefinitions(), object);
 }
 
 void to_json(const dataservice::write::model::Creator& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("id", x.GetId(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("id", x.GetId(), object);
 }
 
-void to_json(const dataservice::write::model::Owner& x, rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("creator", x.GetCreator(), value, allocator);
-  serialize("organisation", x.GetOrganisation(), value, allocator);
+void to_json(const dataservice::write::model::Owner& x,
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("creator", x.GetCreator(), object);
+  serialize("organisation", x.GetOrganisation(), object);
 }
 
 void to_json(const dataservice::write::model::Partitioning& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("scheme", x.GetScheme(), value, allocator);
-  serialize("tileLevels", x.GetTileLevels(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("scheme", x.GetScheme(), object);
+  serialize("tileLevels", x.GetTileLevels(), object);
 }
 
 void to_json(const dataservice::write::model::Schema& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("hrn", x.GetHrn(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("hrn", x.GetHrn(), object);
 }
 
 void to_json(const dataservice::write::model::StreamProperties& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("dataInThroughputMbps", x.GetDataInThroughputMbps(), value,
-            allocator);
-  serialize("dataOutThroughputMbps", x.GetDataOutThroughputMbps(), value,
-            allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("dataInThroughputMbps", x.GetDataInThroughputMbps(), object);
+  serialize("dataOutThroughputMbps", x.GetDataOutThroughputMbps(), object);
 }
 
 void to_json(const dataservice::write::model::Encryption& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("algorithm", x.GetAlgorithm(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("algorithm", x.GetAlgorithm(), object);
 }
 
 void to_json(const dataservice::write::model::Volume& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("volumeType", x.GetVolumeType(), value, allocator);
-  serialize("maxMemoryPolicy", x.GetMaxMemoryPolicy(), value, allocator);
-  serialize("packageType", x.GetPackageType(), value, allocator);
-  serialize("encryption", x.GetEncryption(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("volumeType", x.GetVolumeType(), object);
+  serialize("maxMemoryPolicy", x.GetMaxMemoryPolicy(), object);
+  serialize("packageType", x.GetPackageType(), object);
+  serialize("encryption", x.GetEncryption(), object);
 }
 
-void to_json(const dataservice::write::model::Layer& x, rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("id", x.GetId(), value, allocator);
-  serialize("name", x.GetName(), value, allocator);
-  serialize("summary", x.GetSummary(), value, allocator);
-  serialize("description", x.GetDescription(), value, allocator);
-  serialize("owner", x.GetOwner(), value, allocator);
-  serialize("coverage", x.GetCoverage(), value, allocator);
-  serialize("schema", x.GetSchema(), value, allocator);
-  serialize("contentType", x.GetContentType(), value, allocator);
-  serialize("contentEncoding", x.GetContentEncoding(), value, allocator);
-  serialize("partitioning", x.GetPartitioning(), value, allocator);
-  serialize("layerType", x.GetLayerType(), value, allocator);
-  serialize("digest", x.GetDigest(), value, allocator);
-  serialize("tags", x.GetTags(), value, allocator);
-  serialize("billingTags", x.GetBillingTags(), value, allocator);
-  serialize("ttl", x.GetTtl(), value, allocator);
-  serialize("indexProperties", x.GetIndexProperties(), value, allocator);
-  serialize("streamProperties", x.GetStreamProperties(), value, allocator);
-  serialize("volume", x.GetVolume(), value, allocator);
+void to_json(const dataservice::write::model::Layer& x,
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("id", x.GetId(), object);
+  serialize("name", x.GetName(), object);
+  serialize("summary", x.GetSummary(), object);
+  serialize("description", x.GetDescription(), object);
+  serialize("owner", x.GetOwner(), object);
+  serialize("coverage", x.GetCoverage(), object);
+  serialize("schema", x.GetSchema(), object);
+  serialize("contentType", x.GetContentType(), object);
+  serialize("contentEncoding", x.GetContentEncoding(), object);
+  serialize("partitioning", x.GetPartitioning(), object);
+  serialize("layerType", x.GetLayerType(), object);
+  serialize("digest", x.GetDigest(), object);
+  serialize("tags", x.GetTags(), object);
+  serialize("billingTags", x.GetBillingTags(), object);
+  serialize("ttl", x.GetTtl(), object);
+  serialize("indexProperties", x.GetIndexProperties(), object);
+  serialize("streamProperties", x.GetStreamProperties(), object);
+  serialize("volume", x.GetVolume(), object);
 }
 
 void to_json(const dataservice::write::model::Notifications& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("enabled", x.GetEnabled(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("enabled", x.GetEnabled(), object);
 }
 
 void to_json(const dataservice::write::model::Catalog& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
-  value.SetObject();
-  serialize("id", x.GetId(), value, allocator);
-  serialize("hrn", x.GetHrn(), value, allocator);
-  serialize("name", x.GetName(), value, allocator);
-  serialize("summary", x.GetSummary(), value, allocator);
-  serialize("description", x.GetDescription(), value, allocator);
-  serialize("coverage", x.GetCoverage(), value, allocator);
-  serialize("owner", x.GetOwner(), value, allocator);
-  serialize("tags", x.GetTags(), value, allocator);
-  serialize("billingTags", x.GetBillingTags(), value, allocator);
-  serialize("created", x.GetCreated(), value, allocator);
-  serialize("layers", x.GetLayers(), value, allocator);
-  serialize("version", x.GetVersion(), value, allocator);
-  serialize("notifications", x.GetNotifications(), value, allocator);
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
+  serialize("id", x.GetId(), object);
+  serialize("hrn", x.GetHrn(), object);
+  serialize("name", x.GetName(), object);
+  serialize("summary", x.GetSummary(), object);
+  serialize("description", x.GetDescription(), object);
+  serialize("coverage", x.GetCoverage(), object);
+  serialize("owner", x.GetOwner(), object);
+  serialize("tags", x.GetTags(), object);
+  serialize("billingTags", x.GetBillingTags(), object);
+  serialize("created", x.GetCreated(), object);
+  serialize("layers", x.GetLayers(), object);
+  serialize("version", x.GetVersion(), object);
+  serialize("notifications", x.GetNotifications(), object);
 }
 
 }  // namespace serializer

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/CatalogSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/CatalogSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,61 +19,50 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include "../model/Catalog.h"
 
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::Coverage& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::IndexDefinition& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::IndexProperties& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::Creator& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
-void to_json(const dataservice::write::model::Owner& x, rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+void to_json(const dataservice::write::model::Owner& x,
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::Partitioning& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::Schema& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::StreamProperties& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::Encryption& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::Volume& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
-void to_json(const dataservice::write::model::Layer& x, rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+void to_json(const dataservice::write::model::Layer& x,
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::Notifications& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 void to_json(const dataservice::write::model::Catalog& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/IndexInfoSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/IndexInfoSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,71 +19,59 @@
 
 #include "IndexInfoSerializer.h"
 
+#include <utility>
+
 namespace olp {
 namespace serializer {
-void to_json(const dataservice::write::model::Index &x, rapidjson::Value &value,
-             rapidjson::Document::AllocatorType &allocator) {
-  rapidjson::Value jsonValue(rapidjson::kObjectType);
-  value.SetArray();
-  jsonValue.AddMember("id", rapidjson::StringRef(x.GetId().c_str()), allocator);
+void to_json(const dataservice::write::model::Index &x,
+             boost::json::value &value) {
+  boost::json::object jsonValue;
+  value.emplace_array();
+  jsonValue.emplace("id", x.GetId());
 
-  rapidjson::Value indexFields(rapidjson::kObjectType);
+  boost::json::object indexFields;
   for (auto &field_pair : x.GetIndexFields()) {
-    using dataservice::write::model::BooleanIndexValue;
-    using dataservice::write::model::HereTileIndexValue;
-    using dataservice::write::model::IndexType;
-    using dataservice::write::model::IntIndexValue;
-    using dataservice::write::model::StringIndexValue;
-    using dataservice::write::model::TimeWindowIndexValue;
-
+    namespace model = dataservice::write::model;
     const auto &field = field_pair.second;
-    const auto key = rapidjson::StringRef(field_pair.first.c_str());
+    const auto &key = field_pair.first;
     auto index_type = field->getIndexType();
-    if (index_type == IndexType::String) {
-      auto s = std::static_pointer_cast<StringIndexValue>(field);
-      rapidjson::Value str_val;
-      const auto &str = s->GetValue();
-      str_val.SetString(
-          str.c_str(), static_cast<rapidjson::SizeType>(str.size()), allocator);
-      indexFields.AddMember(key, str_val, allocator);
-    } else if (index_type == IndexType::Int) {
-      auto s = std::static_pointer_cast<IntIndexValue>(field);
-      indexFields.AddMember(key, s->GetValue(), allocator);
-    } else if (index_type == IndexType::Bool) {
-      auto s = std::static_pointer_cast<BooleanIndexValue>(field);
-      indexFields.AddMember(key, s->GetValue(), allocator);
-    } else if (index_type == IndexType::Heretile) {
-      auto s = std::static_pointer_cast<HereTileIndexValue>(field);
-      indexFields.AddMember(key, s->GetValue(), allocator);
-    } else if (index_type == IndexType::TimeWindow) {
-      auto s = std::static_pointer_cast<TimeWindowIndexValue>(field);
-      indexFields.AddMember(key, s->GetValue(), allocator);
+    if (index_type == model::IndexType::String) {
+      auto s = std::static_pointer_cast<model::StringIndexValue>(field);
+      boost::json::string str_val{s->GetValue()};
+      indexFields.emplace(key, std::move(str_val));
+    } else if (index_type == model::IndexType::Int) {
+      auto s = std::static_pointer_cast<model::IntIndexValue>(field);
+      indexFields.emplace(key, s->GetValue());
+    } else if (index_type == model::IndexType::Bool) {
+      auto s = std::static_pointer_cast<model::BooleanIndexValue>(field);
+      indexFields.emplace(key, s->GetValue());
+    } else if (index_type == model::IndexType::Heretile) {
+      auto s = std::static_pointer_cast<model::HereTileIndexValue>(field);
+      indexFields.emplace(key, s->GetValue());
+    } else if (index_type == model::IndexType::TimeWindow) {
+      auto s = std::static_pointer_cast<model::TimeWindowIndexValue>(field);
+      indexFields.emplace(key, s->GetValue());
     }
   }
-  jsonValue.AddMember("fields", indexFields, allocator);
+  jsonValue.emplace("fields", std::move(indexFields));
   // TODO: Separate Metadata Model serialization into its own file when needed
   // by another model.
   if (x.GetMetadata()) {
-    rapidjson::Value metadatas(rapidjson::kObjectType);
-    for (const auto &metadata : *x.GetMetadata()) {
-      auto metadata_value = metadata.second;
-      auto metadata_key = metadata.first.c_str();
-      indexFields.AddMember(
-          rapidjson::StringRef(metadata_key),
-          rapidjson::StringRef(metadata_value.c_str(), metadata_value.size()),
-          allocator);
+    for (auto &metadata : x.GetMetadata().get()) {
+      auto &metadata_value = metadata.second;
+      auto &metadata_key = metadata.first;
+      indexFields.emplace(metadata_key, metadata_value);
     }
   }
 
   if (x.GetCheckSum()) {
-    jsonValue.AddMember(
-        "checksum", rapidjson::StringRef(x.GetCheckSum()->c_str()), allocator);
+    jsonValue.emplace("checksum", x.GetCheckSum().get());
   }
 
   if (x.GetSize()) {
-    jsonValue.AddMember("size", *x.GetSize(), allocator);
+    jsonValue.emplace("size", x.GetSize().get());
   }
-  value.PushBack(jsonValue, allocator);
+  value.as_array().emplace_back(std::move(jsonValue));
 }
 
 }  // namespace serializer

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/IndexInfoSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/IndexInfoSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/generated/model/Index.h>
 
 namespace olp {
 namespace serializer {
-void to_json(const dataservice::write::model::Index& x, rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+void to_json(const dataservice::write::model::Index& x,
+             boost::json::value& value);
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/JsonSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/JsonSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,24 +19,19 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
+#include <string>
+
+#include <boost/json/serialize.hpp>
+#include <boost/json/value.hpp>
 
 namespace olp {
 namespace serializer {
 template <typename T>
 inline std::string serialize(const T& object) {
-  rapidjson::Document doc;
-  auto& allocator = doc.GetAllocator();
-
-  doc.SetObject();
-  to_json(object, doc, allocator);
-
-  rapidjson::StringBuffer buffer;
-  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-  doc.Accept(writer);
-  return buffer.GetString();
+  boost::json::value value;
+  value.emplace_object();
+  to_json(object, value);
+  return boost::json::serialize(value);
 }
 
 }  // namespace serializer

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublicationSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublicationSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,59 +19,54 @@
 
 #include "PublicationSerializer.h"
 
+#include <utility>
+
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::Publication& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
   if (x.GetId()) {
-    value.AddMember("id", rapidjson::StringRef(x.GetId()->c_str()), allocator);
+    object.emplace("id", x.GetId().get());
   }
 
   // TODO: Separate Details Model serializtion into it's own file when needed by
   // another model.
   if (x.GetDetails()) {
-    rapidjson::Value details(rapidjson::kObjectType);
-    details.AddMember("state",
-                      rapidjson::StringRef(x.GetDetails()->GetState().c_str()),
-                      allocator);
-    details.AddMember(
-        "message", rapidjson::StringRef(x.GetDetails()->GetMessage().c_str()),
-        allocator);
-    details.AddMember("started", x.GetDetails()->GetStarted(), allocator);
-    details.AddMember("modified", x.GetDetails()->GetModified(), allocator);
-    details.AddMember("expires", x.GetDetails()->GetExpires(), allocator);
-    value.AddMember("details", details, allocator);
+    boost::json::object details;
+    details.emplace("state", x.GetDetails()->GetState());
+    details.emplace("message", x.GetDetails()->GetMessage());
+    details.emplace("started", x.GetDetails()->GetStarted());
+    details.emplace("modified", x.GetDetails()->GetModified());
+    details.emplace("expires", x.GetDetails()->GetExpires());
+    object.emplace("details", std::move(details));
   }
 
   if (x.GetLayerIds()) {
-    rapidjson::Value layer_ids(rapidjson::kArrayType);
-    for (auto& layer_id : *x.GetLayerIds()) {
-      layer_ids.PushBack(rapidjson::StringRef(layer_id.c_str()), allocator);
+    boost::json::array layer_ids;
+    for (auto& layer_id : x.GetLayerIds().get()) {
+      layer_ids.emplace_back(layer_id);
     }
-    value.AddMember("layerIds", layer_ids, allocator);
+    object.emplace("layerIds", std::move(layer_ids));
   }
 
   if (x.GetCatalogVersion()) {
-    value.AddMember("catalogVersion", *x.GetCatalogVersion(), allocator);
+    object.emplace("catalogVersion", x.GetCatalogVersion().get());
   }
 
   if (x.GetVersionDependencies()) {
-    rapidjson::Value version_dependencies(rapidjson::kArrayType);
-    for (auto& version_dependency : *x.GetVersionDependencies()) {
+    boost::json::array version_dependencies;
+    for (auto& version_dependency : x.GetVersionDependencies().get()) {
       // TODO: Separate VersionDependency Model serializtion into it's own file
       // when needed by another model.
-      rapidjson::Value version_dependency_json(rapidjson::kObjectType);
-      version_dependency_json.AddMember(
-          "direct", version_dependency.GetDirect(), allocator);
-      version_dependency_json.AddMember(
-          "hrn", rapidjson::StringRef(version_dependency.GetHrn().c_str()),
-          allocator);
-      version_dependency_json.AddMember(
-          "version", version_dependency.GetVersion(), allocator);
-      version_dependencies.PushBack(version_dependency_json, allocator);
+      boost::json::object version_dependency_json;
+      version_dependency_json.emplace("direct", version_dependency.GetDirect());
+      version_dependency_json.emplace("hrn", version_dependency.GetHrn());
+      version_dependency_json.emplace("version",
+                                      version_dependency.GetVersion());
+      version_dependencies.emplace_back(std::move(version_dependency_json));
     }
-    value.AddMember("versionDependencies", version_dependencies, allocator);
+    object.emplace("versionDependencies", std::move(version_dependencies));
   }
 }
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublicationSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublicationSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/generated/model/Publication.h>
 
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::Publication& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishDataRequestSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishDataRequestSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,32 +22,27 @@
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::PublishDataRequest& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
   if (x.GetData()) {
     const auto& data = x.GetData().get();
-    auto data_stringref = rapidjson::StringRef(
+    auto data_stringref = boost::json::string_view(
         reinterpret_cast<char*>(data->data()), data->size());
-    value.AddMember("data", std::move(data_stringref), allocator);
+    object.emplace("data", data_stringref);
   }
 
-  value.AddMember("layerId", rapidjson::StringRef(x.GetLayerId().c_str()),
-                  allocator);
+  object.emplace("layerId", x.GetLayerId());
 
   if (x.GetTraceId()) {
-    value.AddMember("traceId", rapidjson::StringRef(x.GetTraceId()->c_str()),
-                    allocator);
+    object.emplace("traceId", x.GetTraceId().get());
   }
 
   if (x.GetBillingTag()) {
-    value.AddMember("billingTag",
-                    rapidjson::StringRef(x.GetBillingTag()->c_str()),
-                    allocator);
+    object.emplace("billingTag", x.GetBillingTag().get());
   }
 
   if (x.GetChecksum()) {
-    value.AddMember("checksum", rapidjson::StringRef(x.GetChecksum()->c_str()),
-                    allocator);
+    object.emplace("checksum", x.GetChecksum().get());
   }
 }
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishDataRequestSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishDataRequestSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/model/PublishDataRequest.h>
 
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::PublishDataRequest& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,42 +22,37 @@
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::PublishPartition& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
+             boost::json::value& value) {
+  auto& object = value.emplace_object();
   if (x.GetPartition()) {
-    value.AddMember("partition",
-                    rapidjson::StringRef(x.GetPartition()->c_str()), allocator);
+    object.emplace("partition", x.GetPartition().get());
   }
 
   if (x.GetChecksum()) {
-    value.AddMember("checksum", rapidjson::StringRef(x.GetChecksum()->c_str()),
-                    allocator);
+    object.emplace("checksum", x.GetChecksum().get());
   }
 
   if (x.GetCompressedDataSize()) {
-    value.AddMember("compressedDataSize", *x.GetCompressedDataSize(),
-                    allocator);
+    object.emplace("compressedDataSize", x.GetCompressedDataSize().get());
   }
 
   if (x.GetDataSize()) {
-    value.AddMember("dataSize", *x.GetDataSize(), allocator);
+    object.emplace("dataSize", x.GetDataSize().get());
   }
 
   if (x.GetData()) {
     const auto& data = x.GetData().get();
-    auto data_stringref = rapidjson::StringRef(
+    auto data_stringref = boost::json::string_view(
         reinterpret_cast<char*>(data->data()), data->size());
-    value.AddMember("data", std::move(data_stringref), allocator);
+    object.emplace("data", data_stringref);
   }
 
   if (x.GetDataHandle()) {
-    value.AddMember("dataHandle",
-                    rapidjson::StringRef(x.GetDataHandle()->c_str()),
-                    allocator);
+    object.emplace("dataHandle", x.GetDataHandle().get());
   }
 
   if (x.GetTimestamp()) {
-    value.AddMember("timestamp", *x.GetTimestamp(), allocator);
+    object.emplace("timestamp", x.GetTimestamp().get());
   }
 }
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include "generated/model/PublishPartition.h"
 
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::PublishPartition& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionsSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionsSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,21 +19,22 @@
 
 #include "PublishPartitionsSerializer.h"
 
+#include <utility>
+
 #include "PublishPartitionSerializer.h"
 
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::PublishPartitions& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator) {
+             boost::json::value& value) {
   if (x.GetPartitions()) {
-    rapidjson::Value partitions(rapidjson::kArrayType);
-    for (auto& partition : *x.GetPartitions()) {
-      rapidjson::Value partition_value(rapidjson::kObjectType);
-      to_json(partition, partition_value, allocator);
-      partitions.PushBack(partition_value, allocator);
+    boost::json::array partitions;
+    for (auto& partition : x.GetPartitions().get()) {
+      boost::json::value partition_value(boost::json::object_kind_t{});
+      to_json(partition, partition_value);
+      partitions.emplace_back(std::move(partition_value));
     }
-    value.AddMember("partitions", partitions, allocator);
+    value.as_object().emplace("partitions", std::move(partitions));
   }
 }
 

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionsSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/PublishPartitionsSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,13 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include "generated/model/PublishPartitions.h"
 
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::PublishPartitions& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/UpdateIndexRequestSerializer.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/UpdateIndexRequestSerializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,84 +19,69 @@
 
 #include "UpdateIndexRequestSerializer.h"
 
+#include <utility>
+
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::UpdateIndexRequest &x,
-             rapidjson::Value &value,
-             rapidjson::Document::AllocatorType &allocator) {
-  rapidjson::Value additions(rapidjson::kArrayType);
+             boost::json::value &value) {
+  boost::json::array additions;
+  value.emplace_object();
   for (auto &addition : x.GetIndexAdditions()) {
-    rapidjson::Value additionValue(rapidjson::kObjectType);
-    additionValue.AddMember(
-        "id", rapidjson::StringRef(addition.GetId().c_str()), allocator);
+    boost::json::object additionValue;
+    additionValue.emplace("id", addition.GetId());
 
-    rapidjson::Value indexFields(rapidjson::kObjectType);
+    boost::json::object indexFields;
     for (const auto &field_pair : addition.GetIndexFields()) {
-      using dataservice::write::model::BooleanIndexValue;
-      using dataservice::write::model::HereTileIndexValue;
-      using dataservice::write::model::IndexType;
-      using dataservice::write::model::IntIndexValue;
-      using dataservice::write::model::StringIndexValue;
-      using dataservice::write::model::TimeWindowIndexValue;
-
+      namespace model = dataservice::write::model;
       const auto &field = field_pair.second;
-      const auto key = rapidjson::StringRef(field_pair.first.c_str());
+      const auto &key = field_pair.first;
       auto index_type = field->getIndexType();
-      if (index_type == IndexType::String) {
-        auto s = std::static_pointer_cast<StringIndexValue>(field);
-        rapidjson::Value str_val;
-        const auto &str = s->GetValue();
-        str_val.SetString(str.c_str(),
-                          static_cast<rapidjson::SizeType>(str.size()),
-                          allocator);
-        indexFields.AddMember(key, str_val, allocator);
-      } else if (index_type == IndexType::Int) {
-        auto s = std::static_pointer_cast<IntIndexValue>(field);
-        indexFields.AddMember(key, s->GetValue(), allocator);
-      } else if (index_type == IndexType::Bool) {
-        auto s = std::static_pointer_cast<BooleanIndexValue>(field);
-        indexFields.AddMember(key, s->GetValue(), allocator);
-      } else if (index_type == IndexType::Heretile) {
-        auto s = std::static_pointer_cast<HereTileIndexValue>(field);
-        indexFields.AddMember(key, s->GetValue(), allocator);
-      } else if (index_type == IndexType::TimeWindow) {
-        auto s = std::static_pointer_cast<TimeWindowIndexValue>(field);
-        indexFields.AddMember(key, s->GetValue(), allocator);
+      if (index_type == model::IndexType::String) {
+        auto s = std::static_pointer_cast<model::StringIndexValue>(field);
+        boost::json::value str_val{s->GetValue()};
+        indexFields.emplace(key, std::move(str_val));
+      } else if (index_type == model::IndexType::Int) {
+        auto s = std::static_pointer_cast<model::IntIndexValue>(field);
+        indexFields.emplace(key, s->GetValue());
+      } else if (index_type == model::IndexType::Bool) {
+        auto s = std::static_pointer_cast<model::BooleanIndexValue>(field);
+        indexFields.emplace(key, s->GetValue());
+      } else if (index_type == model::IndexType::Heretile) {
+        auto s = std::static_pointer_cast<model::HereTileIndexValue>(field);
+        indexFields.emplace(key, s->GetValue());
+      } else if (index_type == model::IndexType::TimeWindow) {
+        auto s = std::static_pointer_cast<model::TimeWindowIndexValue>(field);
+        indexFields.emplace(key, s->GetValue());
       }
     }
-    additionValue.AddMember("fields", indexFields, allocator);
+    additionValue.emplace("fields", indexFields);
     // TODO: Separate Details Model serializtion into it's own file when needed
     // by another model.
     if (addition.GetMetadata()) {
-      rapidjson::Value metadatas(rapidjson::kObjectType);
-      for (const auto &metadata : *addition.GetMetadata()) {
+      for (const auto &metadata : addition.GetMetadata().get()) {
         const auto &metadata_value = metadata.second;
-        const auto &metadata_key = metadata.first.c_str();
-        indexFields.AddMember(
-            rapidjson::StringRef(metadata_key),
-            rapidjson::StringRef(metadata_value.c_str(), metadata_value.size()),
-            allocator);
+        const auto &metadata_key = metadata.first;
+        indexFields.emplace(metadata_key, metadata_value);
       }
     }
 
     if (addition.GetCheckSum()) {
-      additionValue.AddMember(
-          "checksum", rapidjson::StringRef(addition.GetCheckSum()->c_str()),
-          allocator);
+      additionValue.emplace("checksum", addition.GetCheckSum().get());
     }
 
     if (addition.GetSize()) {
-      additionValue.AddMember("size", *addition.GetSize(), allocator);
+      additionValue.emplace("size", addition.GetSize().get());
     }
 
-    additions.PushBack(additionValue, allocator);
+    additions.emplace_back(additionValue);
   }
-  value.AddMember("additions", additions, allocator);
-  rapidjson::Value removals(rapidjson::kArrayType);
+  value.as_object().emplace("additions", std::move(additions));
+  boost::json::array removals;
   for (auto &removal : x.GetIndexRemovals()) {
-    removals.PushBack(rapidjson::StringRef(removal.c_str()), allocator);
+    removals.emplace_back(removal);
   }
-  value.AddMember("removals", removals, allocator);
+  value.as_object().emplace("removals", std::move(removals));
 }
 
 }  // namespace serializer

--- a/olp-cpp-sdk-dataservice-write/src/generated/serializer/UpdateIndexRequestSerializer.h
+++ b/olp-cpp-sdk-dataservice-write/src/generated/serializer/UpdateIndexRequestSerializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,15 +19,14 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
+#include <boost/json/value.hpp>
 
 #include <olp/dataservice/write/model/UpdateIndexRequest.h>
 
 namespace olp {
 namespace serializer {
 void to_json(const dataservice::write::model::UpdateIndexRequest& x,
-             rapidjson::Value& value,
-             rapidjson::Document::AllocatorType& allocator);
+             boost::json::value& value);
 
 }  // namespace serializer
 }  // namespace olp

--- a/olp-cpp-sdk-dataservice-write/src/utils/BoostJsonSrc.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/utils/BoostJsonSrc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2026 HERE Europe B.V.
+ * Copyright (C) 2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,20 +17,4 @@
  * License-Filename: LICENSE
  */
 
-#pragma once
-
-#include <boost/json/value.hpp>
-#include "generated/model/Partitions.h"
-
-#include <string>
-
-namespace olp {
-namespace parser {
-void from_json(const boost::json::value& value,
-               olp::dataservice::write::model::Partition& x);
-
-void from_json(const boost::json::value& value,
-               olp::dataservice::write::model::Partitions& x);
-
-}  // namespace parser
-}  // namespace olp
+#include <boost/json/src.hpp>

--- a/olp-cpp-sdk-dataservice-write/tests/ParserTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/ParserTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@
 #include <generated/parser/VersionDependencyParser.h>
 #include <generated/parser/LayerVersionsParser.h>
 #include <generated/parser/PublishDataRequestParser.h>
-#include <olp/core/generated/parser/JsonParser.h>
+#include <json_boost/parser/JsonParser.h>
 // clang-format on
 
 namespace {

--- a/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplPublishToBatchTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplPublishToBatchTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
 #include "generated/serializer/ApiSerializer.h"
 #include "generated/serializer/PublicationSerializer.h"
 #include "generated/serializer/CatalogSerializer.h"
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <json_boost/serializer/SerializerWrapper.h>
 #include "generated/serializer/JsonSerializer.h"
 // clang-format on
 

--- a/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplTest.cpp
+++ b/olp-cpp-sdk-dataservice-write/tests/VersionedLayerClientImplTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@
 // clang-format off
 #include "generated/serializer/ApiSerializer.h"
 #include "generated/serializer/PublicationSerializer.h"
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <json_boost/serializer/SerializerWrapper.h>
 #include "generated/serializer/JsonSerializer.h"
 // clang-format on
 

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(olp-cpp-sdk-tests-common
 
 target_include_directories(olp-cpp-sdk-tests-common PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+  "$<BUILD_INTERFACE:${INTERNAL_INCLUDE_DIR}>"
 )
 
 target_include_directories(olp-cpp-sdk-tests-common 

--- a/tests/common/ReadDefaultResponses.cpp
+++ b/tests/common/ReadDefaultResponses.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 #include <utility>
 #include <vector>
 
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <generated/serializer/SerializerWrapper.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 

--- a/tests/common/ResponseGenerator.cpp
+++ b/tests/common/ResponseGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@
 #include "generated/serializer/ApiSerializer.h"
 #include "generated/serializer/VersionResponseSerializer.h"
 #include "generated/serializer/PartitionsSerializer.h"
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <generated/serializer/SerializerWrapper.h>
 #include "generated/serializer/JsonSerializer.h"
 // clang-format on
 

--- a/tests/common/WriteDefaultResponses.h
+++ b/tests/common/WriteDefaultResponses.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@
 #include <utility>
 #include <vector>
 
+#include <generated/serializer/SerializerWrapper.h>
 #include <olp/dataservice/write/generated/model/Publication.h>
-#include <olp/core/generated/serializer/SerializerWrapper.h>
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
@@ -87,7 +87,8 @@ class DefaultResponses {
   static olp::dataservice::write::model::Publication
   GeneratePublicationResponse(
       const std::vector<std::string>& layer_ids,
-      const std::vector<olp::dataservice::write::model::VersionDependency> dependencies) {
+      const std::vector<olp::dataservice::write::model::VersionDependency>
+          dependencies) {
     olp::dataservice::write::model::Publication publication;
 
     std::string id = "abcdefghijklmnopqrstuvwxyz0123456789-";

--- a/tests/integration/olp-cpp-sdk-dataservice-write/VersionedLayerClientPublishToBatchTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/VersionedLayerClientPublishToBatchTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@
 #include "generated/serializer/ApiSerializer.h"
 #include "generated/serializer/CatalogSerializer.h"
 #include "generated/serializer/PublicationSerializer.h"
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <json_boost/serializer/SerializerWrapper.h>
 #include "generated/serializer/JsonSerializer.h"
 // clang-format on
 

--- a/tests/integration/olp-cpp-sdk-dataservice-write/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-write/VersionedLayerClientTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
 // clang-format off
 #include "generated/serializer/ApiSerializer.h"
 #include "generated/serializer/PublicationSerializer.h"
-#include <olp/core/generated/serializer/SerializerWrapper.h>
+#include <json_boost/serializer/SerializerWrapper.h>
 #include "generated/serializer/JsonSerializer.h"
 // clang-format on
 


### PR DESCRIPTION
Migrating from RapidJSON

Move json headers from core to internal location. Prevents exposing internal headers from being exposed.
Could be converted to OBJECTS or static lib if there's need with linking boost to it privately. Considered to be an improvement opportunity for future

Relates-To: OCMAM-445