### PR TITLE
Use XCode 26.1.1 in MacOS15 build

### DIFF
--- a/.github/workflows/psv_pipelines.yml
+++ b/.github/workflows/psv_pipelines.yml
@@ -282,7 +282,7 @@ jobs:
         run: scripts/ios/azure_ios_build_psv.sh
         shell: bash
         env:
-          SELECT_XCODE_LOCATION: "/Applications/Xcode_26.1.app"
+          SELECT_XCODE_LOCATION: "/Applications/Xcode_26.1.1.app"
 
   psv-ios-os15-arm64-xcode-16-build:
     name: PSV.iOS.MacOS15.Xcode16.ARM64


### PR DESCRIPTION
Fixing 'error: iOS 26.1 Platform Not Installed.'

Alternative: xcodebuild -downloadPlatform iOS
no delay in the job duration observed and no there's no this command in the log to check if actual download has happened or is it just a setup

Relates-To: MINOR