### PR TITLE
Update CodeCov Action to v7

### DIFF
--- a/.github/workflows/psv_pipelines.yml
+++ b/.github/workflows/psv_pipelines.yml
@@ -46,7 +46,7 @@ jobs:
       run: ./scripts/linux/psv/test_psv.sh
       shell: bash
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@v7
       with:
         fail_ci_if_error: true # optional (default = false)
         verbose: true # optional (default = false)


### PR DESCRIPTION
https://github.com/codecov/codecov-action/releases/tag/v7.0.0 released at June 7 so it's enough stable to switch and avoid known issues/bugs from v6.

Relates-To: Minor