### PR TITLE
Add build with std::any and std::optional

### DIFF
--- a/.github/workflows/psv_pipelines.yml
+++ b/.github/workflows/psv_pipelines.yml
@@ -88,6 +88,22 @@ jobs:
         run: ./scripts/linux/psv/test_psv.sh
         shell: bash
 
+  psv-linux-22-04-gcc11-build-porting-std:
+    name: PSV.Linux.22.04.gcc11.OLP_SDK_USE_STD_OPTIONAL.OLP_SDK_USE_STD_ANY
+    runs-on: ubuntu-22.04
+    env:
+      BUILD_TYPE: RelWithDebInfo
+      EXTRA_CMAKE_OPTIONS: -DCMAKE_CXX_STANDARD=17 -DOLP_SDK_USE_STD_OPTIONAL=ON -DOLP_SDK_USE_STD_ANY=ON -DOLP_SDK_ENABLE_TESTING=OFF
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Install Ubuntu dependencies
+        run: sudo apt-get update && sudo apt-get install -y libboost-all-dev ccache libssl-dev libcurl4-openssl-dev --no-install-recommends
+        shell: bash
+      - name: Compile project with cmake and ccache
+        run: gcc --version && ./scripts/linux/psv/build_psv.sh
+        shell: bash
+
   psv-linux-latest-gcc14-build:
     name: PSV.Linux.latest.gcc14.Tests
     runs-on: ubuntu-latest

