### PR TITLE
Add line breaks to clang-format filter

### DIFF
--- a/scripts/misc/clang_format_ci.sh
+++ b/scripts/misc/clang_format_ci.sh
@@ -40,7 +40,7 @@ git fetch origin master
 git branch --all
 # Get affected files and filter source files
 FILES=$(git diff-tree --no-commit-id --name-only --diff-filter=d -r origin/master "$CURRENT_BRANCH" \
-        | grep '\.c\|\.cpp\|\.cxx\|\.h\|\.hpp\|\.hxx\|\.mm')
+        | grep '\.c$\|\.cpp$\|\.cxx$\|\.h$\|\.hpp$\|\.hxx$\|\.mm$')
 
 if [ -z "$FILES" ]; then
   printf "No affected files, exiting.\n"


### PR DESCRIPTION
This excludes cmake files. clang-format is not able to format cmake
scripts and makes them ugly.

These line breaks are not working on BSD grep.
Alternative \b is not perfect as well as it matches c1 and c_

Relates-To: MINOR