### PR TITLE
Return NoContent if no partition found in QuadTree

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsRepository.cpp
@@ -633,9 +633,9 @@ PartitionResponse PartitionsRepository::GetAggregatedTile(
 
   auto partition = FindPartition(quad_tree_response.GetResult(), request, true);
   if (!partition) {
-    return {
-        client::ApiError::NotFound("Tile or its closest ancestors not found"),
-        quad_tree_response.GetPayload()};
+    return {client::ApiError(client::ErrorCode::NoContent,
+                             "Tile or its closest ancestors not found"),
+            quad_tree_response.GetPayload()};
   }
   return {std::move(*partition), quad_tree_response.GetPayload()};
 }
@@ -653,9 +653,9 @@ PartitionResponse PartitionsRepository::GetTile(
   auto partition =
       FindPartition(quad_tree_response.GetResult(), request, false);
   if (!partition) {
-    return {
-        client::ApiError::NotFound("Tile or its closest ancestors not found"),
-        quad_tree_response.GetPayload()};
+    return {client::ApiError(client::ErrorCode::NoContent,
+                             "Tile or its closest ancestors not found"),
+            quad_tree_response.GetPayload()};
   }
   return {std::move(*partition), quad_tree_response.GetPayload()};
 }

--- a/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/tests/PartitionsRepositoryTest.cpp
@@ -1208,7 +1208,7 @@ TEST_F(PartitionsRepositoryTest, GetAggregatedPartitionForVersionedTile) {
     const auto& error = response.GetError();
 
     ASSERT_FALSE(response.IsSuccessful());
-    ASSERT_EQ(error.GetErrorCode(), ErrorCode::NotFound);
+    ASSERT_EQ(error.GetErrorCode(), ErrorCode::NoContent);
   }
 
   {

--- a/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
+++ b/tests/integration/olp-cpp-sdk-dataservice-read/VersionedLayerClientTest.cpp
@@ -3607,7 +3607,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetAggregatedData) {
     const auto& error = response.GetError();
 
     ASSERT_FALSE(response.IsSuccessful());
-    ASSERT_EQ(error.GetErrorCode(), client::ErrorCode::NotFound);
+    ASSERT_EQ(error.GetErrorCode(), client::ErrorCode::NoContent);
     testing::Mock::VerifyAndClearExpectations(network_mock_.get());
   }
   {
@@ -3633,7 +3633,7 @@ TEST_F(DataserviceReadVersionedLayerClientTest, GetAggregatedData) {
     const auto& error = response.GetError();
 
     ASSERT_FALSE(response.IsSuccessful());
-    ASSERT_EQ(error.GetErrorCode(), client::ErrorCode::NotFound);
+    ASSERT_EQ(error.GetErrorCode(), client::ErrorCode::NoContent);
 
     const auto& network_stats = response.GetPayload();
     EXPECT_EQ(network_stats.GetBytesDownloaded(), 1024);


### PR DESCRIPTION
Network and response parsing errors should be handled earlier so we have valid data and requested tile is not present. NoContent better reflects this state.

Relates-To: HERESUP-50889