--- a/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCacheImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -311,7 +311,7 @@ olp::porting::any DefaultCacheImpl::Get(const std::string& key,
 
   if (memory_cache_) {
     auto value = memory_cache_->Get(key);
-    if (!value.empty()) {
+    if (olp::porting::has_value(value)) {
       PromoteKeyLru(key);
       return value;
     }
@@ -1066,7 +1066,7 @@ OperationOutcome<KeyValueCache::ValueTypePtr> DefaultCacheImpl::Read(
 
   if (memory_cache_) {
     auto value = memory_cache_->Get(key);
-    if (!value.empty()) {
+    if (olp::porting::has_value(value)) {
       PromoteKeyLru(key);
       return olp::porting::any_cast<KeyValueCache::ValueTypePtr>(value);
     }

--- a/olp-cpp-sdk-core/src/cache/InMemoryCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/InMemoryCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  * License-Filename: LICENSE
  */
+
+#include <cstring>
+#include <utility>
 
 #include "InMemoryCache.h"
 
@@ -41,7 +44,7 @@ InMemoryCache::InMemoryCache(size_t max_size, ModelCacheCostFunc cache_cost,
       });
 }
 
-bool InMemoryCache::Put(const std::string& key, const boost::any& item,
+bool InMemoryCache::Put(const std::string& key, const olp::porting::any& item,
                         time_t expire_seconds, size_t size) {
   std::lock_guard<std::mutex> lock{mutex_};
 

--- a/olp-cpp-sdk-core/src/client/repository/ApiCacheRepository.cpp
+++ b/olp-cpp-sdk-core/src/client/repository/ApiCacheRepository.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 HERE Europe B.V.
+ * Copyright (C) 2020-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ porting::optional<std::string> ApiCacheRepository::Get(
   OLP_SDK_LOG_TRACE_F(kLogTag, "Get -> '%s'", key.c_str());
 
   auto url = cache_->Get(key, [](const std::string& value) { return value; });
-  if (url.empty()) {
+  if (!olp::porting::has_value(url)) {
     return porting::none;
   }
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/ApiCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/ApiCacheRepository.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ porting::optional<std::string> ApiCacheRepository::Get(
   OLP_SDK_LOG_TRACE_F(kLogTag, "Get -> '%s'", key.c_str());
 
   auto url = cache_->Get(key, [](const std::string& value) { return value; });
-  if (url.empty()) {
+  if (!olp::porting::has_value(url)) {
     return olp::porting::none;
   }
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogCacheRepository.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 
 #include "CatalogCacheRepository.h"
 
+#include <limits>
 #include <string>
 
 #include <olp/core/cache/KeyGenerator.h>
@@ -73,7 +74,7 @@ porting::optional<model::Catalog> CatalogCacheRepository::Get() {
     return parser::parse<model::Catalog>(value);
   });
 
-  if (cached_catalog.empty()) {
+  if (!olp::porting::has_value(cached_catalog)) {
     return olp::porting::none;
   }
 
@@ -99,7 +100,7 @@ porting::optional<model::VersionResponse> CatalogCacheRepository::GetVersion() {
     return parser::parse<model::VersionResponse>(value);
   });
 
-  if (cached_version.empty()) {
+  if (!olp::porting::has_value(cached_version)) {
     return olp::porting::none;
   }
   return olp::porting::any_cast<model::VersionResponse>(cached_version);

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
@@ -185,12 +185,12 @@ porting::optional<model::LayerVersions> PartitionsCacheRepository::Get(
         return parser::parse<model::LayerVersions>(serialized_object);
       });
 
-  if (cached_layer_versions.empty()) {
+  if (!olp::porting::has_value(cached_layer_versions)) {
     return olp::porting::none;
   }
 
-  return std::move(
-      olp::porting::any_cast<model::LayerVersions&&>(cached_layer_versions));
+  return std::move(olp::porting::any_cast<model::LayerVersions&&>(
+      std::move(cached_layer_versions)));
 }
 
 client::ApiNoResponse PartitionsCacheRepository::Put(

--- a/olp-cpp-sdk-dataservice-write/src/ApiClientLookup.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/ApiClientLookup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,10 @@
  */
 
 #include "ApiClientLookup.h"
+
+#include <map>
+#include <memory>
+#include <utility>
 
 #include <olp/core/cache/KeyValueCache.h>
 #include <olp/core/client/ApiError.h>
@@ -148,7 +152,7 @@ ApiClientLookup::ApiClientResponse ApiClientLookup::LookupApiClient(
   if (cache) {
     auto url =
         cache->Get(cache_key, [](const std::string& value) { return value; });
-    if (!url.empty()) {
+    if (olp::porting::has_value(url)) {
       auto base_url = olp::porting::any_cast<std::string>(url);
       OLP_SDK_LOG_INFO_F(kLogTag, "LookupApiClient(%s, %s) -> from cache",
                          service.c_str(), service_version.c_str());

--- a/olp-cpp-sdk-dataservice-write/src/CatalogSettings.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/CatalogSettings.cpp
@@ -107,7 +107,7 @@ CatalogSettings::LayerSettingsResult CatalogSettings::GetLayerSettings(
         return parser::parse<model::Catalog>(model);
       });
 
-  if (cached_catalog.empty()) {
+  if (!olp::porting::has_value(cached_catalog)) {
     return client::ApiError(
         client::ErrorCode::Unknown,
         (boost::format("Cached catalog '%1' is empty") % catalog_.ToString())

--- a/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/StreamLayerClientImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,10 @@
  */
 
 #include "StreamLayerClientImpl.h"
+
+#include <memory>
+#include <string>
+#include <utility>
 
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -93,7 +97,7 @@ size_t StreamLayerClientImpl::QueueSize() const {
   const auto uuid_list_any =
       cache_->Get(GetUuidListKey(), [](const std::string& s) { return s; });
   std::string uuid_list = "";
-  if (!uuid_list_any.empty()) {
+  if (olp::porting::has_value(uuid_list_any)) {
     uuid_list = olp::porting::any_cast<std::string>(uuid_list_any);
     return std::count(uuid_list.cbegin(), uuid_list.cend(), ',');
   }
@@ -134,7 +138,7 @@ porting::optional<std::string> StreamLayerClientImpl::Queue(
     const auto uuid_list_any =
         cache_->Get(GetUuidListKey(), [](const std::string& s) { return s; });
     std::string uuid_list = "";
-    if (!uuid_list_any.empty()) {
+    if (olp::porting::has_value(uuid_list_any)) {
       uuid_list = olp::porting::any_cast<std::string>(uuid_list_any);
     }
     uuid_list += publish_data_key + ",";
@@ -153,7 +157,7 @@ StreamLayerClientImpl::PopFromQueue() {
   const auto uuid_list_any =
       cache_->Get(GetUuidListKey(), [](const std::string& s) { return s; });
 
-  if (uuid_list_any.empty()) {
+  if (!olp::porting::has_value(uuid_list_any)) {
     OLP_SDK_LOG_ERROR(kLogTag, "Unable to Restore UUID list from Cache");
     return olp::porting::none;
   }
@@ -176,7 +180,7 @@ StreamLayerClientImpl::PopFromQueue() {
   cache_->Put(GetUuidListKey(), uuid_list,
               [&uuid_list]() { return uuid_list; });
 
-  if (publish_data_any.empty()) {
+  if (!olp::porting::has_value(publish_data_any)) {
     OLP_SDK_LOG_ERROR(kLogTag,
                       "Unable to Restore PublishData Request from Cache");
     return olp::porting::none;


### PR DESCRIPTION
boost::any and boost::optional used by default and it make sense to check that alternative options are not broken

Relates-To: MINOR